### PR TITLE
Harden session key storage

### DIFF
--- a/src/composables/useChangePassword.spec.ts
+++ b/src/composables/useChangePassword.spec.ts
@@ -17,7 +17,7 @@ describe('useChangePassword Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       unlock: vi.fn(),
-      plaintextMnemonic: 'test mnemonic',
+      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
       updateVault: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
@@ -60,12 +60,12 @@ describe('useChangePassword Composable', () => {
     );
   });
 
-  it('should throw error if mnemonic is missing from store', async () => {
+  it('should throw error if mnemonic cannot be decrypted', async () => {
     mockWallet.unlock.mockResolvedValue(true);
-    mockWallet.plaintextMnemonic = null;
+    mockWallet.getMnemonic.mockRejectedValue(new Error('Wallet is locked'));
     const { performChange } = useChangePassword();
     await expect(performChange('old', 'new-pass-12345678', 'new-pass-12345678')).rejects.toThrow(
-      'Could not access wallet data'
+      'Wallet is locked'
     );
   });
 });

--- a/src/composables/useChangePassword.spec.ts
+++ b/src/composables/useChangePassword.spec.ts
@@ -17,7 +17,7 @@ describe('useChangePassword Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       unlock: vi.fn(),
-      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
+      withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic'))),
       updateVault: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
@@ -62,7 +62,7 @@ describe('useChangePassword Composable', () => {
 
   it('should throw error if mnemonic cannot be decrypted', async () => {
     mockWallet.unlock.mockResolvedValue(true);
-    mockWallet.getMnemonic.mockRejectedValue(new Error('Wallet is locked'));
+    mockWallet.withMnemonic.mockRejectedValue(new Error('Wallet is locked'));
     const { performChange } = useChangePassword();
     await expect(performChange('old', 'new-pass-12345678', 'new-pass-12345678')).rejects.toThrow(
       'Wallet is locked'

--- a/src/composables/useChangePassword.ts
+++ b/src/composables/useChangePassword.ts
@@ -40,11 +40,7 @@ export function useChangePassword() {
     }
 
     // Re-encrypt with new password
-    const mnemonic = walletStore.plaintextMnemonic;
-    if (!mnemonic) {
-      throw new ChangePasswordError('general', 'Could not access wallet data. Please try again.');
-    }
-
+    const mnemonic = await walletStore.getMnemonic();
     const newEncrypted = await encrypt(mnemonic, newPassword);
     walletStore.updateVault(newEncrypted);
 

--- a/src/composables/useChangePassword.ts
+++ b/src/composables/useChangePassword.ts
@@ -40,9 +40,10 @@ export function useChangePassword() {
     }
 
     // Re-encrypt with new password
-    const mnemonic = await walletStore.getMnemonic();
-    const newEncrypted = await encrypt(mnemonic, newPassword);
-    walletStore.updateVault(newEncrypted);
+    await walletStore.withMnemonic(async (mnemonic) => {
+      const newEncrypted = await encrypt(mnemonic, newPassword);
+      walletStore.updateVault(newEncrypted);
+    });
 
     isSuccess.value = true;
     return true;

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -41,8 +41,8 @@ describe('useSendTransaction Composable', () => {
       currencySymbol: '$',
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
-      plaintextMnemonic: 'test mnemonic',
-      cacheMnemonic: vi.fn()
+      isMnemonicLoaded: true,
+      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic'))
     };
     vi.mocked(useApp).mockReturnValue({
       wallet: mockWallet
@@ -173,14 +173,15 @@ describe('useSendTransaction Composable', () => {
     tx.value.utxos = [
       { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
     ] as any;
-    mockWallet.plaintextMnemonic = 'mnemonic';
+    mockWallet.isMnemonicLoaded = true;
+    mockWallet.getMnemonic = vi.fn(() => Promise.resolve('mnemonic'));
     vi.mocked(api.fetchTxHex).mockRejectedValue(new Error('Network error'));
 
     await expect(send('password', false)).rejects.toThrow('Network error');
   });
 
   it('should throw error if password is missing and mnemonic not loaded', async () => {
-    mockWallet.plaintextMnemonic = null;
+    mockWallet.isMnemonicLoaded = false;
     const { send } = useSendTransaction();
     await expect(send('', false)).rejects.toThrow('Password required');
   });

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -42,7 +42,7 @@ describe('useSendTransaction Composable', () => {
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       isMnemonicLoaded: true,
-      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic'))
+      withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic')))
     };
     vi.mocked(useApp).mockReturnValue({
       wallet: mockWallet
@@ -174,7 +174,7 @@ describe('useSendTransaction Composable', () => {
       { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
     ] as any;
     mockWallet.isMnemonicLoaded = true;
-    mockWallet.getMnemonic = vi.fn(() => Promise.resolve('mnemonic'));
+    mockWallet.withMnemonic = vi.fn((fn: any) => Promise.resolve(fn('mnemonic')));
     vi.mocked(api.fetchTxHex).mockRejectedValue(new Error('Network error'));
 
     await expect(send('password', false)).rejects.toThrow('Network error');

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -112,11 +112,12 @@ export function useSendTransaction() {
     isSending = true;
 
     try {
-      let mnemonic = walletStore.plaintextMnemonic;
-      if (!mnemonic) {
+      let mnemonic: string;
+      if (walletStore.isMnemonicLoaded) {
+        mnemonic = await walletStore.getMnemonic();
+      } else {
         if (!password) throw new Error('Password required');
         mnemonic = await decryptMnemonic(walletStore.encryptedMnemonic!, password);
-        await walletStore.cacheMnemonic(mnemonic);
       }
 
       const { selectedUtxos } = tx.value.selectUtxos(isMax);

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -114,7 +114,7 @@ export function useSendTransaction() {
     try {
       let mnemonic: string;
       if (walletStore.isMnemonicLoaded) {
-        mnemonic = await walletStore.getMnemonic();
+        mnemonic = await walletStore.withMnemonic((m) => m);
       } else {
         if (!password) throw new Error('Password required');
         mnemonic = await decryptMnemonic(walletStore.encryptedMnemonic!, password);

--- a/src/composables/useShowMnemonic.spec.ts
+++ b/src/composables/useShowMnemonic.spec.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useShowMnemonic } from './useShowMnemonic';
 import { useApp } from '@/composables/useApp';
-import * as encryption from '@/utils/encryption';
 import { defineComponent, createApp } from 'vue';
 
 // Mock dependencies
 vi.mock('@/composables/useApp');
-vi.mock('@/utils/encryption', () => ({
-  decrypt: vi.fn()
-}));
 
 // Helper to test composables that use lifecycle hooks
 function withSetup<T>(composable: () => T): [T, ReturnType<typeof createApp>] {
@@ -32,7 +28,7 @@ describe('useShowMnemonic Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       unlock: vi.fn(),
-      plaintextMnemonic: 'test mnemonic',
+      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
       encryptedMnemonic: 'encrypted'
     };
     vi.mocked(useApp).mockReturnValue({
@@ -59,16 +55,15 @@ describe('useShowMnemonic Composable', () => {
     expect(mockWallet.unlock).toHaveBeenCalledWith('correct-pass');
   });
 
-  it('should use fallback decryption if plaintext is not in store', async () => {
+  it('should use getMnemonic to decrypt on demand', async () => {
     mockWallet.unlock.mockResolvedValue(true);
-    mockWallet.plaintextMnemonic = null;
-    vi.mocked(encryption.decrypt).mockResolvedValue('decrypted-fallback');
+    mockWallet.getMnemonic.mockResolvedValue('decrypted mnemonic');
 
     const [composable] = withSetup(() => useShowMnemonic());
     await composable.reveal('correct-pass');
 
-    expect(composable.mnemonic.value).toBe('decrypted-fallback');
-    expect(encryption.decrypt).toHaveBeenCalledWith('encrypted', 'correct-pass');
+    expect(composable.mnemonic.value).toBe('decrypted mnemonic');
+    expect(mockWallet.getMnemonic).toHaveBeenCalled();
   });
 
   it('should set error and return false when password is incorrect', async () => {

--- a/src/composables/useShowMnemonic.spec.ts
+++ b/src/composables/useShowMnemonic.spec.ts
@@ -28,7 +28,7 @@ describe('useShowMnemonic Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       unlock: vi.fn(),
-      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
+      withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic'))),
       encryptedMnemonic: 'encrypted'
     };
     vi.mocked(useApp).mockReturnValue({
@@ -55,15 +55,17 @@ describe('useShowMnemonic Composable', () => {
     expect(mockWallet.unlock).toHaveBeenCalledWith('correct-pass');
   });
 
-  it('should use getMnemonic to decrypt on demand', async () => {
+  it('should use withMnemonic to decrypt on demand', async () => {
     mockWallet.unlock.mockResolvedValue(true);
-    mockWallet.getMnemonic.mockResolvedValue('decrypted mnemonic');
+    mockWallet.withMnemonic.mockImplementation((fn: any) =>
+      Promise.resolve(fn('decrypted mnemonic'))
+    );
 
     const [composable] = withSetup(() => useShowMnemonic());
     await composable.reveal('correct-pass');
 
     expect(composable.mnemonic.value).toBe('decrypted mnemonic');
-    expect(mockWallet.getMnemonic).toHaveBeenCalled();
+    expect(mockWallet.withMnemonic).toHaveBeenCalled();
   });
 
   it('should set error and return false when password is incorrect', async () => {

--- a/src/composables/useShowMnemonic.ts
+++ b/src/composables/useShowMnemonic.ts
@@ -21,7 +21,7 @@ export function useShowMnemonic() {
         return false;
       }
 
-      mnemonic.value = await walletStore.getMnemonic();
+      mnemonic.value = await walletStore.withMnemonic((m) => m);
 
       step.value = 2;
       return true;

--- a/src/composables/useShowMnemonic.ts
+++ b/src/composables/useShowMnemonic.ts
@@ -1,6 +1,5 @@
 import { ref, onScopeDispose } from 'vue';
 import { useApp } from '@/composables/useApp';
-import { decrypt } from '@/utils/encryption';
 
 export function useShowMnemonic() {
   const { wallet: walletStore } = useApp();
@@ -22,11 +21,7 @@ export function useShowMnemonic() {
         return false;
       }
 
-      if (walletStore.plaintextMnemonic) {
-        mnemonic.value = walletStore.plaintextMnemonic;
-      } else {
-        mnemonic.value = await decrypt(walletStore.encryptedMnemonic!, password);
-      }
+      mnemonic.value = await walletStore.getMnemonic();
 
       step.value = 2;
       return true;

--- a/src/stores/lockout.spec.ts
+++ b/src/stores/lockout.spec.ts
@@ -20,7 +20,6 @@ vi.mock('../utils/encryption', () => ({
   decrypt: vi.fn((v, p) =>
     p === 'correct' ? Promise.resolve('mnemonic') : Promise.reject(new Error('fail'))
   ),
-  isLegacyVault: vi.fn(() => false),
   deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
   extractSalt: vi.fn(() => new Uint8Array(16)),
   importKey: vi.fn(() => Promise.resolve({ type: 'secret' } as CryptoKey)),

--- a/src/stores/lockout.spec.ts
+++ b/src/stores/lockout.spec.ts
@@ -22,7 +22,9 @@ vi.mock('../utils/encryption', () => ({
   ),
   isLegacyVault: vi.fn(() => false),
   deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
-  extractSalt: vi.fn(() => new Uint8Array(16))
+  extractSalt: vi.fn(() => new Uint8Array(16)),
+  importKey: vi.fn(() => Promise.resolve({ type: 'secret' } as CryptoKey)),
+  decryptWithKey: vi.fn(() => Promise.resolve('mnemonic'))
 }));
 
 // Mock API

--- a/src/stores/lockout.spec.ts
+++ b/src/stores/lockout.spec.ts
@@ -16,11 +16,13 @@ vi.mock('../utils/crypto', async (importOriginal) => {
 
 // Mock encryption
 vi.mock('../utils/encryption', () => ({
-  encrypt: vi.fn(() => Promise.resolve('vault')),
+  encrypt: vi.fn(() => Promise.resolve('pbkdf2:vault')),
   decrypt: vi.fn((v, p) =>
     p === 'correct' ? Promise.resolve('mnemonic') : Promise.reject(new Error('fail'))
   ),
-  isLegacyVault: vi.fn(() => false)
+  isLegacyVault: vi.fn(() => false),
+  deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
+  extractSalt: vi.fn(() => new Uint8Array(16))
 }));
 
 // Mock API

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -143,7 +143,7 @@ describe('Wallet Store', () => {
 
     // Mock chrome.storage.session.get — store returns dataKey as hex string
     (global.chrome.storage.session.get as any).mockResolvedValue({
-      dataKey: '01020304' // dummy key bytes as hex — enough to pass session check
+      dataKey: '0102030405060708091011121314151617181920212223242526272829303132' // 32-byte AES key as hex
     });
 
     const store = useWalletStore();
@@ -341,22 +341,22 @@ describe('Wallet Store', () => {
     vi.useRealTimers();
   });
 
-  it('getMnemonic decrypts on demand using cached key bytes', async () => {
+  it('withMnemonic decrypts on demand using session key', async () => {
     const store = useWalletStore();
     await store.createWallet('password123');
 
     expect(store.isMnemonicLoaded).toBe(true);
-    const mnemonic = await store.getMnemonic();
+    const mnemonic = await store.withMnemonic((m) => m);
     expect(mnemonic.split(' ')).toHaveLength(12);
   });
 
-  it('getMnemonic throws when wallet is locked', async () => {
+  it('withMnemonic throws when wallet is locked', async () => {
     const store = useWalletStore();
     await store.createWallet('password123');
 
     await store.lock();
     expect(store.isMnemonicLoaded).toBe(false);
-    await expect(store.getMnemonic()).rejects.toThrow('Wallet is locked');
+    await expect(store.withMnemonic((m) => m)).rejects.toThrow('Wallet is locked');
   });
 
   describe('Transaction Caching', () => {

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -141,18 +141,16 @@ describe('Wallet Store', () => {
       unlocked_until: Date.now() + 10000
     });
 
-    // Mock chrome.storage.session.get
+    // Mock chrome.storage.session.get — store returns dataKey as hex string
     (global.chrome.storage.session.get as any).mockResolvedValue({
-      mnemonic: 'suffer dish east miss seat great brother hello motion mountain celery plunge'
+      dataKey: '01020304' // dummy key bytes as hex — enough to pass session check
     });
 
     const store = useWalletStore();
     const success = await store.checkSession();
     expect(success).toBe(true);
     expect(store.isUnlocked).toBe(true);
-    expect(store.plaintextMnemonic).toBe(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
-    );
+    expect(store.isMnemonicLoaded).toBe(true);
   });
 
   it('should import a wallet with a mnemonic', async () => {
@@ -239,7 +237,7 @@ describe('Wallet Store', () => {
   it('should throw error when adding account without mnemonic', async () => {
     const store = useWalletStore();
     // No import/unlock, so no mnemonic
-    await expect(store.addAccount()).rejects.toThrow('Mnemonic not loaded');
+    await expect(store.addAccount()).rejects.toThrow('Wallet is locked');
   });
 
   it('should rename an account correctly', async () => {
@@ -343,44 +341,22 @@ describe('Wallet Store', () => {
     vi.useRealTimers();
   });
 
-  it('cacheMnemonic should update the mnemonic in the store', async () => {
+  it('getMnemonic decrypts on demand using cached key bytes', async () => {
     const store = useWalletStore();
     await store.createWallet('password123');
 
-    // After creation, plaintextMnemonic should be set
-    expect(store.plaintextMnemonic).not.toBeNull();
-    const originalMnemonic = store.plaintextMnemonic;
-
-    // Lock clears it
-    store.lock();
-    expect(store.plaintextMnemonic).toBeNull();
-
-    // cacheMnemonic restores it
-    await store.cacheMnemonic(originalMnemonic!);
-    expect(store.plaintextMnemonic).toBe(originalMnemonic);
+    expect(store.isMnemonicLoaded).toBe(true);
+    const mnemonic = await store.getMnemonic();
+    expect(mnemonic.split(' ')).toHaveLength(12);
   });
 
-  it('plaintextMnemonic should be exposed as readonly', async () => {
+  it('getMnemonic throws when wallet is locked', async () => {
     const store = useWalletStore();
     await store.createWallet('password123');
 
-    // Verify it's a Ref and contains a value
-    expect(store.plaintextMnemonic).toBeTruthy();
-
-    const original = store.plaintextMnemonic;
-
-    // Direct assignment should be a no-op (readonly ref)
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    try {
-      (store as any).plaintextMnemonic = 'hacked';
-    } catch {
-      // Expected for readonly in some environments
-    }
-
-    // Should still be the original value, not 'hacked'
-    expect(store.plaintextMnemonic).toBe(original);
-    warnSpy.mockRestore();
+    await store.lock();
+    expect(store.isMnemonicLoaded).toBe(false);
+    await expect(store.getMnemonic()).rejects.toThrow('Wallet is locked');
   });
 
   describe('Transaction Caching', () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -12,7 +12,8 @@ import {
   decrypt,
   isLegacyVault,
   deriveKeyBytes,
-  decryptWithKeyBytes
+  decryptWithKey,
+  importKey
 } from '@/utils/encryption';
 import {
   fetchAddressInfo,
@@ -64,7 +65,8 @@ export const useWalletStore = defineStore('wallet', () => {
     parseInt(localStorage.getItem('peppool_active_account') || '0')
   );
   const encryptedMnemonic = ref<string | null>(localStorage.getItem('peppool_vault'));
-  const sessionKeyBytes = ref<Uint8Array | null>(null);
+  let sessionKey: CryptoKey | null = null;
+  const hasSessionKey = ref(false);
   const isUnlocked = ref(false);
   const lockDuration = ref<number>(parseInt(localStorage.getItem('peppool_lock_duration') || '15'));
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
@@ -86,7 +88,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   // ── Computed ──
   const isCreated = computed(() => !!encryptedMnemonic.value);
-  const isMnemonicLoaded = computed(() => !!sessionKeyBytes.value);
+  const isMnemonicLoaded = computed(() => hasSessionKey.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
   const balanceFiat = computed(() => balance.value * (prices.value[selectedCurrency.value] || 0));
@@ -154,7 +156,10 @@ export const useWalletStore = defineStore('wallet', () => {
         const sessionData = await chrome.storage.session.get(['dataKey']);
         const hex = sessionData.dataKey as string | undefined;
         if (hex) {
-          sessionKeyBytes.value = fromHex(hex);
+          const rawBytes = fromHex(hex);
+          sessionKey = await importKey(rawBytes.buffer as ArrayBuffer, ['decrypt']);
+          rawBytes.fill(0);
+          hasSessionKey.value = true;
         } else {
           isUnlocked.value = false;
           await chrome.storage.local.remove('unlocked_until');
@@ -184,19 +189,21 @@ export const useWalletStore = defineStore('wallet', () => {
     await setAutoLockAlarm(lockDuration.value);
   }
 
-  async function getMnemonic(): Promise<string> {
-    if (!sessionKeyBytes.value || !encryptedMnemonic.value) {
+  async function withMnemonic<T>(fn: (mnemonic: string) => T | Promise<T>): Promise<T> {
+    if (!sessionKey || !encryptedMnemonic.value) {
       throw new Error('Wallet is locked');
     }
-    return decryptWithKeyBytes(encryptedMnemonic.value, sessionKeyBytes.value);
+    const mnemonic = await decryptWithKey(encryptedMnemonic.value, sessionKey);
+    return fn(mnemonic);
   }
 
   async function refreshAuth() {
-    if (!sessionKeyBytes.value) return;
+    if (!sessionKey) return;
     try {
-      const mnemonic = await getMnemonic();
-      const authKey = deriveAuthKeyPair(mnemonic);
-      await ensureAuth(authKey.address, authKey.privateKey, authKey.compressed);
+      await withMnemonic(async (mnemonic) => {
+        const authKey = deriveAuthKeyPair(mnemonic);
+        await ensureAuth(authKey.address, authKey.privateKey, authKey.compressed);
+      });
     } catch {
       /* auth is best-effort — anonymous rate is the fallback */
     }
@@ -282,10 +289,12 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   async function cacheKeyBytes(keyBytes: Uint8Array) {
-    sessionKeyBytes.value = keyBytes;
     if (typeof chrome !== 'undefined' && chrome.storage?.session) {
       await chrome.storage.session.set({ dataKey: toHex(keyBytes) });
     }
+    sessionKey = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
+    hasSessionKey.value = true;
+    keyBytes.fill(0);
   }
 
   async function importWallet(mnemonic: string, password: string) {
@@ -389,7 +398,8 @@ export const useWalletStore = defineStore('wallet', () => {
 
   async function lock() {
     isUnlocked.value = false;
-    sessionKeyBytes.value = null;
+    sessionKey = null;
+    hasSessionKey.value = false;
     if (typeof chrome !== 'undefined' && chrome.storage) {
       await chrome.storage.local.remove('unlocked_until');
       await chrome.storage.session?.remove('dataKey');
@@ -406,7 +416,8 @@ export const useWalletStore = defineStore('wallet', () => {
     accounts.value = [];
     activeAccountIndex.value = 0;
     encryptedMnemonic.value = null;
-    sessionKeyBytes.value = null;
+    sessionKey = null;
+    hasSessionKey.value = false;
     isUnlocked.value = false;
     balance.value = 0;
     prices.value = { USD: 0, EUR: 0 };
@@ -444,21 +455,22 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   async function addAccount(label?: string) {
-    if (!sessionKeyBytes.value) {
+    if (!sessionKey) {
       throw new Error('Wallet is locked. Please re-authenticate.');
     }
-    const mnemonic = await getMnemonic();
-    const nextIndex = accounts.value.length;
-    const newAddress = deriveAddress(mnemonic, nextIndex, 0);
-    const newAccount: Account = {
-      address: newAddress,
-      path: getDerivationPath(nextIndex, 0),
-      label: label || `Account ${nextIndex + 1}`
-    };
-    accounts.value.push(newAccount);
-    localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
-    await syncToChromeStorage();
-    await switchAccount(nextIndex);
+    await withMnemonic(async (mnemonic) => {
+      const nextIndex = accounts.value.length;
+      const newAddress = deriveAddress(mnemonic, nextIndex, 0);
+      const newAccount: Account = {
+        address: newAddress,
+        path: getDerivationPath(nextIndex, 0),
+        label: label || `Account ${nextIndex + 1}`
+      };
+      accounts.value.push(newAccount);
+      localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
+      await syncToChromeStorage();
+      await switchAccount(nextIndex);
+    });
   }
 
   async function renameAccount(index: number, label: string) {
@@ -524,7 +536,7 @@ export const useWalletStore = defineStore('wallet', () => {
     switchAccount,
     addAccount,
     renameAccount,
-    getMnemonic,
+    withMnemonic,
     updateVault
   };
 });

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -7,14 +7,7 @@ import {
   getDerivationPath,
   parseDerivationPath
 } from '@/utils/crypto';
-import {
-  encrypt,
-  decrypt,
-  isLegacyVault,
-  deriveKeyBytes,
-  decryptWithKey,
-  importKey
-} from '@/utils/encryption';
+import { encrypt, decrypt, deriveKeyBytes, decryptWithKey, importKey } from '@/utils/encryption';
 import {
   fetchAddressInfo,
   hasAddressActivity,
@@ -376,11 +369,6 @@ export const useWalletStore = defineStore('wallet', () => {
     try {
       const mnemonic = await decrypt(encryptedMnemonic.value, password);
       verifyVaultIntegrity(mnemonic);
-
-      if (isLegacyVault(encryptedMnemonic.value)) {
-        const upgraded = await encrypt(mnemonic, password);
-        updateVault(upgraded);
-      }
 
       await cacheKeyBytes(await deriveKeyBytes(password, encryptedMnemonic.value));
       isUnlocked.value = true;

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -7,7 +7,13 @@ import {
   getDerivationPath,
   parseDerivationPath
 } from '@/utils/crypto';
-import { encrypt, decrypt, isLegacyVault } from '@/utils/encryption';
+import {
+  encrypt,
+  decrypt,
+  isLegacyVault,
+  deriveKeyBytes,
+  decryptWithKeyBytes
+} from '@/utils/encryption';
 import {
   fetchAddressInfo,
   hasAddressActivity,
@@ -58,7 +64,7 @@ export const useWalletStore = defineStore('wallet', () => {
     parseInt(localStorage.getItem('peppool_active_account') || '0')
   );
   const encryptedMnemonic = ref<string | null>(localStorage.getItem('peppool_vault'));
-  const plaintextMnemonic = ref<string | null>(null);
+  const sessionKeyBytes = ref<Uint8Array | null>(null);
   const isUnlocked = ref(false);
   const lockDuration = ref<number>(parseInt(localStorage.getItem('peppool_lock_duration') || '15'));
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
@@ -80,7 +86,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   // ── Computed ──
   const isCreated = computed(() => !!encryptedMnemonic.value);
-  const isMnemonicLoaded = computed(() => !!plaintextMnemonic.value);
+  const isMnemonicLoaded = computed(() => !!sessionKeyBytes.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
   const balanceFiat = computed(() => balance.value * (prices.value[selectedCurrency.value] || 0));
@@ -145,10 +151,10 @@ export const useWalletStore = defineStore('wallet', () => {
 
     try {
       if (chrome.storage.session) {
-        const sessionData = await chrome.storage.session.get(['mnemonic']);
-        const mnemonic = sessionData.mnemonic as string | undefined;
-        if (mnemonic) {
-          plaintextMnemonic.value = mnemonic;
+        const sessionData = await chrome.storage.session.get(['dataKey']);
+        const hex = sessionData.dataKey as string | undefined;
+        if (hex) {
+          sessionKeyBytes.value = fromHex(hex);
         } else {
           isUnlocked.value = false;
           await chrome.storage.local.remove('unlocked_until');
@@ -178,10 +184,18 @@ export const useWalletStore = defineStore('wallet', () => {
     await setAutoLockAlarm(lockDuration.value);
   }
 
+  async function getMnemonic(): Promise<string> {
+    if (!sessionKeyBytes.value || !encryptedMnemonic.value) {
+      throw new Error('Wallet is locked');
+    }
+    return decryptWithKeyBytes(encryptedMnemonic.value, sessionKeyBytes.value);
+  }
+
   async function refreshAuth() {
-    if (!plaintextMnemonic.value) return;
+    if (!sessionKeyBytes.value) return;
     try {
-      const authKey = deriveAuthKeyPair(plaintextMnemonic.value);
+      const mnemonic = await getMnemonic();
+      const authKey = deriveAuthKeyPair(mnemonic);
       await ensureAuth(authKey.address, authKey.privateKey, authKey.compressed);
     } catch {
       /* auth is best-effort — anonymous rate is the fallback */
@@ -255,15 +269,31 @@ export const useWalletStore = defineStore('wallet', () => {
     await importWallet(mnemonic, password);
   }
 
+  function toHex(bytes: Uint8Array): string {
+    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  function fromHex(hex: string): Uint8Array {
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < hex.length; i += 2) {
+      bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+    }
+    return bytes;
+  }
+
+  async function cacheKeyBytes(keyBytes: Uint8Array) {
+    sessionKeyBytes.value = keyBytes;
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.set({ dataKey: toHex(keyBytes) });
+    }
+  }
+
   async function importWallet(mnemonic: string, password: string) {
     const walletAddress = deriveAddress(mnemonic, 0, 0);
     const encrypted = await encrypt(mnemonic, password);
 
     encryptedMnemonic.value = encrypted;
-    plaintextMnemonic.value = mnemonic;
-    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-      await chrome.storage.session.set({ mnemonic });
-    }
+    await cacheKeyBytes(await deriveKeyBytes(password, encrypted));
 
     const initialAccount: Account = {
       address: walletAddress,
@@ -343,10 +373,7 @@ export const useWalletStore = defineStore('wallet', () => {
         updateVault(upgraded);
       }
 
-      plaintextMnemonic.value = mnemonic;
-      if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-        await chrome.storage.session.set({ mnemonic });
-      }
+      await cacheKeyBytes(await deriveKeyBytes(password, encryptedMnemonic.value));
       isUnlocked.value = true;
       await lockout.reset();
       await refreshBalance(true);
@@ -362,10 +389,10 @@ export const useWalletStore = defineStore('wallet', () => {
 
   async function lock() {
     isUnlocked.value = false;
-    plaintextMnemonic.value = null;
+    sessionKeyBytes.value = null;
     if (typeof chrome !== 'undefined' && chrome.storage) {
       await chrome.storage.local.remove('unlocked_until');
-      await chrome.storage.session?.remove('mnemonic');
+      await chrome.storage.session?.remove('dataKey');
     }
     if (lockTimer) clearTimeout(lockTimer);
     lockTimer = null;
@@ -379,7 +406,7 @@ export const useWalletStore = defineStore('wallet', () => {
     accounts.value = [];
     activeAccountIndex.value = 0;
     encryptedMnemonic.value = null;
-    plaintextMnemonic.value = null;
+    sessionKeyBytes.value = null;
     isUnlocked.value = false;
     balance.value = 0;
     prices.value = { USD: 0, EUR: 0 };
@@ -396,7 +423,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
     if (typeof chrome !== 'undefined' && chrome.storage) {
       await chrome.storage.local.remove(['unlocked_until', 'peppool_permissions']);
-      await chrome.storage.session?.remove('mnemonic');
+      await chrome.storage.session?.remove('dataKey');
     }
 
     if (lockTimer) clearTimeout(lockTimer);
@@ -417,11 +444,12 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   async function addAccount(label?: string) {
-    if (!plaintextMnemonic.value) {
-      throw new Error('Mnemonic not loaded. Please re-authenticate.');
+    if (!sessionKeyBytes.value) {
+      throw new Error('Wallet is locked. Please re-authenticate.');
     }
+    const mnemonic = await getMnemonic();
     const nextIndex = accounts.value.length;
-    const newAddress = deriveAddress(plaintextMnemonic.value, nextIndex, 0);
+    const newAddress = deriveAddress(mnemonic, nextIndex, 0);
     const newAccount: Account = {
       address: newAddress,
       path: getDerivationPath(nextIndex, 0),
@@ -438,17 +466,6 @@ export const useWalletStore = defineStore('wallet', () => {
     accounts.value[index].label = label;
     localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
     await syncToChromeStorage();
-  }
-
-  async function cacheMnemonic(mnemonic: string | null) {
-    plaintextMnemonic.value = mnemonic;
-    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-      if (mnemonic) {
-        await chrome.storage.session.set({ mnemonic });
-      } else {
-        await chrome.storage.session.remove('mnemonic');
-      }
-    }
   }
 
   function updateVault(encrypted: string) {
@@ -472,7 +489,6 @@ export const useWalletStore = defineStore('wallet', () => {
     activeAccount,
     address,
     encryptedMnemonic: readonly(encryptedMnemonic),
-    plaintextMnemonic: readonly(plaintextMnemonic),
     isUnlocked,
     isCreated,
     isMnemonicLoaded,
@@ -508,7 +524,7 @@ export const useWalletStore = defineStore('wallet', () => {
     switchAccount,
     addAccount,
     renameAccount,
-    cacheMnemonic,
+    getMnemonic,
     updateVault
   };
 });

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -18,7 +18,9 @@ vi.mock('../utils/encryption', () => ({
   decrypt: vi.fn(() => Promise.resolve('mnemonic')),
   isLegacyVault: vi.fn(() => false),
   deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
-  extractSalt: vi.fn(() => new Uint8Array(16))
+  extractSalt: vi.fn(() => new Uint8Array(16)),
+  importKey: vi.fn(() => Promise.resolve({ type: 'secret' } as CryptoKey)),
+  decryptWithKey: vi.fn(() => Promise.resolve('mnemonic'))
 }));
 
 // Mock API

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -16,7 +16,6 @@ vi.mock('../utils/crypto', async (importOriginal) => {
 vi.mock('../utils/encryption', () => ({
   encrypt: vi.fn(() => Promise.resolve('pbkdf2:vault')),
   decrypt: vi.fn(() => Promise.resolve('mnemonic')),
-  isLegacyVault: vi.fn(() => false),
   deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
   extractSalt: vi.fn(() => new Uint8Array(16)),
   importKey: vi.fn(() => Promise.resolve({ type: 'secret' } as CryptoKey)),

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -14,9 +14,11 @@ vi.mock('../utils/crypto', async (importOriginal) => {
 
 // Mock encryption
 vi.mock('../utils/encryption', () => ({
-  encrypt: vi.fn(() => Promise.resolve('vault')),
+  encrypt: vi.fn(() => Promise.resolve('pbkdf2:vault')),
   decrypt: vi.fn(() => Promise.resolve('mnemonic')),
-  isLegacyVault: vi.fn(() => false)
+  isLegacyVault: vi.fn(() => false),
+  deriveKeyBytes: vi.fn(() => Promise.resolve(new Uint8Array(32))),
+  extractSalt: vi.fn(() => new Uint8Array(16))
 }));
 
 // Mock API
@@ -44,7 +46,7 @@ describe('Wallet Lock vs Reset Behavior', () => {
     localStorage.setItem('peppool_form_send', '{"recipient":"foo","amount":"10"}');
 
     expect(store.isUnlocked).toBe(true);
-    expect(store.encryptedMnemonic).toBe('vault');
+    expect(store.encryptedMnemonic).toBe('pbkdf2:vault');
     expect(store.address).toBe('Paddress');
 
     // 2. Perform lock
@@ -52,12 +54,12 @@ describe('Wallet Lock vs Reset Behavior', () => {
 
     // CHECK: Still has the wallet
     expect(store.isCreated).toBe(true);
-    expect(store.encryptedMnemonic).toBe('vault');
+    expect(store.encryptedMnemonic).toBe('pbkdf2:vault');
     expect(store.address).toBe('Paddress');
 
     // CHECK: Session data is cleared
     expect(store.isUnlocked).toBe(false);
-    expect(store.plaintextMnemonic).toBeNull();
+    expect(store.isMnemonicLoaded).toBe(false);
     expect(localStorage.getItem('peppool_transactions')).toBeNull();
 
     // CHECK: Form data is wiped for privacy

--- a/src/utils/encryption.spec.ts
+++ b/src/utils/encryption.spec.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  encrypt,
-  decrypt,
-  isLegacyVault,
-  deriveKeyBytes,
-  decryptWithKey,
-  importKey
-} from './encryption';
+import { encrypt, decrypt, deriveKeyBytes, decryptWithKey, importKey } from './encryption';
 
 describe('Encryption Utils', () => {
   it('should encrypt and decrypt a message correctly', async () => {
@@ -27,9 +20,8 @@ describe('Encryption Utils', () => {
     await expect(decrypt(encrypted, 'wrong-password')).rejects.toThrow();
   });
 
-  it('should identify legacy vaults', () => {
-    expect(isLegacyVault('no-prefix-base64')).toBe(true);
-    expect(isLegacyVault('pbkdf2:prefixed-base64')).toBe(false);
+  it('should reject invalid vault format', async () => {
+    await expect(decrypt('no-prefix-base64', 'password')).rejects.toThrow('Invalid vault format');
   });
 
   it('should decrypt with a non-extractable CryptoKey via decryptWithKey', async () => {
@@ -44,32 +36,10 @@ describe('Encryption Utils', () => {
     expect(decrypted).toBe(message);
   });
 
-  it('decryptWithKey rejects legacy vaults', async () => {
+  it('decryptWithKey rejects invalid vault format', async () => {
     const fakeKey = await importKey(new Uint8Array(32).buffer, ['decrypt']);
-    await expect(decryptWithKey('legacy-base64', fakeKey)).rejects.toThrow(
-      'Key-based decryption requires a v2 vault'
+    await expect(decryptWithKey('no-prefix-base64', fakeKey)).rejects.toThrow(
+      'Invalid vault format'
     );
-  });
-
-  it('should decrypt legacy (v1) format correctly', async () => {
-    const text = 'legacy text';
-    const password = 'password';
-
-    const iv = crypto.getRandomValues(new Uint8Array(12));
-    const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(password));
-    const key = await crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, ['encrypt']);
-    const encrypted = await crypto.subtle.encrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      new TextEncoder().encode(text)
-    );
-
-    const legacyResult = new Uint8Array(iv.length + encrypted.byteLength);
-    legacyResult.set(iv);
-    legacyResult.set(new Uint8Array(encrypted), iv.length);
-    const legacyBase64 = btoa(String.fromCharCode(...legacyResult));
-
-    const decrypted = await decrypt(legacyBase64, password);
-    expect(decrypted).toBe(text);
   });
 });

--- a/src/utils/encryption.spec.ts
+++ b/src/utils/encryption.spec.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { encrypt, decrypt, isLegacyVault } from './encryption';
+import {
+  encrypt,
+  decrypt,
+  isLegacyVault,
+  deriveKeyBytes,
+  decryptWithKey,
+  importKey
+} from './encryption';
 
 describe('Encryption Utils', () => {
   it('should encrypt and decrypt a message correctly', async () => {
@@ -23,6 +30,25 @@ describe('Encryption Utils', () => {
   it('should identify legacy vaults', () => {
     expect(isLegacyVault('no-prefix-base64')).toBe(true);
     expect(isLegacyVault('pbkdf2:prefixed-base64')).toBe(false);
+  });
+
+  it('should decrypt with a non-extractable CryptoKey via decryptWithKey', async () => {
+    const message = 'mnemonic phrase for key test';
+    const password = 'test-password';
+
+    const encrypted = await encrypt(message, password);
+    const keyBytes = await deriveKeyBytes(password, encrypted);
+    const cryptoKey = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
+
+    const decrypted = await decryptWithKey(encrypted, cryptoKey);
+    expect(decrypted).toBe(message);
+  });
+
+  it('decryptWithKey rejects legacy vaults', async () => {
+    const fakeKey = await importKey(new Uint8Array(32).buffer, ['decrypt']);
+    await expect(decryptWithKey('legacy-base64', fakeKey)).rejects.toThrow(
+      'Key-based decryption requires a v2 vault'
+    );
   });
 
   it('should decrypt legacy (v1) format correctly', async () => {

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -13,7 +13,8 @@ const FORMAT_PREFIX = 'pbkdf2:';
 async function deriveKey(
   password: string,
   salt: ArrayBuffer,
-  usage: KeyUsage[]
+  usage: KeyUsage[],
+  extractable = false
 ): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey(
     'raw',
@@ -32,9 +33,56 @@ async function deriveKey(
     },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
-    false,
+    extractable,
     usage
   );
+}
+
+function importKey(rawBytes: ArrayBuffer, usage: KeyUsage[]): Promise<CryptoKey> {
+  return crypto.subtle.importKey('raw', rawBytes, { name: 'AES-GCM' }, false, usage);
+}
+
+/**
+ * Extracts the PBKDF2 salt from a v2 vault string.
+ */
+export function extractSalt(vault: string): Uint8Array {
+  if (!vault.startsWith(FORMAT_PREFIX)) {
+    throw new Error('Cannot extract salt from legacy vault');
+  }
+  const base64 = vault.slice(FORMAT_PREFIX.length);
+  const raw = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+  return raw.slice(0, SALT_LENGTH);
+}
+
+/**
+ * Derives the raw AES-256 key bytes from a password and vault.
+ * Store these bytes in session storage — never the password or mnemonic.
+ */
+export async function deriveKeyBytes(password: string, vault: string): Promise<Uint8Array> {
+  const salt = extractSalt(vault);
+  const key = await deriveKey(password, salt.buffer as ArrayBuffer, ['encrypt', 'decrypt'], true);
+  const exported = await crypto.subtle.exportKey('raw', key);
+  return new Uint8Array(exported);
+}
+
+/**
+ * Decrypts a v2 vault string using pre-derived raw key bytes.
+ */
+export async function decryptWithKeyBytes(vault: string, keyBytes: Uint8Array): Promise<string> {
+  if (!vault.startsWith(FORMAT_PREFIX)) {
+    throw new Error('Key-based decryption requires a v2 vault');
+  }
+
+  const base64 = vault.slice(FORMAT_PREFIX.length);
+  const raw = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+
+  const iv = raw.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+  const data = raw.slice(SALT_LENGTH + IV_LENGTH);
+
+  const key = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
+  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
+
+  return new TextDecoder().decode(decrypted);
 }
 
 export async function encrypt(text: string, password: string): Promise<string> {

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -38,7 +38,7 @@ async function deriveKey(
   );
 }
 
-function importKey(rawBytes: ArrayBuffer, usage: KeyUsage[]): Promise<CryptoKey> {
+export function importKey(rawBytes: ArrayBuffer, usage: KeyUsage[]): Promise<CryptoKey> {
   return crypto.subtle.importKey('raw', rawBytes, { name: 'AES-GCM' }, false, usage);
 }
 
@@ -69,6 +69,14 @@ export async function deriveKeyBytes(password: string, vault: string): Promise<U
  * Decrypts a v2 vault string using pre-derived raw key bytes.
  */
 export async function decryptWithKeyBytes(vault: string, keyBytes: Uint8Array): Promise<string> {
+  const key = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
+  return decryptWithKey(vault, key);
+}
+
+/**
+ * Decrypts a v2 vault string using a non-extractable CryptoKey.
+ */
+export async function decryptWithKey(vault: string, key: CryptoKey): Promise<string> {
   if (!vault.startsWith(FORMAT_PREFIX)) {
     throw new Error('Key-based decryption requires a v2 vault');
   }
@@ -79,7 +87,6 @@ export async function decryptWithKeyBytes(vault: string, keyBytes: Uint8Array): 
   const iv = raw.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
   const data = raw.slice(SALT_LENGTH + IV_LENGTH);
 
-  const key = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
   const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
 
   return new TextDecoder().decode(decrypted);

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -1,8 +1,7 @@
 /**
  * AES-GCM encryption with PBKDF2 key derivation for secure local storage.
  *
- * Format (v2 — current):  "pbkdf2:" + base64(salt[16] + iv[12] + ciphertext)
- * Format (v1 — legacy):   base64(iv[12] + ciphertext)  — SHA-256 only, auto-upgraded on unlock
+ * Format: "pbkdf2:" + base64(salt[16] + iv[12] + ciphertext)
  */
 
 const PBKDF2_ITERATIONS = 600_000;
@@ -43,11 +42,11 @@ export function importKey(rawBytes: ArrayBuffer, usage: KeyUsage[]): Promise<Cry
 }
 
 /**
- * Extracts the PBKDF2 salt from a v2 vault string.
+ * Extracts the PBKDF2 salt from a vault string.
  */
 export function extractSalt(vault: string): Uint8Array {
   if (!vault.startsWith(FORMAT_PREFIX)) {
-    throw new Error('Cannot extract salt from legacy vault');
+    throw new Error('Invalid vault format');
   }
   const base64 = vault.slice(FORMAT_PREFIX.length);
   const raw = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
@@ -66,19 +65,11 @@ export async function deriveKeyBytes(password: string, vault: string): Promise<U
 }
 
 /**
- * Decrypts a v2 vault string using pre-derived raw key bytes.
- */
-export async function decryptWithKeyBytes(vault: string, keyBytes: Uint8Array): Promise<string> {
-  const key = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
-  return decryptWithKey(vault, key);
-}
-
-/**
- * Decrypts a v2 vault string using a non-extractable CryptoKey.
+ * Decrypts a vault string using a non-extractable CryptoKey.
  */
 export async function decryptWithKey(vault: string, key: CryptoKey): Promise<string> {
   if (!vault.startsWith(FORMAT_PREFIX)) {
-    throw new Error('Key-based decryption requires a v2 vault');
+    throw new Error('Invalid vault format');
   }
 
   const base64 = vault.slice(FORMAT_PREFIX.length);
@@ -111,9 +102,8 @@ export async function encrypt(text: string, password: string): Promise<string> {
 }
 
 export async function decrypt(encryptedString: string, password: string): Promise<string> {
-  // v1 (legacy) format: raw base64 without prefix
   if (!encryptedString.startsWith(FORMAT_PREFIX)) {
-    return decryptLegacy(encryptedString, password);
+    throw new Error('Invalid vault format');
   }
 
   const base64 = encryptedString.slice(FORMAT_PREFIX.length);
@@ -124,32 +114,6 @@ export async function decrypt(encryptedString: string, password: string): Promis
   const data = raw.slice(SALT_LENGTH + IV_LENGTH);
 
   const key = await deriveKey(password, salt.buffer, ['decrypt']);
-
-  const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
-
-  return new TextDecoder().decode(decrypted);
-}
-
-/**
- * Returns true if the vault string uses the legacy (SHA-256 only) format.
- * Used by the wallet store to auto-upgrade on successful unlock.
- */
-export function isLegacyVault(vault: string): boolean {
-  return !vault.startsWith(FORMAT_PREFIX);
-}
-
-// ---------------------------------------------------------------------------
-// Legacy decryption — kept for backward compatibility with pre-PBKDF2 vaults.
-// These vaults are auto-upgraded to PBKDF2 on the next successful unlock.
-// ---------------------------------------------------------------------------
-async function decryptLegacy(encryptedBase64: string, password: string): Promise<string> {
-  const encryptedData = Uint8Array.from(atob(encryptedBase64), (c) => c.charCodeAt(0));
-  const iv = encryptedData.slice(0, 12);
-  const data = encryptedData.slice(12);
-
-  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(password));
-
-  const key = await crypto.subtle.importKey('raw', hash, { name: 'AES-GCM' }, false, ['decrypt']);
 
   const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, data);
 

--- a/src/views/approval/SignMessageView.spec.ts
+++ b/src/views/approval/SignMessageView.spec.ts
@@ -99,8 +99,8 @@ describe('SignMessageView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignMessageView, {

--- a/src/views/approval/SignMessageView.spec.ts
+++ b/src/views/approval/SignMessageView.spec.ts
@@ -82,8 +82,8 @@ describe('SignMessageView', () => {
   it('should request password if mnemonic is not cached', async () => {
     const store = useWalletStore();
     store.isUnlocked = true;
-    // ensure no mnemonic
-    store.cacheMnemonic(null as any);
+    // ensure no mnemonic loaded
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(false);
 
     const wrapper = mount(SignMessageView, {
       global: globalConfig
@@ -98,7 +98,8 @@ describe('SignMessageView', () => {
     const store = useWalletStore();
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 

--- a/src/views/approval/SignMessageView.vue
+++ b/src/views/approval/SignMessageView.vue
@@ -38,9 +38,7 @@ async function handleApprove() {
   error.value = '';
 
   try {
-    let mnemonic = walletStore.plaintextMnemonic;
-
-    if (!mnemonic) {
+    if (!walletStore.isMnemonicLoaded) {
       if (!password.value) {
         error.value = 'Please enter your password';
         return;
@@ -52,15 +50,10 @@ async function handleApprove() {
         isProcessing.value = false;
         return;
       }
-      mnemonic = walletStore.plaintextMnemonic;
-    }
-
-    if (!mnemonic) {
-      error.value = 'Could not access mnemonic';
-      return;
     }
 
     isProcessing.value = true;
+    const mnemonic = await walletStore.getMnemonic();
 
     const signature = signMessage(mnemonic, messageToSign.value, walletStore.activeAccountIndex, 0);
 

--- a/src/views/approval/SignMessageView.vue
+++ b/src/views/approval/SignMessageView.vue
@@ -53,18 +53,23 @@ async function handleApprove() {
     }
 
     isProcessing.value = true;
-    const mnemonic = await walletStore.getMnemonic();
+    await walletStore.withMnemonic(async (mnemonic) => {
+      const signature = signMessage(
+        mnemonic,
+        messageToSign.value,
+        walletStore.activeAccountIndex,
+        0
+      );
 
-    const signature = signMessage(mnemonic, messageToSign.value, walletStore.activeAccountIndex, 0);
-
-    chrome.runtime.sendMessage({
-      target: 'peppool-background-response',
-      requestId: requestId.value,
-      result: {
-        signature,
-        address: walletStore.address,
-        message: messageToSign.value
-      }
+      chrome.runtime.sendMessage({
+        target: 'peppool-background-response',
+        requestId: requestId.value,
+        result: {
+          signature,
+          address: walletStore.address,
+          message: messageToSign.value
+        }
+      });
     });
 
     // Cleanup storage

--- a/src/views/approval/SignTxView.spec.ts
+++ b/src/views/approval/SignTxView.spec.ts
@@ -117,8 +117,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, {
@@ -184,8 +184,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, { global: globalConfig });
@@ -217,8 +217,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, { global: globalConfig });
@@ -244,8 +244,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, { global: globalConfig });
@@ -286,8 +286,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, { global: globalConfig });
@@ -333,8 +333,8 @@ describe('SignTxView', () => {
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
     vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
-      'suffer dish east miss seat great brother hello motion mountain celery plunge'
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
     );
 
     const wrapper = mount(SignTxView, { global: globalConfig });

--- a/src/views/approval/SignTxView.spec.ts
+++ b/src/views/approval/SignTxView.spec.ts
@@ -116,7 +116,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 
@@ -182,7 +183,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 
@@ -214,7 +216,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 
@@ -240,7 +243,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 
@@ -281,7 +285,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 
@@ -327,7 +332,8 @@ describe('SignTxView', () => {
     store.isUnlocked = true;
     store.activeAccountIndex = 0;
     store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-    store.cacheMnemonic(
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'getMnemonic').mockResolvedValue(
       'suffer dish east miss seat great brother hello motion mountain celery plunge'
     );
 

--- a/src/views/approval/SignTxView.vue
+++ b/src/views/approval/SignTxView.vue
@@ -114,13 +114,13 @@ async function handleApprove() {
     }
 
     isProcessing.value = true;
-    const mnemonic = await walletStore.getMnemonic();
-
-    if (method.value === 'sendTransfer') {
-      await handleSendTransfer(mnemonic);
-    } else if (method.value === 'signPsbt') {
-      await handleSignPsbt(mnemonic);
-    }
+    await walletStore.withMnemonic(async (mnemonic) => {
+      if (method.value === 'sendTransfer') {
+        await handleSendTransfer(mnemonic);
+      } else if (method.value === 'signPsbt') {
+        await handleSignPsbt(mnemonic);
+      }
+    });
   } catch (err: any) {
     console.error('Transaction failed', err);
     error.value = err.message || 'Transaction failed';

--- a/src/views/approval/SignTxView.vue
+++ b/src/views/approval/SignTxView.vue
@@ -99,9 +99,7 @@ async function handleApprove() {
   error.value = '';
 
   try {
-    let mnemonic = walletStore.plaintextMnemonic;
-
-    if (!mnemonic) {
+    if (!walletStore.isMnemonicLoaded) {
       if (!password.value) {
         error.value = 'Please enter your password';
         return;
@@ -113,15 +111,10 @@ async function handleApprove() {
         isProcessing.value = false;
         return;
       }
-      mnemonic = walletStore.plaintextMnemonic;
-    }
-
-    if (!mnemonic) {
-      error.value = 'Could not access mnemonic';
-      return;
     }
 
     isProcessing.value = true;
+    const mnemonic = await walletStore.getMnemonic();
 
     if (method.value === 'sendTransfer') {
       await handleSendTransfer(mnemonic);

--- a/src/views/settings/ChangePasswordView.spec.ts
+++ b/src/views/settings/ChangePasswordView.spec.ts
@@ -55,7 +55,7 @@ describe('ChangePasswordView', () => {
 
     mockWallet = {
       isUnlocked: true,
-      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
+      withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic'))),
       lockout: { lockoutUntil: 0, failedAttempts: 0, isLockedOut: false },
       unlock: vi.fn(),
       updateVault: vi.fn()

--- a/src/views/settings/ChangePasswordView.spec.ts
+++ b/src/views/settings/ChangePasswordView.spec.ts
@@ -55,7 +55,7 @@ describe('ChangePasswordView', () => {
 
     mockWallet = {
       isUnlocked: true,
-      plaintextMnemonic: 'test mnemonic',
+      getMnemonic: vi.fn(() => Promise.resolve('test mnemonic')),
       lockout: { lockoutUntil: 0, failedAttempts: 0, isLockedOut: false },
       unlock: vi.fn(),
       updateVault: vi.fn()


### PR DESCRIPTION
## Summary
- Session storage no longer holds the plaintext mnemonic — only hex-encoded AES-256 key bytes derived via PBKDF2
- In-memory key stored as a non-extractable `CryptoKey` (cannot be read by JS, even via prototype pollution or XSS)
- Raw key bytes are zeroed immediately after import into `CryptoKey`
- Key material removed from Vue's reactivity system (plain closure variable instead of `ref`)
- Replaced `getMnemonic()` with scoped `withMnemonic(fn)` callback pattern to limit mnemonic exposure in memory
- Removed legacy vault (v1) format — SHA-256 only encryption that was never shipped

## Test plan
- [x] All 450 tests pass
- [x] `vue-tsc` passes
- [x] Manual: create/import wallet, verify session storage shows `dataKey` as hex string (no mnemonic visible)
- [x] Manual: lock/unlock, send transaction, sign message — all flows work with on-demand decryption
- [x] Manual: change password flow works correctly