### PR TITLE
Fix outgoing tx amount to show total debited

### DIFF
--- a/src/models/Transaction.spec.ts
+++ b/src/models/Transaction.spec.ts
@@ -34,15 +34,15 @@ describe('Transaction Model', () => {
     expect(tx.isOutgoing).toBe(true);
   });
 
-  it('should calculate outgoing value correctly (excluding change)', () => {
+  it('should calculate outgoing value as total debited from wallet (inputs)', () => {
     const tx = new Transaction(mockRawTx, userAddress);
-    expect(tx.valueRibbits).toBe(50000000);
-    expect(tx.valuePep).toBe(0.5);
+    expect(tx.valueRibbits).toBe(100000000);
+    expect(tx.valuePep).toBe(1);
   });
 
   it('should format amount correctly with sign', () => {
     const tx = new Transaction(mockRawTx, userAddress);
-    expect(tx.formattedAmount).toBe('-0.5');
+    expect(tx.formattedAmount).toBe('-1');
   });
 
   it('should identify incoming transactions correctly', () => {
@@ -75,7 +75,7 @@ describe('Transaction Model', () => {
     expect(tx.txidShort).toBe('12345678...90abcdef');
   });
 
-  it('should sum all outputs for self-send (consolidation) transactions', () => {
+  it('should use input value for self-send (consolidation) transactions', () => {
     const selfSendRaw: RawTransaction = {
       ...mockRawTx,
       vout: [
@@ -85,7 +85,7 @@ describe('Transaction Model', () => {
     };
     const tx = new Transaction(selfSendRaw, userAddress);
     expect(tx.isOutgoing).toBe(true);
-    expect(tx.valueRibbits).toBe(90000000);
+    expect(tx.valueRibbits).toBe(100000000);
   });
 
   describe('Status Display', () => {

--- a/src/models/Transaction.ts
+++ b/src/models/Transaction.ts
@@ -86,10 +86,9 @@ export class Transaction {
 
   get valueRibbits() {
     if (this.isOutgoing) {
-      const others = this.raw.vout.filter((vout) => vout.scriptpubkey_address !== this.userAddress);
-      return others.length > 0
-        ? others.reduce((sum, vout) => sum + vout.value, 0)
-        : this.raw.vout.reduce((sum, vout) => sum + vout.value, 0);
+      return this.raw.vin
+        .filter((vin) => vin.prevout?.scriptpubkey_address === this.userAddress)
+        .reduce((sum, vin) => sum + (vin.prevout?.value ?? 0), 0);
     } else {
       return this.raw.vout
         .filter((vout) => vout.scriptpubkey_address === this.userAddress)


### PR DESCRIPTION
## Summary
- Outgoing transaction amounts now reflect the total PEP leaving the wallet (sum of user inputs) instead of only the recipient amount (sum of non-user outputs)
- Previously a send of 10.5 PEP with 0.00192 fee displayed as `-10.49808` — now correctly shows `-10.5`

## Test plan
- [x] Updated `Transaction.spec.ts` to verify outgoing value uses input sum
- [x] All 344 tests pass
- [x] TypeScript build passes