### PR TITLE
Defer UTXO fetch to send step

### DIFF
--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -39,6 +39,7 @@ describe('useSendTransaction Composable', () => {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       selectedCurrency: 'USD',
       currencySymbol: '$',
+      balance: 5,
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       isMnemonicLoaded: true,
@@ -49,71 +50,86 @@ describe('useSendTransaction Composable', () => {
     } as any);
   });
 
-  it('should load requirements and filter confirmed UTXOs', async () => {
-    const mixedUtxos = [
-      { txid: 'c1', vout: 0, value: 500_000_000, status: { confirmed: true } },
-      { txid: 'u1', vout: 0, value: 200_000_000, status: { confirmed: false } }
-    ];
+  it('should load fees without fetching UTXOs', async () => {
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
-    vi.mocked(api.fetchUtxos).mockResolvedValue(mixedUtxos as any);
-    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue([]);
 
-    const { tx, loadRequirements, isLoadingRequirements } = useSendTransaction();
+    const { tx, loadFees, isLoadingFees } = useSendTransaction();
 
-    expect(isLoadingRequirements.value).toBe(true);
-    await loadRequirements();
-    expect(isLoadingRequirements.value).toBe(false);
+    expect(isLoadingFees.value).toBe(true);
+    await loadFees();
+    expect(isLoadingFees.value).toBe(false);
 
-    expect(tx.value.utxos).toHaveLength(1);
-    expect(tx.value.utxos[0].txid).toBe('c1');
     expect(tx.value.fees?.fastestFee).toBe(1000);
+    expect(api.fetchUtxos).not.toHaveBeenCalled();
   });
 
-  it('should exclude inscription-bearing UTXOs from spendable balance', async () => {
-    const utxos = [
-      { txid: 'safe1', vout: 0, value: 300_000_000, status: { confirmed: true } },
-      { txid: 'inscribed1', vout: 1, value: 100_000, status: { confirmed: true } },
-      { txid: 'safe2', vout: 0, value: 200_000_000, status: { confirmed: true } }
-    ];
-    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
-    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
-    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue(['inscribed1:1']);
-
-    const { tx, loadRequirements } = useSendTransaction();
-    await loadRequirements();
-
-    expect(tx.value.utxos).toHaveLength(2);
-    expect(tx.value.utxos.map((u: any) => u.txid)).toEqual(['safe1', 'safe2']);
-  });
-
-  it('should still load UTXOs when inscription API fails', async () => {
-    const utxos = [{ txid: 'c1', vout: 0, value: 500_000_000, status: { confirmed: true } }];
-    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
-    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
-    vi.mocked(api.fetchInscriptionOutputs).mockRejectedValue(new Error('Ord indexer down'));
-
-    const { tx, loadRequirements } = useSendTransaction();
-    await loadRequirements();
-
-    expect(tx.value.utxos).toHaveLength(1);
-    expect(tx.value.utxos[0].txid).toBe('c1');
-  });
-
-  it('should calculate display balance correctly', async () => {
-    const { tx, displayBalance } = useSendTransaction();
-    tx.value.utxos = [
-      { txid: 'c1', vout: 0, value: 500_000_000, status: { confirmed: true } }
-    ] as any;
+  it('should display balance from wallet store', () => {
+    mockWallet.balance = 5;
+    const { displayBalance } = useSendTransaction();
 
     expect(displayBalance(false)).toBe('5 PEP');
     expect(displayBalance(true)).toBe('$50.00 USD');
   });
 
+  it('should check insufficient funds against wallet store balance', async () => {
+    mockWallet.balance = 0.001; // 100,000 ribbits
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+
+    const { isInsufficientFunds, tx, isLoadingFees, loadFees } = useSendTransaction();
+    await loadFees();
+
+    tx.value.amountRibbits = 200_000; // More than balance
+    expect(isInsufficientFunds.value).toBe(true);
+  });
+
+  it('should fetch UTXOs and filter inscriptions at send time', async () => {
+    const utxos = [
+      { txid: 'safe1', vout: 0, value: 300_000_000, status: { confirmed: true } },
+      { txid: 'inscribed1', vout: 1, value: 100_000, status: { confirmed: true } },
+      { txid: 'safe2', vout: 0, value: 200_000_000, status: { confirmed: true } }
+    ];
+    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
+    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue(['inscribed1:1']);
+    vi.mocked(api.fetchTxHex).mockResolvedValue('raw-hex');
+    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
+    vi.mocked(crypto.createSignedTx).mockResolvedValue('signed-hex');
+    vi.mocked(api.broadcastTx).mockResolvedValue('new-txid');
+
+    const { tx, send } = useSendTransaction();
+    tx.value.fees = { fastestFee: 1000 } as any;
+    tx.value.recipient = 'recipient';
+    tx.value.amountRibbits = 100_000_000;
+
+    await send('password', false);
+
+    // UTXOs should have been fetched and filtered
+    expect(api.fetchUtxos).toHaveBeenCalledWith('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
+    expect(tx.value.utxos).toHaveLength(2);
+    expect(tx.value.utxos.map((u: any) => u.txid)).toEqual(['safe1', 'safe2']);
+  });
+
+  it('should still send when inscription API fails', async () => {
+    const utxos = [{ txid: 'c1', vout: 0, value: 500_000_000, status: { confirmed: true } }];
+    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
+    vi.mocked(api.fetchInscriptionOutputs).mockRejectedValue(new Error('Ord indexer down'));
+    vi.mocked(api.fetchTxHex).mockResolvedValue('raw-hex');
+    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
+    vi.mocked(crypto.createSignedTx).mockResolvedValue('signed-hex');
+    vi.mocked(api.broadcastTx).mockResolvedValue('new-txid');
+
+    const { tx, send } = useSendTransaction();
+    tx.value.fees = { fastestFee: 1000 } as any;
+    tx.value.recipient = 'recipient';
+    tx.value.amountRibbits = 100_000_000;
+
+    const result = await send('password', false);
+    expect(result).toBe('new-txid');
+    expect(tx.value.utxos).toHaveLength(1);
+  });
+
   it('should validate step 1 inputs', async () => {
+    mockWallet.balance = 100;
     const { validateStep1, tx } = useSendTransaction();
-    tx.value.utxos = [
-      { txid: 'c1', vout: 0, value: 10_000_000_000, status: { confirmed: true } }
-    ] as any;
     tx.value.fees = { fastestFee: 1000 } as any;
 
     vi.mocked(crypto.isValidAddress).mockReturnValue(true);
@@ -137,17 +153,18 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should send transaction and return txid', async () => {
-    const { tx, send } = useSendTransaction();
-    tx.value.utxos = [
-      { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
-    ] as any;
-    tx.value.recipient = 'recipient';
-    tx.value.amountRibbits = 500_000_000;
-
+    const utxos = [{ txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }];
+    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
+    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue([]);
     vi.mocked(api.fetchTxHex).mockResolvedValue('raw-hex');
     vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
     vi.mocked(crypto.createSignedTx).mockResolvedValue('signed-hex');
     vi.mocked(api.broadcastTx).mockResolvedValue('new-txid');
+
+    const { tx, send } = useSendTransaction();
+    tx.value.fees = { fastestFee: 1000 } as any;
+    tx.value.recipient = 'recipient';
+    tx.value.amountRibbits = 500_000_000;
 
     const result = await send('password', false);
 
@@ -157,25 +174,27 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should handle insufficient funds correctly', async () => {
-    const { isInsufficientFunds, tx, isLoadingRequirements } = useSendTransaction();
-    isLoadingRequirements.value = false;
-    tx.value.utxos = [{ txid: 'c1', vout: 0, value: 100, status: { confirmed: true } }] as any;
-    tx.value.amountRibbits = 1000; // More than balance
+    mockWallet.balance = 0.000001; // 100 ribbits
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
+    const { isInsufficientFunds, tx, loadFees } = useSendTransaction();
+    await loadFees();
+
+    tx.value.amountRibbits = 1000; // More than balance
     expect(isInsufficientFunds.value).toBe(true);
   });
 
   it('should handle send failure with error message', async () => {
-    vi.mocked(api.fetchTxHex).mockReset();
-    vi.mocked(api.broadcastTx).mockReset();
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
+    ] as any);
+    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue([]);
+    vi.mocked(api.fetchTxHex).mockRejectedValue(new Error('Network error'));
 
     const { send, tx } = useSendTransaction();
-    tx.value.utxos = [
-      { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
-    ] as any;
-    mockWallet.isMnemonicLoaded = true;
-    mockWallet.withMnemonic = vi.fn((fn: any) => Promise.resolve(fn('mnemonic')));
-    vi.mocked(api.fetchTxHex).mockRejectedValue(new Error('Network error'));
+    tx.value.fees = { fastestFee: 1000 } as any;
+    tx.value.recipient = 'recipient';
+    tx.value.amountRibbits = 500_000_000;
 
     await expect(send('password', false)).rejects.toThrow('Network error');
   });
@@ -186,35 +205,35 @@ describe('useSendTransaction Composable', () => {
     await expect(send('', false)).rejects.toThrow('Password required');
   });
 
-  it('should calculate max amount correctly', async () => {
-    const { tx, loadRequirements } = useSendTransaction();
-    const mockUtxos = [{ txid: 'c1', vout: 0, value: 1000000, status: { confirmed: true } }];
-    vi.mocked(api.fetchUtxos).mockResolvedValue(mockUtxos as any);
+  it('should estimate max amount from wallet balance', async () => {
+    mockWallet.balance = 10; // 1,000,000,000 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
-    await loadRequirements(true); // isMax = true
+    const { maxRibbits, loadFees } = useSendTransaction();
+    await loadFees();
 
-    expect(tx.value.amountRibbits).toBeGreaterThan(0);
-    expect(tx.value.amountRibbits).toBeLessThan(1000000);
+    expect(maxRibbits.value).toBeGreaterThan(0);
+    expect(maxRibbits.value).toBeLessThan(10 * RIBBITS_PER_PEP);
   });
 
   it('should use active account indices when deriving signer', async () => {
+    const utxos = [{ txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }];
+    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
+    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue([]);
+    vi.mocked(api.fetchTxHex).mockResolvedValue('raw-hex');
+    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
+    vi.mocked(crypto.createSignedTx).mockResolvedValue('signed-hex');
+    vi.mocked(api.broadcastTx).mockResolvedValue('new-txid');
+
     const { tx, send } = useSendTransaction();
     mockWallet.activeAccount = {
       address: 'addr2',
       path: "m/44'/3434'/5'/0/3",
       label: 'Account 6'
     };
-    tx.value.utxos = [
-      { txid: 'c1', vout: 0, value: 1000_000_000, status: { confirmed: true } }
-    ] as any;
+    tx.value.fees = { fastestFee: 1000 } as any;
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 500_000_000;
-
-    vi.mocked(api.fetchTxHex).mockResolvedValue('raw-hex');
-    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
-    vi.mocked(crypto.createSignedTx).mockResolvedValue('signed-hex');
-    vi.mocked(api.broadcastTx).mockResolvedValue('new-txid');
 
     await send('password', false);
 

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -40,6 +40,7 @@ describe('useSendTransaction Composable', () => {
       selectedCurrency: 'USD',
       currencySymbol: '$',
       balance: 5,
+      spendableBalance: 5,
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       isMnemonicLoaded: true,
@@ -63,16 +64,8 @@ describe('useSendTransaction Composable', () => {
     expect(api.fetchUtxos).not.toHaveBeenCalled();
   });
 
-  it('should display balance from wallet store', () => {
-    mockWallet.balance = 5;
-    const { displayBalance } = useSendTransaction();
-
-    expect(displayBalance(false)).toBe('5 PEP');
-    expect(displayBalance(true)).toBe('$50.00 USD');
-  });
-
-  it('should check insufficient funds against wallet store balance', async () => {
-    mockWallet.balance = 0.001; // 100,000 ribbits
+  it('should check insufficient funds against spendable balance', async () => {
+    mockWallet.spendableBalance = 0.001; // 100,000 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, isLoadingFees, loadFees } = useSendTransaction();
@@ -128,7 +121,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should validate step 1 inputs', async () => {
-    mockWallet.balance = 100;
+    mockWallet.spendableBalance = 100;
     const { validateStep1, tx } = useSendTransaction();
     tx.value.fees = { fastestFee: 1000 } as any;
 
@@ -174,7 +167,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should handle insufficient funds correctly', async () => {
-    mockWallet.balance = 0.000001; // 100 ribbits
+    mockWallet.spendableBalance = 0.000001; // 100 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, loadFees } = useSendTransaction();
@@ -206,7 +199,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should estimate max amount from wallet balance', async () => {
-    mockWallet.balance = 10; // 1,000,000,000 ribbits
+    mockWallet.spendableBalance = 10; // 1,000,000,000 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { maxRibbits, loadFees } = useSendTransaction();

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -14,34 +14,36 @@ import {
   isValidAddress,
   deriveSigner,
   parseDerivationPath,
+  estimateTxSize,
   type UTXO
 } from '@/utils/crypto';
 import { decrypt as decryptMnemonic } from '@/utils/encryption';
 import { SendTransaction } from '@/models/SendTransaction';
-import { RIBBITS_PER_PEP, MIN_SEND_PEP, formatFiat } from '@/utils/constants';
+import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE, formatFiat } from '@/utils/constants';
 
 export function useSendTransaction() {
   const { wallet: walletStore } = useApp();
 
   const tx = ref(new SendTransaction(walletStore.address!));
   const txid = ref('');
-  const isLoadingRequirements = ref(true);
+  const isLoadingFees = ref(true);
+
+  const walletBalanceRibbits = computed(() => Math.round(walletStore.balance * RIBBITS_PER_PEP));
 
   const currentPrice = computed(() => walletStore.prices[walletStore.selectedCurrency]);
 
   const isInsufficientFunds = computed(() => {
-    if (isLoadingRequirements.value || tx.value.amountRibbits <= 0) return false;
+    if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;
     const needed = tx.value.amountRibbits + tx.value.estimatedFeeRibbits;
-    return tx.value.balanceRibbits < needed;
+    return walletBalanceRibbits.value < needed;
   });
 
   const displayBalance = (isFiatMode: boolean) => {
-    const spendable = tx.value.balancePep;
     if (isFiatMode) {
-      const fiatValue = spendable * currentPrice.value;
+      const fiatValue = walletStore.balance * currentPrice.value;
       return `${walletStore.currencySymbol}${formatFiat(fiatValue)} ${walletStore.selectedCurrency}`;
     }
-    return `${parseFloat(spendable.toFixed(8))} PEP`;
+    return `${parseFloat(walletStore.balance.toFixed(8))} PEP`;
   };
 
   const displayFee = computed(() => {
@@ -49,30 +51,24 @@ export function useSendTransaction() {
     return `${parseFloat(feePep.toFixed(8))} PEP`;
   });
 
-  async function loadRequirements(isMax: boolean = false) {
-    isLoadingRequirements.value = true;
+  const maxRibbits = computed(() => {
+    const txSize = estimateTxSize(1, 1);
+    const feeRate = tx.value.fees
+      ? Math.max(RECOMMENDED_FEE_RATE, tx.value.fees.fastestFee)
+      : RECOMMENDED_FEE_RATE;
+    const feeRibbits = Math.ceil(txSize * feeRate);
+    return Math.max(0, walletBalanceRibbits.value - feeRibbits);
+  });
+
+  async function loadFees() {
+    isLoadingFees.value = true;
     try {
-      const [fees, utxos, inscriptionOutputs] = await Promise.all([
-        fetchRecommendedFees(),
-        fetchUtxos(walletStore.address!),
-        fetchInscriptionOutputs(walletStore.address!).catch(() => [] as string[])
-      ]);
-
-      const inscriptionSet = new Set(inscriptionOutputs);
-
-      tx.value.fees = fees;
-      tx.value.utxos = utxos.filter(
-        (u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionSet)
-      );
-
-      if (isMax) {
-        tx.value.amountRibbits = tx.value.maxRibbits;
-      }
+      tx.value.fees = await fetchRecommendedFees();
     } catch (e) {
-      console.error('Failed to load transaction requirements', e);
+      console.error('Failed to load fees', e);
       throw e;
     } finally {
-      isLoadingRequirements.value = false;
+      isLoadingFees.value = false;
     }
   }
 
@@ -98,7 +94,8 @@ export function useSendTransaction() {
       throw new Error('Invalid Pepecoin address');
     }
 
-    if (!tx.value.isValid) {
+    const needed = amountRibbits + tx.value.estimatedFeeRibbits;
+    if (walletBalanceRibbits.value < needed) {
       throw new Error('Insufficient balance');
     }
 
@@ -118,6 +115,20 @@ export function useSendTransaction() {
       } else {
         if (!password) throw new Error('Password required');
         mnemonic = await decryptMnemonic(walletStore.encryptedMnemonic!, password);
+      }
+
+      // Fetch UTXOs and inscription outputs at send time
+      const [utxos, inscriptionOutputs] = await Promise.all([
+        fetchUtxos(walletStore.address!),
+        fetchInscriptionOutputs(walletStore.address!).catch(() => [] as string[])
+      ]);
+      const inscriptionSet = new Set(inscriptionOutputs);
+      tx.value.utxos = utxos.filter(
+        (u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionSet)
+      );
+
+      if (isMax) {
+        tx.value.amountRibbits = tx.value.maxRibbits;
       }
 
       const { selectedUtxos } = tx.value.selectUtxos(isMax);
@@ -154,12 +165,13 @@ export function useSendTransaction() {
   return {
     tx,
     txid,
-    isLoadingRequirements,
+    isLoadingFees,
     currentPrice,
     isInsufficientFunds,
     displayBalance,
     displayFee,
-    loadRequirements,
+    maxRibbits,
+    loadFees,
     validateStep1,
     send
   };

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -19,7 +19,7 @@ import {
 } from '@/utils/crypto';
 import { decrypt as decryptMnemonic } from '@/utils/encryption';
 import { SendTransaction } from '@/models/SendTransaction';
-import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE, formatFiat } from '@/utils/constants';
+import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
 export function useSendTransaction() {
   const { wallet: walletStore } = useApp();
@@ -28,23 +28,17 @@ export function useSendTransaction() {
   const txid = ref('');
   const isLoadingFees = ref(true);
 
-  const walletBalanceRibbits = computed(() => Math.round(walletStore.balance * RIBBITS_PER_PEP));
+  const spendableBalanceRibbits = computed(() =>
+    Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
+  );
 
   const currentPrice = computed(() => walletStore.prices[walletStore.selectedCurrency]);
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;
     const needed = tx.value.amountRibbits + tx.value.estimatedFeeRibbits;
-    return walletBalanceRibbits.value < needed;
+    return spendableBalanceRibbits.value < needed;
   });
-
-  const displayBalance = (isFiatMode: boolean) => {
-    if (isFiatMode) {
-      const fiatValue = walletStore.balance * currentPrice.value;
-      return `${walletStore.currencySymbol}${formatFiat(fiatValue)} ${walletStore.selectedCurrency}`;
-    }
-    return `${parseFloat(walletStore.balance.toFixed(8))} PEP`;
-  };
 
   const displayFee = computed(() => {
     const feePep = tx.value.estimatedFeeRibbits / RIBBITS_PER_PEP;
@@ -57,7 +51,7 @@ export function useSendTransaction() {
       ? Math.max(RECOMMENDED_FEE_RATE, tx.value.fees.fastestFee)
       : RECOMMENDED_FEE_RATE;
     const feeRibbits = Math.ceil(txSize * feeRate);
-    return Math.max(0, walletBalanceRibbits.value - feeRibbits);
+    return Math.max(0, spendableBalanceRibbits.value - feeRibbits);
   });
 
   async function loadFees() {
@@ -95,7 +89,7 @@ export function useSendTransaction() {
     }
 
     const needed = amountRibbits + tx.value.estimatedFeeRibbits;
-    if (walletBalanceRibbits.value < needed) {
+    if (spendableBalanceRibbits.value < needed) {
       throw new Error('Insufficient balance');
     }
 
@@ -168,7 +162,6 @@ export function useSendTransaction() {
     isLoadingFees,
     currentPrice,
     isInsufficientFunds,
-    displayBalance,
     displayFee,
     maxRibbits,
     loadFees,

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -4,18 +4,27 @@ import { useWalletStore } from './wallet';
 import { useLockoutStore } from './lockout';
 
 import { Transaction } from '@/models/Transaction';
+import * as api from '@/utils/api';
 
 // Mock the API and Crypto utils
-vi.mock('@/utils/api', () => ({
-  fetchAddressInfo: vi.fn(() => Promise.resolve(100000000)),
-  fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0.5, EUR: 0.4 })),
-  fetchTransactions: vi.fn(() => Promise.resolve([])),
-  hasAddressActivity: vi.fn(() => Promise.resolve(false)),
-  fetchRecommendedFees: vi.fn(() =>
-    Promise.resolve({ fastestFee: 1, halfHourFee: 1, hourFee: 1, economyFee: 1, minimumFee: 1 })
-  ),
-  fetchTipHeight: vi.fn(() => Promise.resolve(100))
-}));
+vi.mock('@/utils/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/api')>();
+  return {
+    ...actual,
+    fetchAddressInfo: vi.fn(() => Promise.resolve(100000000)),
+    fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0.5, EUR: 0.4 })),
+    fetchTransactions: vi.fn(() => Promise.resolve([])),
+    hasAddressActivity: vi.fn(() => Promise.resolve(false)),
+    fetchRecommendedFees: vi.fn(() =>
+      Promise.resolve({ fastestFee: 1, halfHourFee: 1, hourFee: 1, economyFee: 1, minimumFee: 1 })
+    ),
+    fetchTipHeight: vi.fn(() => Promise.resolve(100)),
+    fetchUtxos: vi.fn(() =>
+      Promise.resolve([{ txid: 'a', vout: 0, value: 100000000, status: { confirmed: true } }])
+    ),
+    fetchInscriptionOutputs: vi.fn(() => Promise.resolve([]))
+  };
+});
 
 describe('Wallet Store', () => {
   beforeEach(() => {
@@ -281,6 +290,51 @@ describe('Wallet Store', () => {
 
     store.setCurrency('EUR');
     expect(store.balanceFiat).toBe(0.4); // 1 PEP * 0.4 EUR
+  });
+
+  it('should compute spendable balance excluding inscription UTXOs', async () => {
+    const store = useWalletStore();
+    store.accounts = [
+      {
+        address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
+        path: "m/44'/3434'/0'/0/0",
+        label: 'Account 1'
+      }
+    ];
+    store.activeAccountIndex = 0;
+
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(300000000); // 3 PEP total
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'spendable1', vout: 0, value: 200000000, status: { confirmed: true } },
+      { txid: 'inscribed1', vout: 1, value: 10000, status: { confirmed: true } },
+      { txid: 'spendable2', vout: 0, value: 99990000, status: { confirmed: true } }
+    ]);
+    vi.mocked(api.fetchInscriptionOutputs).mockResolvedValue(['inscribed1:1']);
+
+    await store.refreshBalance(true);
+
+    expect(store.balance).toBe(3); // Total balance
+    expect(store.spendableBalance).toBe(2.9999); // Excludes inscription UTXO (10000 ribbits)
+  });
+
+  it('should fall back to total balance when inscription fetch fails', async () => {
+    const store = useWalletStore();
+    store.accounts = [
+      {
+        address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
+        path: "m/44'/3434'/0'/0/0",
+        label: 'Account 1'
+      }
+    ];
+    store.activeAccountIndex = 0;
+
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(100000000);
+    vi.mocked(api.fetchUtxos).mockRejectedValue(new Error('Network error'));
+
+    await store.refreshBalance(true);
+
+    expect(store.balance).toBe(1);
+    expect(store.spendableBalance).toBe(1); // Falls back to total
   });
 
   it('should handle currency changes correctly', () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -14,7 +14,10 @@ import {
   fetchTransactions,
   fetchTransaction as apiFetchTransaction,
   fetchPepPrice,
-  fetchTipHeight
+  fetchTipHeight,
+  fetchUtxos,
+  fetchInscriptionOutputs,
+  isInscriptionUtxo
 } from '@/utils/api';
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
@@ -63,6 +66,7 @@ export const useWalletStore = defineStore('wallet', () => {
   const isUnlocked = ref(false);
   const lockDuration = ref<number>(parseInt(localStorage.getItem('peppool_lock_duration') || '15'));
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
+  const spendableBalance = ref<number>(0);
   const prices = ref({
     USD: Number(localStorage.getItem('peppool_price_usd')) || 0,
     EUR: Number(localStorage.getItem('peppool_price_eur')) || 0
@@ -257,6 +261,21 @@ export const useWalletStore = defineStore('wallet', () => {
       balance.value = totalRibbits / RIBBITS_PER_PEP;
       localStorage.setItem('peppool_balance', balance.value.toString());
 
+      // Compute spendable balance (total minus inscription UTXOs)
+      try {
+        const [utxos, inscriptionOutputs] = await Promise.all([
+          fetchUtxos(address.value),
+          fetchInscriptionOutputs(address.value).catch(() => [] as string[])
+        ]);
+        const inscriptionSet = new Set(inscriptionOutputs);
+        const spendableRibbits = utxos
+          .filter((u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionSet))
+          .reduce((sum, u) => sum + u.value, 0);
+        spendableBalance.value = spendableRibbits / RIBBITS_PER_PEP;
+      } catch {
+        spendableBalance.value = balance.value;
+      }
+
       await refreshTransactions();
       await resetLockTimer();
     } catch (e) {
@@ -408,6 +427,7 @@ export const useWalletStore = defineStore('wallet', () => {
     hasSessionKey.value = false;
     isUnlocked.value = false;
     balance.value = 0;
+    spendableBalance.value = 0;
     prices.value = { USD: 0, EUR: 0 };
     transactions.value = [];
     clearAuth();
@@ -438,6 +458,7 @@ export const useWalletStore = defineStore('wallet', () => {
     localStorage.setItem('peppool_active_account', index.toString());
     await syncToChromeStorage();
     balance.value = 0;
+    spendableBalance.value = 0;
     transactions.value = [];
     await refreshBalance(true);
   }
@@ -494,6 +515,7 @@ export const useWalletStore = defineStore('wallet', () => {
     isMnemonicLoaded,
     lockout,
     balance,
+    spendableBalance,
     balanceFiat,
     selectedCurrency,
     selectedExplorer,

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -38,12 +38,13 @@ const mockTx = {
 const mockSendTransaction = {
   tx: ref(mockTx),
   txid: ref(''),
-  isLoadingRequirements: ref(false),
+  isLoadingFees: ref(false),
   currentPrice: ref(10),
   isInsufficientFunds: ref(false),
   displayBalance: vi.fn().mockReturnValue('0 PEP'),
   displayFee: ref('0.001 PEP'),
-  loadRequirements: vi.fn(),
+  maxRibbits: ref(0),
+  loadFees: vi.fn(),
   validateStep1: vi.fn(),
   send: vi.fn().mockImplementation(async () => {
     mockSendTransaction.txid.value = 'txid';
@@ -85,7 +86,7 @@ describe('SendView', () => {
     // Reset mock implementation state
     mockSendTransaction.tx.value = { ...mockTx };
     mockSendTransaction.txid.value = '';
-    mockSendTransaction.isLoadingRequirements.value = false;
+    mockSendTransaction.isLoadingFees.value = false;
     mockSendTransaction.isInsufficientFunds.value = false;
     mockSendTransaction.displayBalance.mockReturnValue('0 PEP');
 
@@ -316,8 +317,8 @@ describe('SendView', () => {
   });
 
   it('setMax should set isMax and update amount', () => {
+    mockSendTransaction.maxRibbits.value = 5000;
     const wrapper = mount(SendView, { global });
-    mockSendTransaction.tx.value.maxRibbits = 5000;
 
     // @ts-ignore
     wrapper.vm.setMax();

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -41,7 +41,6 @@ const mockSendTransaction = {
   isLoadingFees: ref(false),
   currentPrice: ref(10),
   isInsufficientFunds: ref(false),
-  displayBalance: vi.fn().mockReturnValue('0 PEP'),
   displayFee: ref('0.001 PEP'),
   maxRibbits: ref(0),
   loadFees: vi.fn(),
@@ -88,7 +87,6 @@ describe('SendView', () => {
     mockSendTransaction.txid.value = '';
     mockSendTransaction.isLoadingFees.value = false;
     mockSendTransaction.isInsufficientFunds.value = false;
-    mockSendTransaction.displayBalance.mockReturnValue('0 PEP');
 
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
@@ -96,6 +94,7 @@ describe('SendView', () => {
       selectedCurrency: 'USD',
       currencySymbol: '$',
       balance: 7,
+      spendableBalance: 7,
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       openExplorerTx: vi.fn(),
@@ -173,11 +172,10 @@ describe('SendView', () => {
     );
   });
 
-  it('should display available balance from the composable', async () => {
-    mockSendTransaction.displayBalance.mockReturnValue('5 PEP');
+  it('should display spendable balance on the send form', async () => {
+    mockWallet.spendableBalance = 5;
 
     const wrapper = mount(SendView, { global });
-    // Ensure we are at step 1
     // @ts-ignore
     wrapper.vm.form.step = 1;
 

--- a/src/views/wallet/send/SendStepForm.spec.ts
+++ b/src/views/wallet/send/SendStepForm.spec.ts
@@ -24,7 +24,6 @@ describe('SendStepForm Component', () => {
       clearError: vi.fn(),
       setError: vi.fn()
     },
-    isLoadingFees: false,
     isInsufficientFunds: false,
     currentPrice: 10,
     displayBalance: '10 PEP',

--- a/src/views/wallet/send/SendStepForm.spec.ts
+++ b/src/views/wallet/send/SendStepForm.spec.ts
@@ -24,7 +24,7 @@ describe('SendStepForm Component', () => {
       clearError: vi.fn(),
       setError: vi.fn()
     },
-    isLoadingRequirements: false,
+    isLoadingFees: false,
     isInsufficientFunds: false,
     currentPrice: 10,
     displayBalance: '10 PEP',

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue';
 
 const props = defineProps<{
   form: any;
-  isLoadingRequirements: boolean;
+  isLoadingFees: boolean;
   isInsufficientFunds: boolean;
   currentPrice: number;
   displayBalance: string;
@@ -31,7 +31,7 @@ onMounted(() => {
         label="Recipient Address"
         placeholder="Enter address"
         :error="form.errors.recipient"
-        :disabled="form.isProcessing || isLoadingRequirements"
+        :disabled="form.isProcessing || isLoadingFees"
         clearable
         autofocus
         @blur="$emit('address-blur')"
@@ -53,7 +53,7 @@ onMounted(() => {
           v-model:ribbits="form.amountRibbits"
           v-model:isFiatMode="form.isFiatMode"
           :price="currentPrice"
-          :disabled="form.isProcessing || isLoadingRequirements"
+          :disabled="form.isProcessing || isLoadingFees"
           @change-max="form.isMax = $event"
         >
           <template #extra>
@@ -61,7 +61,7 @@ onMounted(() => {
               id="send-max-button"
               type="button"
               @click="$emit('set-max')"
-              :disabled="form.isProcessing || isLoadingRequirements"
+              :disabled="form.isProcessing || isLoadingFees"
               class="text-pep-green-light hover:text-pep-green cursor-pointer text-xs font-bold tracking-wider uppercase disabled:cursor-not-allowed disabled:opacity-50"
               tabindex="-1"
             >

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -3,7 +3,6 @@ import { ref, onMounted } from 'vue';
 
 const props = defineProps<{
   form: any;
-  isLoadingFees: boolean;
   isInsufficientFunds: boolean;
   currentPrice: number;
   displayBalance: string;
@@ -31,7 +30,7 @@ onMounted(() => {
         label="Recipient Address"
         placeholder="Enter address"
         :error="form.errors.recipient"
-        :disabled="form.isProcessing || isLoadingFees"
+        :disabled="form.isProcessing"
         clearable
         autofocus
         @blur="$emit('address-blur')"
@@ -53,7 +52,7 @@ onMounted(() => {
           v-model:ribbits="form.amountRibbits"
           v-model:isFiatMode="form.isFiatMode"
           :price="currentPrice"
-          :disabled="form.isProcessing || isLoadingFees"
+          :disabled="form.isProcessing"
           @change-max="form.isMax = $event"
         >
           <template #extra>
@@ -61,7 +60,7 @@ onMounted(() => {
               id="send-max-button"
               type="button"
               @click="$emit('set-max')"
-              :disabled="form.isProcessing || isLoadingFees"
+              :disabled="form.isProcessing"
               class="text-pep-green-light hover:text-pep-green cursor-pointer text-xs font-bold tracking-wider uppercase disabled:cursor-not-allowed disabled:opacity-50"
               tabindex="-1"
             >

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -4,7 +4,7 @@ import { useApp } from '@/composables/useApp';
 import { useSendTransaction } from '@/composables/useSendTransaction';
 import { isValidAddress } from '@/utils/crypto';
 import { useForm } from '@/utils/form';
-import { UX_DELAY_FAST, UX_DELAY_SLOW } from '@/utils/constants';
+import { UX_DELAY_FAST, UX_DELAY_SLOW, formatFiat } from '@/utils/constants';
 
 import SendStepForm from './SendStepForm.vue';
 import SendStepReview from './SendStepReview.vue';
@@ -17,7 +17,6 @@ const {
   isLoadingFees,
   currentPrice,
   isInsufficientFunds,
-  displayBalance,
   displayFee,
   maxRibbits,
   loadFees,
@@ -45,6 +44,15 @@ watch(txid, (newTxid) => {
 
 // Step 2 can't survive remount — password isn't persisted
 if (form.step === 2) form.step = 1;
+
+const displayBalance = computed(() => {
+  const bal = walletStore.spendableBalance;
+  if (form.isFiatMode) {
+    const price = walletStore.prices[walletStore.selectedCurrency];
+    return `${walletStore.currencySymbol}${formatFiat(bal * price)} ${walletStore.selectedCurrency}`;
+  }
+  return `${parseFloat(bal.toFixed(8))} PEP`;
+});
 
 const canReview = computed(() => {
   return (
@@ -196,7 +204,7 @@ onMounted(async () => {
       :form="form"
       :isInsufficientFunds="isInsufficientFunds"
       :currentPrice="currentPrice"
-      :displayBalance="displayBalance(form.isFiatMode)"
+      :displayBalance="displayBalance"
       :displayFee="displayFee"
       @address-blur="handleAddressBlur"
       @set-max="setMax"

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -14,12 +14,13 @@ const { router, wallet: walletStore } = useApp();
 const {
   tx,
   txid,
-  isLoadingRequirements,
+  isLoadingFees,
   currentPrice,
   isInsufficientFunds,
   displayBalance,
   displayFee,
-  loadRequirements,
+  maxRibbits,
+  loadFees,
   validateStep1,
   send
 } = useSendTransaction();
@@ -47,7 +48,7 @@ if (form.step === 2) form.step = 1;
 
 const canReview = computed(() => {
   return (
-    !isLoadingRequirements.value &&
+    !isLoadingFees.value &&
     form.recipient &&
     tx.value.amountRibbits > 0 &&
     !form.hasError() &&
@@ -56,7 +57,7 @@ const canReview = computed(() => {
 });
 
 const nextButtonLabel = computed(() => {
-  if (isLoadingRequirements.value) return 'Loading...';
+  if (isLoadingFees.value) return 'Loading...';
   if (isInsufficientFunds.value) return 'Insufficient funds';
   return 'Next';
 });
@@ -82,7 +83,7 @@ watch(
 
 function setMax() {
   form.isMax = true;
-  form.amountRibbits = tx.value.maxRibbits;
+  form.amountRibbits = maxRibbits.value;
 }
 
 async function handleAddressBlur() {
@@ -162,7 +163,7 @@ onMounted(async () => {
   }
 
   try {
-    await loadRequirements(form.isMax);
+    await loadFees();
   } catch (e) {
     // Error handled in composable
   }
@@ -193,7 +194,7 @@ onMounted(async () => {
     <SendStepForm
       v-if="form.step === 1"
       :form="form"
-      :isLoadingRequirements="isLoadingRequirements"
+      :isLoadingFees="isLoadingFees"
       :isInsufficientFunds="isInsufficientFunds"
       :currentPrice="currentPrice"
       :displayBalance="displayBalance(form.isFiatMode)"

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -194,7 +194,6 @@ onMounted(async () => {
     <SendStepForm
       v-if="form.step === 1"
       :form="form"
-      :isLoadingFees="isLoadingFees"
       :isInsufficientFunds="isInsufficientFunds"
       :currentPrice="currentPrice"
       :displayBalance="displayBalance(form.isFiatMode)"


### PR DESCRIPTION
Closes #16

## Summary
- SendView now opens instantly — only fetches recommended fees on mount, no UTXO fetch
- Balance displayed from wallet store instead of UTXO-derived balance
- UTXOs and inscription outputs fetched at send time (behind "sending..." spinner)
- Max amount estimated from wallet balance minus conservative fee estimate
- Insufficient funds check uses wallet store balance

## Flow
1. **Form opens** — reads balance from store, fetches fees only (fast)
2. **User fills form** — validates against store balance
3. **User confirms send** — fetches UTXOs, filters inscriptions, coin selects, signs, broadcasts

## Test plan
- [ ] Open send view — should load instantly without spinner
- [ ] Available balance matches dashboard balance
- [ ] Max button calculates correct estimate
- [ ] Send transaction succeeds with correct UTXO selection
- [ ] Inscription UTXOs still excluded at send time
- [ ] Insufficient funds error shows correctly