### PR TITLE
Move lock timer to session with inactivity-based locking

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -11,17 +11,14 @@
 
 import { loadPermissions, savePermissions, hasPermission, revokeOrigin } from '@/utils/permissions';
 
-const ALARM_NAME = 'peppool-auto-lock';
+const ALARM_NAME_AUTOLOCK = 'peppool-inactivity-lock';
 
 // ── Alarm handler ──────────────────────────────────────────────────────────
 chrome.alarms.onAlarm.addListener(async (alarm) => {
-  if (alarm.name !== ALARM_NAME) return;
-
-  // Actively purge sensitive data from storage
-  await chrome.storage.local.remove('unlocked_until');
+  if (alarm.name !== ALARM_NAME_AUTOLOCK) return;
 
   try {
-    await chrome.storage.session.remove('mnemonic');
+    await chrome.storage.session.remove(['sessionStartTime', 'dataKey']);
   } catch {
     // session storage may not be available in all contexts
   }
@@ -47,7 +44,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   // 1. Internal Extension Messages
   if (sender.id === chrome.runtime.id) {
     if (message.type === 'set-auto-lock') {
-      chrome.alarms.create(ALARM_NAME, {
+      chrome.alarms.create(ALARM_NAME_AUTOLOCK, {
         delayInMinutes: message.delayMinutes
       });
       sendResponse({ ok: true });
@@ -55,7 +52,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     if (message.type === 'clear-auto-lock') {
-      chrome.alarms.clear(ALARM_NAME);
+      chrome.alarms.clear(ALARM_NAME_AUTOLOCK);
       sendResponse({ ok: true });
       return true;
     }

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -136,13 +136,9 @@ describe('Wallet Store', () => {
     );
     localStorage.setItem('peppool_active_account', '0');
 
-    // Mock chrome.storage.local.get for session expiry
-    (global.chrome.storage.local.get as any).mockResolvedValue({
-      unlocked_until: Date.now() + 10000
-    });
-
-    // Mock chrome.storage.session.get — store returns dataKey as hex string
+    // Mock chrome.storage.session.get — store returns sessionStartTime and dataKey
     (global.chrome.storage.session.get as any).mockResolvedValue({
+      sessionStartTime: Date.now(),
       dataKey: '0102030405060708091011121314151617181920212223242526272829303132' // 32-byte AES key as hex
     });
 
@@ -179,10 +175,8 @@ describe('Wallet Store', () => {
     expect(store.prices.USD).toBe(0);
     expect(localStorage.getItem('peppool_vault')).toBeNull();
     expect(localStorage.getItem('other_app_key')).toBe('keep-me');
-    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
-      'unlocked_until',
-      'peppool_permissions'
-    ]);
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith('peppool_permissions');
+    expect(chrome.storage.session.remove).toHaveBeenCalledWith(['sessionStartTime', 'dataKey']);
   });
 
   it('encryptedMnemonic should be exposed as readonly', async () => {

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -78,11 +78,15 @@ describe('Wallet Store', () => {
 
     store.lock();
     expect(store.isUnlocked).toBe(false);
+    vi.mocked(chrome.storage.session.set).mockClear();
 
     const success = await store.unlock('password123');
     expect(success).toBe(true);
     expect(store.isUnlocked).toBe(true);
     expect(store.address).toBe(originalAddress);
+    expect(chrome.storage.session.set).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionStartTime: expect.any(Number) })
+    );
   });
 
   it('should fail unlock if mnemonic derives different primary address', async () => {
@@ -158,6 +162,9 @@ describe('Wallet Store', () => {
     expect(store.isUnlocked).toBe(true);
     expect(store.address).toBe('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
     expect(store.accounts).toHaveLength(1);
+    expect(chrome.storage.session.set).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionStartTime: expect.any(Number) })
+    );
   });
 
   it('should perform a full wallet reset', async () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -164,15 +164,8 @@ export const useWalletStore = defineStore('wallet', () => {
     return true;
   }
 
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
   async function resetLockTimer() {
     if (!isUnlocked.value) return;
-
-    if (debounceTimer) return;
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null;
-    }, 1000);
 
     const durationMs = lockDuration.value * 60 * 1000;
 
@@ -183,6 +176,16 @@ export const useWalletStore = defineStore('wallet', () => {
     if (lockTimer) clearTimeout(lockTimer);
     lockTimer = setTimeout(() => lock(), durationMs);
     await setAutoLockAlarm(lockDuration.value);
+  }
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function debouncedResetLockTimer() {
+    if (!isUnlocked.value || debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+    }, 1000);
+    resetLockTimer();
   }
 
   async function withMnemonic<T>(fn: (mnemonic: string) => T | Promise<T>): Promise<T> {
@@ -312,6 +315,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
     await syncToChromeStorage();
 
+    await resetLockTimer();
     await lockout.reset();
     await refreshBalance(true);
     await discoverAccounts(mnemonic);
@@ -371,6 +375,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
       await cacheKeyBytes(await deriveKeyBytes(password, encryptedMnemonic.value));
       isUnlocked.value = true;
+      await resetLockTimer();
       await lockout.reset();
       await refreshBalance(true);
       return true;
@@ -513,7 +518,7 @@ export const useWalletStore = defineStore('wallet', () => {
     refreshTransactions,
     fetchTransaction,
     fetchMoreTransactions,
-    resetLockTimer,
+    resetLockTimer: debouncedResetLockTimer,
     startPolling,
     stopPolling,
     unlock,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -135,31 +135,27 @@ export const useWalletStore = defineStore('wallet', () => {
 
   async function checkSession() {
     await lockout.restore();
-    if (typeof chrome === 'undefined' || !chrome.storage) return false;
+    if (typeof chrome === 'undefined' || !chrome.storage?.session) return false;
 
-    const data = await chrome.storage.local.get(['unlocked_until']);
-    const unlockedUntil = data.unlocked_until as number | undefined;
+    const sessionData = await chrome.storage.session.get(['sessionStartTime', 'dataKey']);
+    const sessionStart = sessionData.sessionStartTime as number | undefined;
+    const hex = sessionData.dataKey as string | undefined;
 
-    if (!unlockedUntil || unlockedUntil <= Date.now()) return false;
+    if (!sessionStart || !hex) return false;
 
-    isUnlocked.value = true;
+    const elapsed = Date.now() - sessionStart;
+    if (elapsed >= lockDuration.value * 60 * 1000) {
+      await chrome.storage.session.remove(['sessionStartTime', 'dataKey']);
+      return false;
+    }
 
     try {
-      if (chrome.storage.session) {
-        const sessionData = await chrome.storage.session.get(['dataKey']);
-        const hex = sessionData.dataKey as string | undefined;
-        if (hex) {
-          const rawBytes = fromHex(hex);
-          sessionKey = await importKey(rawBytes.buffer as ArrayBuffer, ['decrypt']);
-          rawBytes.fill(0);
-          hasSessionKey.value = true;
-        } else {
-          isUnlocked.value = false;
-          await chrome.storage.local.remove('unlocked_until');
-          return false;
-        }
-      }
-    } catch (err) {
+      const rawBytes = fromHex(hex);
+      sessionKey = await importKey(rawBytes.buffer as ArrayBuffer, ['decrypt']);
+      rawBytes.fill(0);
+      hasSessionKey.value = true;
+      isUnlocked.value = true;
+    } catch {
       isUnlocked.value = false;
       return false;
     }
@@ -168,13 +164,20 @@ export const useWalletStore = defineStore('wallet', () => {
     return true;
   }
 
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
   async function resetLockTimer() {
     if (!isUnlocked.value) return;
-    const durationMs = lockDuration.value * 60 * 1000;
-    const expiry = Date.now() + durationMs;
 
-    if (typeof chrome !== 'undefined' && chrome.storage) {
-      await chrome.storage.local.set({ unlocked_until: expiry });
+    if (debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+    }, 1000);
+
+    const durationMs = lockDuration.value * 60 * 1000;
+
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.set({ sessionStartTime: Date.now() });
     }
 
     if (lockTimer) clearTimeout(lockTimer);
@@ -247,10 +250,7 @@ export const useWalletStore = defineStore('wallet', () => {
       localStorage.setItem('peppool_price_eur', currentPrices.EUR.toString());
 
       const tipHeight = await fetchTipHeight();
-      if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) {
-        await resetLockTimer();
-        return;
-      }
+      if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
       lastTipHeight = tipHeight;
 
       const totalRibbits = await fetchAddressInfo(address.value);
@@ -258,7 +258,6 @@ export const useWalletStore = defineStore('wallet', () => {
       localStorage.setItem('peppool_balance', balance.value.toString());
 
       await refreshTransactions();
-      await resetLockTimer();
     } catch (e) {
       console.error('Failed to refresh balance', e);
     }
@@ -388,9 +387,8 @@ export const useWalletStore = defineStore('wallet', () => {
     isUnlocked.value = false;
     sessionKey = null;
     hasSessionKey.value = false;
-    if (typeof chrome !== 'undefined' && chrome.storage) {
-      await chrome.storage.local.remove('unlocked_until');
-      await chrome.storage.session?.remove('dataKey');
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.remove(['sessionStartTime', 'dataKey']);
     }
     if (lockTimer) clearTimeout(lockTimer);
     lockTimer = null;
@@ -421,8 +419,8 @@ export const useWalletStore = defineStore('wallet', () => {
     }
 
     if (typeof chrome !== 'undefined' && chrome.storage) {
-      await chrome.storage.local.remove(['unlocked_until', 'peppool_permissions']);
-      await chrome.storage.session?.remove('dataKey');
+      await chrome.storage.local.remove('peppool_permissions');
+      await chrome.storage.session?.remove(['sessionStartTime', 'dataKey']);
     }
 
     if (lockTimer) clearTimeout(lockTimer);


### PR DESCRIPTION
Closes #17

## Summary
- Replace `unlocked_until` in `chrome.storage.local` with `sessionStartTime` in `chrome.storage.session`
- Wallet now locks after X minutes of **inactivity** (no clicks), not X minutes after unlock
- Interaction resets are debounced (1s) to avoid hammering storage on rapid clicks
- Background alarm clears session on inactivity timeout
- Browser close = session gone = wallet locked on next open
- Remove stale `mnemonic` reference in background alarm handler (was already replaced by `dataKey` in PR #13)
- Remove `resetLockTimer` calls from `refreshBalance` (not user interaction)

## Test plan
- [x] Unlock wallet, verify `sessionStartTime` appears in `chrome.storage.session`
- [x] Wait for auto-lock duration without interacting — wallet should lock
- [x] Click within the extension — verify lock timer resets
- [x] Close and reopen browser — wallet should require login