### PR TITLE
Refactor: split wallet store into wallet + account stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `peppool-wallet` are documented in this file.
 - Inscription data sync with background refresh and cached UTXO exclusion ([#12](https://github.com/mvdnbrk/peppool-wallet/pull/12))
 
 ### Changed
+- Split wallet store into separate wallet and account stores ([#20](https://github.com/mvdnbrk/peppool-wallet/pull/20))
 - Consolidate price logic into single price module with unified cache key ([#24](https://github.com/mvdnbrk/peppool-wallet/pull/24))
 - Move settings and wallet state to chrome.storage.local with dedicated settings store ([#23](https://github.com/mvdnbrk/peppool-wallet/pull/23))
 - Wipe derived cache on app version change ([#22](https://github.com/mvdnbrk/peppool-wallet/pull/22))

--- a/src/composables/useApp.spec.ts
+++ b/src/composables/useApp.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useApp } from './useApp';
 import { useWalletStore } from '@/stores/wallet';
+import { useAccountStore } from '@/stores/account';
 import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 
@@ -23,23 +24,34 @@ vi.mock('@/stores/wallet', () => ({
   useWalletStore: vi.fn()
 }));
 
+// Mock Account Store
+vi.mock('@/stores/account', () => ({
+  useAccountStore: vi.fn()
+}));
+
 describe('useApp Composable', () => {
   let mockStore: any;
+  let mockAccountStore: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockStore = {
       isUnlocked: false
     };
+    mockAccountStore = {
+      balance: 0
+    };
     vi.mocked(useWalletStore).mockReturnValue(mockStore);
+    vi.mocked(useAccountStore).mockReturnValue(mockAccountStore);
   });
 
-  it('should return router, route, and wallet', () => {
+  it('should return router, route, wallet, and account', () => {
     const TestComponent = defineComponent({
       setup() {
         const app = useApp();
         expect(app.router).toBe(mockRouter);
         expect(app.wallet).toBe(mockStore);
+        expect(app.account).toBe(mockAccountStore);
         expect(app.route).toBeDefined();
         return () => null;
       }

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -1,18 +1,21 @@
 import { useRouter, useRoute } from 'vue-router';
 import { useWalletStore } from '@/stores/wallet';
+import { useAccountStore } from '@/stores/account';
 
 /**
- * Core application hook to provide access to the router and wallet store
- * with common helpers.
+ * Core application hook to provide access to the router, wallet store,
+ * and account store with common helpers.
  */
 export function useApp() {
   const router = useRouter();
   const route = useRoute();
   const wallet = useWalletStore();
+  const account = useAccountStore();
 
   return {
     router,
     route,
-    wallet
+    wallet,
+    account
   };
 }

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -41,22 +41,26 @@ vi.mock('@/utils/crypto', async (importOriginal) => {
 
 describe('useSendTransaction Composable', () => {
   let mockWallet: any;
+  let mockAccount: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccount = {
+      spendableBalance: 5
+    };
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       selectedCurrency: 'USD',
       currencySymbol: '$',
       balance: 5,
-      spendableBalance: 5,
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       isMnemonicLoaded: true,
       withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic')))
     };
     vi.mocked(useApp).mockReturnValue({
-      wallet: mockWallet
+      wallet: mockWallet,
+      account: mockAccount
     } as any);
   });
 
@@ -74,7 +78,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should check insufficient funds against spendable balance', async () => {
-    mockWallet.spendableBalance = 0.001; // 100,000 ribbits
+    mockAccount.spendableBalance = 0.001; // 100,000 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, isLoadingFees, loadFees } = useSendTransaction();
@@ -130,7 +134,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should validate step 1 inputs', async () => {
-    mockWallet.spendableBalance = 100;
+    mockAccount.spendableBalance = 100;
     const { validateStep1, tx } = useSendTransaction();
     tx.value.fees = { fastestFee: 1000 } as any;
 
@@ -176,7 +180,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should handle insufficient funds correctly', async () => {
-    mockWallet.spendableBalance = 0.000001; // 100 ribbits
+    mockAccount.spendableBalance = 0.000001; // 100 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, loadFees } = useSendTransaction();
@@ -208,7 +212,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should estimate max amount from wallet balance', async () => {
-    mockWallet.spendableBalance = 10; // 1,000,000,000 ribbits
+    mockAccount.spendableBalance = 10; // 1,000,000,000 ribbits
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { maxRibbits, loadFees } = useSendTransaction();

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -22,14 +22,14 @@ import { SendTransaction } from '@/models/SendTransaction';
 import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
 export function useSendTransaction() {
-  const { wallet: walletStore } = useApp();
+  const { wallet: walletStore, account } = useApp();
   const inscriptionStore = useInscriptionStore();
   const tx = ref(new SendTransaction(walletStore.address!));
   const txid = ref('');
   const isLoadingFees = ref(true);
 
   const spendableBalanceRibbits = computed(() =>
-    Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
+    Math.round(account.spendableBalance * RIBBITS_PER_PEP)
   );
 
   const currentPrice = computed(() => walletStore.prices[walletStore.selectedCurrency]);

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -132,9 +132,9 @@ describe('Account Store', () => {
     expect(account.transactions).toHaveLength(1);
     expect(account.transactions[0]!.txid).toBe('tx1');
 
-    const cached = localStorage.getItem('peppool_transactions');
-    expect(cached).not.toBeNull();
-    expect(JSON.parse(cached!)[0].txid).toBe('tx1');
+    const cached = JSON.parse(localStorage.getItem('peppool_transactions')!);
+    expect(cached[addr]).toHaveLength(1);
+    expect(cached[addr][0].txid).toBe('tx1');
   });
 
   it('should restore transactions from cache', () => {
@@ -149,7 +149,7 @@ describe('Account Store', () => {
       fee: 1000,
       status: { confirmed: true, block_height: 100, block_time: Date.now() / 1000 }
     };
-    localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
+    localStorage.setItem('peppool_transactions', JSON.stringify({ [addr]: [mockTx] }));
 
     const account = useAccountStore();
     account.loadCachedTransactions(addr);

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useAccountStore } from './account';
+
+import { Transaction } from '@/models/Transaction';
+import * as api from '@/utils/api';
+
+vi.mock('@/utils/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/api')>();
+  return {
+    ...actual,
+    fetchAddressInfo: vi.fn(() => Promise.resolve(100000000)),
+    fetchTransactions: vi.fn(() => Promise.resolve([])),
+    fetchTipHeight: vi.fn(() => Promise.resolve(100)),
+    fetchUtxos: vi.fn(() =>
+      Promise.resolve([{ txid: 'a', vout: 0, value: 100000000, status: { confirmed: true } }])
+    ),
+    fetchAddressInscriptions: vi.fn(() =>
+      Promise.resolve({ inscriptions: [], outputs: [], total: 0 })
+    ),
+    fetchInscription: vi.fn(),
+    fetchTransaction: vi.fn()
+  };
+});
+
+const addr = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
+
+describe('Account Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with zero balance', () => {
+    const account = useAccountStore();
+    expect(account.balance).toBe(0);
+    expect(account.spendableBalance).toBe(0);
+    expect(account.transactions).toHaveLength(0);
+    expect(account.canLoadMore).toBe(true);
+  });
+
+  it('should restore cached balance from localStorage', () => {
+    localStorage.setItem('peppool_balance', '42');
+    const account = useAccountStore();
+    expect(account.balance).toBe(42);
+  });
+
+  it('should sync balance from API', async () => {
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(500000000);
+    const account = useAccountStore();
+
+    await account.sync(addr, true);
+
+    expect(account.balance).toBe(5);
+    expect(localStorage.getItem('peppool_balance')).toBe('5');
+  });
+
+  it('should skip sync when tip height unchanged', async () => {
+    vi.mocked(api.fetchTipHeight).mockResolvedValue(100);
+    const account = useAccountStore();
+
+    await account.sync(addr, true);
+    vi.clearAllMocks();
+
+    await account.sync(addr, false);
+    expect(api.fetchAddressInfo).not.toHaveBeenCalled();
+  });
+
+  it('should force sync regardless of tip height', async () => {
+    vi.mocked(api.fetchTipHeight).mockResolvedValue(100);
+    const account = useAccountStore();
+
+    await account.sync(addr, true);
+    vi.clearAllMocks();
+    vi.mocked(api.fetchTipHeight).mockResolvedValue(100);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(200000000);
+
+    await account.sync(addr, true);
+    expect(api.fetchAddressInfo).toHaveBeenCalled();
+    expect(account.balance).toBe(2);
+  });
+
+  it('should compute spendable balance excluding inscription UTXOs', async () => {
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(300000000);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'spendable1', vout: 0, value: 200000000, status: { confirmed: true } },
+      { txid: 'inscribed1', vout: 1, value: 10000, status: { confirmed: true } },
+      { txid: 'spendable2', vout: 0, value: 99990000, status: { confirmed: true } }
+    ]);
+    vi.mocked(api.fetchAddressInscriptions).mockResolvedValue({
+      inscriptions: [],
+      outputs: ['inscribed1:1'],
+      total: 0
+    });
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
+    expect(account.balance).toBe(3);
+    expect(account.spendableBalance).toBe(2.9999);
+  });
+
+  it('should fall back to total balance when UTXO fetch fails', async () => {
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(100000000);
+    vi.mocked(api.fetchUtxos).mockRejectedValue(new Error('Network error'));
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
+    expect(account.balance).toBe(1);
+    expect(account.spendableBalance).toBe(1);
+  });
+
+  it('should refresh transactions and cache them', async () => {
+    const mockTx = {
+      txid: 'tx1',
+      version: 1,
+      locktime: 0,
+      vin: [],
+      vout: [{ value: 100000000, scriptpubkey_address: addr }],
+      size: 100,
+      weight: 400,
+      fee: 1000,
+      status: { confirmed: true, block_height: 100, block_time: Date.now() / 1000 }
+    };
+    vi.mocked(api.fetchTransactions).mockResolvedValue([mockTx] as any);
+
+    const account = useAccountStore();
+    await account.refreshTransactions(addr);
+
+    expect(account.transactions).toHaveLength(1);
+    expect(account.transactions[0]!.txid).toBe('tx1');
+
+    const cached = localStorage.getItem('peppool_transactions');
+    expect(cached).not.toBeNull();
+    expect(JSON.parse(cached!)[0].txid).toBe('tx1');
+  });
+
+  it('should restore transactions from cache', () => {
+    const mockTx = {
+      txid: 'cached-tx',
+      version: 1,
+      locktime: 0,
+      vin: [],
+      vout: [{ value: 100000000, scriptpubkey_address: addr }],
+      size: 100,
+      weight: 400,
+      fee: 1000,
+      status: { confirmed: true, block_height: 100, block_time: Date.now() / 1000 }
+    };
+    localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
+
+    const account = useAccountStore();
+    account.loadCachedTransactions(addr);
+
+    expect(account.transactions).toHaveLength(1);
+    expect(account.transactions[0]!.txid).toBe('cached-tx');
+  });
+
+  it('should fetch more transactions and append uniquely', async () => {
+    const baseTx = {
+      version: 1,
+      locktime: 0,
+      vin: [],
+      vout: [{ value: 100000000, scriptpubkey_address: addr }],
+      size: 100,
+      weight: 400,
+      fee: 1000,
+      status: { confirmed: true, block_height: 100, block_time: Date.now() / 1000 }
+    };
+
+    const account = useAccountStore();
+    account.transactions = [new Transaction({ ...baseTx, txid: 'tx1' } as any, addr)];
+
+    const fullPage = Array(25)
+      .fill(null)
+      .map((_, i) => ({ ...baseTx, txid: `page-${i}` }));
+    vi.mocked(api.fetchTransactions).mockResolvedValue(fullPage as any);
+
+    const hasMore = await account.fetchMoreTransactions(addr);
+    expect(hasMore).toBe(true);
+    expect(account.canLoadMore).toBe(true);
+
+    vi.mocked(api.fetchTransactions).mockResolvedValue([]);
+    const hasNoMore = await account.fetchMoreTransactions(addr);
+    expect(hasNoMore).toBe(false);
+    expect(account.canLoadMore).toBe(false);
+  });
+
+  it('should fetch a single transaction', async () => {
+    const mockTx = {
+      txid: 'single-tx',
+      version: 1,
+      locktime: 0,
+      vin: [],
+      vout: [{ value: 100000000, scriptpubkey_address: addr }],
+      size: 100,
+      weight: 400,
+      fee: 1000,
+      status: { confirmed: true, block_height: 100, block_time: Date.now() / 1000 }
+    };
+    vi.mocked(api.fetchTransaction).mockResolvedValue(mockTx as any);
+
+    const account = useAccountStore();
+    const tx = await account.fetchTransaction('single-tx', addr);
+
+    expect(tx.txid).toBe('single-tx');
+    expect(tx).toBeInstanceOf(Transaction);
+  });
+
+  it('should reset all state', () => {
+    const account = useAccountStore();
+    account.balance = 5;
+    account.spendableBalance = 4;
+    account.transactions = [{ txid: 'x' } as any];
+    account.canLoadMore = false;
+
+    account.reset();
+
+    expect(account.balance).toBe(0);
+    expect(account.spendableBalance).toBe(0);
+    expect(account.transactions).toHaveLength(0);
+    expect(account.canLoadMore).toBe(true);
+  });
+});

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -37,7 +37,7 @@ describe('Account Store', () => {
     expect(account.balance).toBe(0);
     expect(account.spendableBalance).toBe(0);
     expect(account.transactions).toHaveLength(0);
-    expect(account.canLoadMore).toBe(true);
+    expect(account.canLoadMoreTransactions).toBe(false);
   });
 
   it('should restore cached balance from localStorage', () => {
@@ -180,12 +180,12 @@ describe('Account Store', () => {
 
     const hasMore = await account.fetchMoreTransactions(addr);
     expect(hasMore).toBe(true);
-    expect(account.canLoadMore).toBe(true);
+    expect(account.canLoadMoreTransactions).toBe(true);
 
     vi.mocked(api.fetchTransactions).mockResolvedValue([]);
     const hasNoMore = await account.fetchMoreTransactions(addr);
     expect(hasNoMore).toBe(false);
-    expect(account.canLoadMore).toBe(false);
+    expect(account.canLoadMoreTransactions).toBe(false);
   });
 
   it('should fetch a single transaction', async () => {
@@ -214,13 +214,13 @@ describe('Account Store', () => {
     account.balance = 5;
     account.spendableBalance = 4;
     account.transactions = [{ txid: 'x' } as any];
-    account.canLoadMore = false;
+    account.canLoadMoreTransactions = true;
 
     account.reset();
 
     expect(account.balance).toBe(0);
     expect(account.spendableBalance).toBe(0);
     expect(account.transactions).toHaveLength(0);
-    expect(account.canLoadMore).toBe(true);
+    expect(account.canLoadMoreTransactions).toBe(false);
   });
 });

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -41,8 +41,9 @@ describe('Account Store', () => {
   });
 
   it('should restore cached balance from localStorage', () => {
-    localStorage.setItem('peppool_balance', '42');
+    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 42 }));
     const account = useAccountStore();
+    account.loadCachedData(addr);
     expect(account.balance).toBe(42);
   });
 
@@ -53,7 +54,8 @@ describe('Account Store', () => {
     await account.sync(addr, true);
 
     expect(account.balance).toBe(5);
-    expect(localStorage.getItem('peppool_balance')).toBe('5');
+    const balanceCache = JSON.parse(localStorage.getItem('peppool_balance')!);
+    expect(balanceCache[addr]).toBe(5);
   });
 
   it('should skip sync when tip height unchanged', async () => {
@@ -152,7 +154,7 @@ describe('Account Store', () => {
     localStorage.setItem('peppool_transactions', JSON.stringify({ [addr]: [mockTx] }));
 
     const account = useAccountStore();
-    account.loadCachedTransactions(addr);
+    account.loadCachedData(addr);
 
     expect(account.transactions).toHaveLength(1);
     expect(account.transactions[0]!.txid).toBe('cached-tx');

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -1,0 +1,123 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import {
+  fetchAddressInfo,
+  fetchTransactions,
+  fetchTransaction as apiFetchTransaction,
+  fetchTipHeight,
+  fetchUtxos,
+  filterSpendableUtxos
+} from '@/utils/api';
+import { Transaction } from '@/models/Transaction';
+import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
+import { useInscriptionStore } from './inscriptions';
+
+export const useAccountStore = defineStore('account', () => {
+  const inscriptionStore = useInscriptionStore();
+
+  // ── State ──
+  const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
+  const spendableBalance = ref<number>(0);
+  const transactions = ref<Transaction[]>([]);
+  const canLoadMore = ref(true);
+  let lastTipHeight = 0;
+
+  // ── Init: restore cached transactions ──
+  function loadCachedTransactions(address: string) {
+    try {
+      const cachedTxs = localStorage.getItem('peppool_transactions');
+      if (cachedTxs) {
+        transactions.value = JSON.parse(cachedTxs).map((raw: any) => new Transaction(raw, address));
+      }
+    } catch {
+      /* ignore corrupt cache */
+    }
+  }
+
+  // ── Actions ──
+  async function refreshTransactions(address: string) {
+    try {
+      const rawTxs = await fetchTransactions(address);
+      transactions.value = rawTxs.map((raw) => new Transaction(raw, address));
+      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
+      localStorage.setItem('peppool_transactions', JSON.stringify(rawTxs.slice(0, 20)));
+    } catch (e) {
+      console.error('Failed to fetch transactions', e);
+    }
+  }
+
+  async function fetchMoreTransactions(address: string) {
+    if (transactions.value.length === 0) return false;
+    const lastTx = transactions.value[transactions.value.length - 1];
+    if (!lastTx) return false;
+    try {
+      const rawTxs = await fetchTransactions(address, lastTx.txid);
+      const newTxs = rawTxs.map((raw) => new Transaction(raw, address));
+      const existingIds = new Set(transactions.value.map((t) => t.txid));
+      const uniqueNewTxs = newTxs.filter((t) => !existingIds.has(t.txid));
+      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
+      transactions.value = [...transactions.value, ...uniqueNewTxs];
+      return uniqueNewTxs.length > 0;
+    } catch (e) {
+      console.error('Failed to fetch more transactions', e);
+      return false;
+    }
+  }
+
+  async function fetchTransaction(txid: string, address: string): Promise<Transaction> {
+    const rawTx = await apiFetchTransaction(txid);
+    return new Transaction(rawTx, address);
+  }
+
+  async function sync(address: string, force = false) {
+    try {
+      const tipHeight = await fetchTipHeight();
+      if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
+      lastTipHeight = tipHeight;
+
+      const totalRibbits = await fetchAddressInfo(address);
+      balance.value = totalRibbits / RIBBITS_PER_PEP;
+      localStorage.setItem('peppool_balance', balance.value.toString());
+
+      await refreshTransactions(address);
+      await inscriptionStore.sync(address, tipHeight);
+
+      try {
+        const [utxos, inscriptionSet] = await Promise.all([
+          fetchUtxos(address),
+          inscriptionStore.getOutputsSet(address)
+        ]);
+        const spendableRibbits = filterSpendableUtxos(utxos, inscriptionSet).reduce(
+          (sum, u) => sum + u.value,
+          0
+        );
+        spendableBalance.value = spendableRibbits / RIBBITS_PER_PEP;
+      } catch {
+        spendableBalance.value = balance.value;
+      }
+    } catch (e) {
+      console.error('Failed to sync account', e);
+    }
+  }
+
+  function reset() {
+    balance.value = 0;
+    spendableBalance.value = 0;
+    transactions.value = [];
+    canLoadMore.value = true;
+    lastTipHeight = 0;
+  }
+
+  return {
+    balance,
+    spendableBalance,
+    transactions,
+    canLoadMore,
+    loadCachedTransactions,
+    refreshTransactions,
+    fetchMoreTransactions,
+    fetchTransaction,
+    sync,
+    reset
+  };
+});

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -19,7 +19,7 @@ export const useAccountStore = defineStore('account', () => {
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
   const spendableBalance = ref<number>(0);
   const transactions = ref<Transaction[]>([]);
-  const canLoadMore = ref(true);
+  const canLoadMoreTransactions = ref(false);
   let lastTipHeight = 0;
 
   // ── Init: restore cached transactions ──
@@ -39,7 +39,7 @@ export const useAccountStore = defineStore('account', () => {
     try {
       const rawTxs = await fetchTransactions(address);
       transactions.value = rawTxs.map((raw) => new Transaction(raw, address));
-      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
+      canLoadMoreTransactions.value = rawTxs.length >= TXS_PER_PAGE;
       localStorage.setItem('peppool_transactions', JSON.stringify(rawTxs.slice(0, 20)));
     } catch (e) {
       console.error('Failed to fetch transactions', e);
@@ -55,7 +55,7 @@ export const useAccountStore = defineStore('account', () => {
       const newTxs = rawTxs.map((raw) => new Transaction(raw, address));
       const existingIds = new Set(transactions.value.map((t) => t.txid));
       const uniqueNewTxs = newTxs.filter((t) => !existingIds.has(t.txid));
-      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
+      canLoadMoreTransactions.value = rawTxs.length >= TXS_PER_PAGE;
       transactions.value = [...transactions.value, ...uniqueNewTxs];
       return uniqueNewTxs.length > 0;
     } catch (e) {
@@ -104,7 +104,7 @@ export const useAccountStore = defineStore('account', () => {
     balance.value = 0;
     spendableBalance.value = 0;
     transactions.value = [];
-    canLoadMore.value = true;
+    canLoadMoreTransactions.value = false;
     lastTipHeight = 0;
   }
 
@@ -112,7 +112,7 @@ export const useAccountStore = defineStore('account', () => {
     balance,
     spendableBalance,
     transactions,
-    canLoadMore,
+    canLoadMoreTransactions,
     loadCachedTransactions,
     refreshTransactions,
     fetchMoreTransactions,

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -16,27 +16,31 @@ export const useAccountStore = defineStore('account', () => {
   const inscriptionStore = useInscriptionStore();
 
   // ── State ──
-  const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
+  const balance = ref<number>(0);
   const spendableBalance = ref<number>(0);
   const transactions = ref<Transaction[]>([]);
   const canLoadMoreTransactions = ref(false);
   let lastTipHeight = 0;
 
-  // ── Transaction cache (keyed by address) ──
-  function getTransactionCache(): Record<string, unknown[]> {
+  // ── Cache (keyed by address) ──
+  function getCache<T>(key: string): Record<string, T> {
     try {
-      return JSON.parse(localStorage.getItem('peppool_transactions') || '{}');
+      return JSON.parse(localStorage.getItem(key) || '{}');
     } catch {
       return {};
     }
   }
 
-  function loadCachedTransactions(address: string) {
+  function loadCachedData(address: string) {
     try {
-      const cache = getTransactionCache();
-      const cached = cache[address];
-      if (cached) {
-        transactions.value = cached.map((raw: any) => new Transaction(raw, address));
+      const balanceCache = getCache<number>('peppool_balance');
+      if (balanceCache[address] != null) {
+        balance.value = balanceCache[address];
+      }
+
+      const txCache = getCache<unknown[]>('peppool_transactions');
+      if (txCache[address]) {
+        transactions.value = txCache[address].map((raw: any) => new Transaction(raw, address));
       }
     } catch {
       /* ignore corrupt cache */
@@ -49,9 +53,9 @@ export const useAccountStore = defineStore('account', () => {
       const rawTxs = await fetchTransactions(address);
       transactions.value = rawTxs.map((raw) => new Transaction(raw, address));
       canLoadMoreTransactions.value = rawTxs.length >= TXS_PER_PAGE;
-      const cache = getTransactionCache();
-      cache[address] = rawTxs.slice(0, 20);
-      localStorage.setItem('peppool_transactions', JSON.stringify(cache));
+      const txCache = getCache<unknown[]>('peppool_transactions');
+      txCache[address] = rawTxs.slice(0, 20);
+      localStorage.setItem('peppool_transactions', JSON.stringify(txCache));
     } catch (e) {
       console.error('Failed to fetch transactions', e);
     }
@@ -88,7 +92,9 @@ export const useAccountStore = defineStore('account', () => {
 
       const totalRibbits = await fetchAddressInfo(address);
       balance.value = totalRibbits / RIBBITS_PER_PEP;
-      localStorage.setItem('peppool_balance', balance.value.toString());
+      const balanceCache = getCache<number>('peppool_balance');
+      balanceCache[address] = balance.value;
+      localStorage.setItem('peppool_balance', JSON.stringify(balanceCache));
 
       await refreshTransactions(address);
       await inscriptionStore.sync(address, tipHeight);
@@ -124,7 +130,7 @@ export const useAccountStore = defineStore('account', () => {
     spendableBalance,
     transactions,
     canLoadMoreTransactions,
-    loadCachedTransactions,
+    loadCachedData,
     refreshTransactions,
     fetchMoreTransactions,
     fetchTransaction,

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -22,12 +22,21 @@ export const useAccountStore = defineStore('account', () => {
   const canLoadMoreTransactions = ref(false);
   let lastTipHeight = 0;
 
-  // ── Init: restore cached transactions ──
+  // ── Transaction cache (keyed by address) ──
+  function getTransactionCache(): Record<string, unknown[]> {
+    try {
+      return JSON.parse(localStorage.getItem('peppool_transactions') || '{}');
+    } catch {
+      return {};
+    }
+  }
+
   function loadCachedTransactions(address: string) {
     try {
-      const cachedTxs = localStorage.getItem('peppool_transactions');
-      if (cachedTxs) {
-        transactions.value = JSON.parse(cachedTxs).map((raw: any) => new Transaction(raw, address));
+      const cache = getTransactionCache();
+      const cached = cache[address];
+      if (cached) {
+        transactions.value = cached.map((raw: any) => new Transaction(raw, address));
       }
     } catch {
       /* ignore corrupt cache */
@@ -40,7 +49,9 @@ export const useAccountStore = defineStore('account', () => {
       const rawTxs = await fetchTransactions(address);
       transactions.value = rawTxs.map((raw) => new Transaction(raw, address));
       canLoadMoreTransactions.value = rawTxs.length >= TXS_PER_PAGE;
-      localStorage.setItem('peppool_transactions', JSON.stringify(rawTxs.slice(0, 20)));
+      const cache = getTransactionCache();
+      cache[address] = rawTxs.slice(0, 20);
+      localStorage.setItem('peppool_transactions', JSON.stringify(cache));
     } catch (e) {
       console.error('Failed to fetch transactions', e);
     }

--- a/src/stores/inscriptions.ts
+++ b/src/stores/inscriptions.ts
@@ -11,22 +11,23 @@ interface PersistedData {
   lastSyncedHeight: number;
 }
 
-function storageKey(address: string): string {
-  return `peppool_inscriptions_${address}`;
+const STORAGE_KEY = 'peppool_inscriptions';
+function getCache(): Record<string, PersistedData> {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+  } catch {
+    return {};
+  }
 }
 
 function loadFromStorage(address: string): PersistedData {
-  try {
-    const raw = localStorage.getItem(storageKey(address));
-    if (raw) return JSON.parse(raw);
-  } catch {
-    /* ignore corrupt data */
-  }
-  return { inscriptions: {}, outputs: [], lastSyncedHeight: 0 };
+  return getCache()[address] || { inscriptions: {}, outputs: [], lastSyncedHeight: 0 };
 }
 
 function saveToStorage(address: string, data: PersistedData): void {
-  localStorage.setItem(storageKey(address), JSON.stringify(data));
+  const cache = getCache();
+  cache[address] = data;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
 }
 
 export const useInscriptionStore = defineStore('inscriptions', () => {

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useWalletStore } from './wallet';
+import { useAccountStore } from './account';
 import { useLockoutStore } from './lockout';
 
 import { Transaction } from '@/models/Transaction';
@@ -39,9 +40,10 @@ describe('Wallet Store', () => {
 
   it('should initialize as not created', () => {
     const store = useWalletStore();
+    const account = useAccountStore();
     expect(store.isCreated).toBe(false);
     expect(store.isUnlocked).toBe(false);
-    expect(store.canLoadMore).toBe(true);
+    expect(account.canLoadMore).toBe(true);
   });
 
   it('should create a wallet and persist it', async () => {
@@ -229,8 +231,9 @@ describe('Wallet Store', () => {
     await store.switchAccount(1);
     expect(store.address).toBe('addr2');
     expect(localStorage.getItem('peppool_active_account')).toBe('1');
-    expect(store.balance).toBe(1); // Should be refreshed on switch
-    expect(store.transactions).toHaveLength(0); // Should be cleared on switch
+    const account = useAccountStore();
+    expect(account.balance).toBe(1); // Should be refreshed on switch
+    expect(account.transactions).toHaveLength(0); // Should be cleared on switch
   });
 
   it('should add a new account correctly', async () => {
@@ -322,8 +325,9 @@ describe('Wallet Store', () => {
 
     await store.refreshBalance(true);
 
-    expect(store.balance).toBe(3); // Total balance
-    expect(store.spendableBalance).toBe(2.9999); // Excludes inscription UTXO (10000 ribbits)
+    const account = useAccountStore();
+    expect(account.balance).toBe(3); // Total balance
+    expect(account.spendableBalance).toBe(2.9999); // Excludes inscription UTXO (10000 ribbits)
   });
 
   it('should fall back to total balance when inscription fetch fails', async () => {
@@ -342,8 +346,9 @@ describe('Wallet Store', () => {
 
     await store.refreshBalance(true);
 
-    expect(store.balance).toBe(1);
-    expect(store.spendableBalance).toBe(1); // Falls back to total
+    const account = useAccountStore();
+    expect(account.balance).toBe(1);
+    expect(account.spendableBalance).toBe(1); // Falls back to total
   });
 
   it('should handle currency changes correctly', () => {
@@ -447,17 +452,10 @@ describe('Wallet Store', () => {
       const api = await import('@/utils/api');
       vi.mocked(api.fetchTransactions).mockResolvedValue([mockTx] as any);
 
-      const store = useWalletStore();
-      store.accounts = [
-        {
-          address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
-          path: "m/44'/3434'/0'/0/0",
-          label: 'Account 1'
-        }
-      ];
-      store.activeAccountIndex = 0;
+      const account = useAccountStore();
+      const addr = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
 
-      await store.refreshTransactions();
+      await account.refreshTransactions(addr);
 
       const cached = localStorage.getItem('peppool_transactions');
       expect(cached).not.toBeNull();
@@ -480,8 +478,9 @@ describe('Wallet Store', () => {
       );
 
       const store = useWalletStore();
-      expect(store.transactions).toHaveLength(1);
-      expect(store.transactions[0]!.txid).toBe(mockTx.txid);
+      const account = useAccountStore();
+      expect(account.transactions).toHaveLength(1);
+      expect(account.transactions[0]!.txid).toBe(mockTx.txid);
     });
 
     it('should clear cached transactions on lock', async () => {
@@ -502,14 +501,12 @@ describe('Wallet Store', () => {
 
     it('should fetch more transactions and append them uniquely', async () => {
       const api = await import('@/utils/api');
-      const store = useWalletStore();
+      const account = useAccountStore();
       const addr = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
-      store.accounts = [{ address: addr, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
-      store.activeAccountIndex = 0;
 
       // Setup initial transactions
       const tx1 = { ...mockTx, txid: 'tx1' };
-      store.transactions = [new Transaction(tx1, addr)];
+      account.transactions = [new Transaction(tx1, addr)];
 
       // Mock API to return a full page of transactions
       const fullPage = Array(25)
@@ -517,16 +514,16 @@ describe('Wallet Store', () => {
         .map((_, i) => ({ ...mockTx, txid: `page-${i}` }));
       vi.mocked(api.fetchTransactions).mockResolvedValue(fullPage as any);
 
-      const hasMore = await store.fetchMoreTransactions();
+      const hasMore = await account.fetchMoreTransactions(addr);
 
       expect(hasMore).toBe(true);
-      expect(store.canLoadMore).toBe(true);
+      expect(account.canLoadMore).toBe(true);
 
       // Mock API to return nothing (end of list)
       vi.mocked(api.fetchTransactions).mockResolvedValue([]);
-      const hasNoMore = await store.fetchMoreTransactions();
+      const hasNoMore = await account.fetchMoreTransactions(addr);
       expect(hasNoMore).toBe(false);
-      expect(store.canLoadMore).toBe(false);
+      expect(account.canLoadMore).toBe(false);
     });
   });
 

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -43,7 +43,7 @@ describe('Wallet Store', () => {
     const account = useAccountStore();
     expect(store.isCreated).toBe(false);
     expect(store.isUnlocked).toBe(false);
-    expect(account.canLoadMore).toBe(true);
+    expect(account.canLoadMoreTransactions).toBe(false);
   });
 
   it('should create a wallet and persist it', async () => {
@@ -517,13 +517,13 @@ describe('Wallet Store', () => {
       const hasMore = await account.fetchMoreTransactions(addr);
 
       expect(hasMore).toBe(true);
-      expect(account.canLoadMore).toBe(true);
+      expect(account.canLoadMoreTransactions).toBe(true);
 
       // Mock API to return nothing (end of list)
       vi.mocked(api.fetchTransactions).mockResolvedValue([]);
       const hasNoMore = await account.fetchMoreTransactions(addr);
       expect(hasNoMore).toBe(false);
-      expect(account.canLoadMore).toBe(false);
+      expect(account.canLoadMoreTransactions).toBe(false);
     });
   });
 

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -457,14 +457,14 @@ describe('Wallet Store', () => {
 
       await account.refreshTransactions(addr);
 
-      const cached = localStorage.getItem('peppool_transactions');
-      expect(cached).not.toBeNull();
-      expect(JSON.parse(cached!)).toHaveLength(1);
-      expect(JSON.parse(cached!)[0].txid).toBe(mockTx.txid);
+      const cached = JSON.parse(localStorage.getItem('peppool_transactions')!);
+      expect(cached[addr]).toHaveLength(1);
+      expect(cached[addr][0].txid).toBe(mockTx.txid);
     });
 
     it('should restore transactions from cache on initialization', () => {
-      localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
+      const addr = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
+      localStorage.setItem('peppool_transactions', JSON.stringify({ [addr]: [mockTx] }));
       localStorage.setItem('peppool_active_account', '0');
       localStorage.setItem(
         'peppool_accounts',
@@ -484,7 +484,7 @@ describe('Wallet Store', () => {
     });
 
     it('should clear cached transactions on lock', async () => {
-      localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
+      localStorage.setItem('peppool_transactions', JSON.stringify({ addr1: [mockTx] }));
       const store = useWalletStore();
 
       await store.lock();
@@ -492,7 +492,7 @@ describe('Wallet Store', () => {
     });
 
     it('should clear cached transactions on resetWallet', async () => {
-      localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
+      localStorage.setItem('peppool_transactions', JSON.stringify({ addr1: [mockTx] }));
       const store = useWalletStore();
 
       await store.resetWallet();

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -82,7 +82,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   // Initialize cached transactions
   if (address.value) {
-    accountStore.loadCachedTransactions(address.value);
+    accountStore.loadCachedData(address.value);
   }
 
   // ── Actions ──

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -8,22 +8,12 @@ import {
   parseDerivationPath
 } from '@/utils/crypto';
 import { encrypt, decrypt, deriveKeyBytes, decryptWithKey, importKey } from '@/utils/encryption';
-import {
-  fetchAddressInfo,
-  hasAddressActivity,
-  fetchTransactions,
-  fetchTransaction as apiFetchTransaction,
-  fetchPepPrice,
-  fetchTipHeight,
-  fetchUtxos,
-  filterSpendableUtxos
-} from '@/utils/api';
+import { hasAddressActivity, fetchPepPrice } from '@/utils/api';
 import { ensureAuth, clearAuth } from '@/utils/auth';
-import { Transaction } from '@/models/Transaction';
-import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
 import { EXPLORERS, type ExplorerId, pepeExplorer } from '@/utils/explorer';
 import { useLockoutStore } from './lockout';
 import { useInscriptionStore } from './inscriptions';
+import { useAccountStore } from './account';
 
 export interface Account {
   address: string;
@@ -55,6 +45,7 @@ async function clearAutoLockAlarm() {
 export const useWalletStore = defineStore('wallet', () => {
   const lockout = useLockoutStore();
   const inscriptionStore = useInscriptionStore();
+  const accountStore = useAccountStore();
 
   // ── State ──
   const accounts = ref<Account[]>(JSON.parse(localStorage.getItem('peppool_accounts') || '[]'));
@@ -66,8 +57,6 @@ export const useWalletStore = defineStore('wallet', () => {
   const hasSessionKey = ref(false);
   const isUnlocked = ref(false);
   const lockDuration = ref<number>(parseInt(localStorage.getItem('peppool_lock_duration') || '15'));
-  const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
-  const spendableBalance = ref<number>(0);
   const prices = ref({
     USD: Number(localStorage.getItem('peppool_price_usd')) || 0,
     EUR: Number(localStorage.getItem('peppool_price_eur')) || 0
@@ -79,29 +68,21 @@ export const useWalletStore = defineStore('wallet', () => {
     (localStorage.getItem('peppool_explorer') as ExplorerId) || 'peppool'
   );
 
-  const transactions = ref<Transaction[]>([]);
-  const canLoadMore = ref(true);
   let lockTimer: ReturnType<typeof setTimeout> | null = null;
-  let lastTipHeight = 0;
 
   // ── Computed ──
   const isCreated = computed(() => !!encryptedMnemonic.value);
   const isMnemonicLoaded = computed(() => hasSessionKey.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
-  const balanceFiat = computed(() => balance.value * (prices.value[selectedCurrency.value] || 0));
+  const balanceFiat = computed(
+    () => accountStore.balance * (prices.value[selectedCurrency.value] || 0)
+  );
   const currencySymbol = computed(() => (selectedCurrency.value === 'USD' ? '$' : '€'));
 
-  // Initialize transactions from cache
-  try {
-    const cachedTxs = localStorage.getItem('peppool_transactions');
-    if (cachedTxs) {
-      transactions.value = JSON.parse(cachedTxs).map(
-        (raw: any) => new Transaction(raw, address.value || '')
-      );
-    }
-  } catch {
-    /* ignore */
+  // Initialize cached transactions
+  if (address.value) {
+    accountStore.loadCachedTransactions(address.value);
   }
 
   // ── Actions ──
@@ -213,41 +194,6 @@ export const useWalletStore = defineStore('wallet', () => {
     }
   }
 
-  async function refreshTransactions() {
-    if (!address.value) return;
-    try {
-      const rawTxs = await fetchTransactions(address.value);
-      transactions.value = rawTxs.map((raw) => new Transaction(raw, address.value!));
-      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
-      localStorage.setItem('peppool_transactions', JSON.stringify(rawTxs.slice(0, 20)));
-    } catch (e) {
-      console.error('Failed to fetch transactions', e);
-    }
-  }
-
-  async function fetchMoreTransactions() {
-    if (!address.value || transactions.value.length === 0) return false;
-    const lastTx = transactions.value[transactions.value.length - 1];
-    if (!lastTx) return false;
-    try {
-      const rawTxs = await fetchTransactions(address.value, lastTx.txid);
-      const newTxs = rawTxs.map((raw) => new Transaction(raw, address.value!));
-      const existingIds = new Set(transactions.value.map((t) => t.txid));
-      const uniqueNewTxs = newTxs.filter((t) => !existingIds.has(t.txid));
-      canLoadMore.value = rawTxs.length >= TXS_PER_PAGE;
-      transactions.value = [...transactions.value, ...uniqueNewTxs];
-      return uniqueNewTxs.length > 0;
-    } catch (e) {
-      console.error('Failed to fetch more transactions', e);
-      return false;
-    }
-  }
-
-  async function fetchTransaction(txid: string): Promise<Transaction> {
-    const rawTx = await apiFetchTransaction(txid);
-    return new Transaction(rawTx, address.value || '');
-  }
-
   async function refreshBalance(force = false) {
     if (!address.value) return;
     try {
@@ -257,30 +203,7 @@ export const useWalletStore = defineStore('wallet', () => {
       localStorage.setItem('peppool_price_usd', currentPrices.USD.toString());
       localStorage.setItem('peppool_price_eur', currentPrices.EUR.toString());
 
-      const tipHeight = await fetchTipHeight();
-      if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
-      lastTipHeight = tipHeight;
-
-      const totalRibbits = await fetchAddressInfo(address.value);
-      balance.value = totalRibbits / RIBBITS_PER_PEP;
-      localStorage.setItem('peppool_balance', balance.value.toString());
-
-      await refreshTransactions();
-      await inscriptionStore.sync(address.value, tipHeight);
-
-      try {
-        const [utxos, inscriptionSet] = await Promise.all([
-          fetchUtxos(address.value),
-          inscriptionStore.getOutputsSet(address.value)
-        ]);
-        const spendableRibbits = filterSpendableUtxos(utxos, inscriptionSet).reduce(
-          (sum, u) => sum + u.value,
-          0
-        );
-        spendableBalance.value = spendableRibbits / RIBBITS_PER_PEP;
-      } catch {
-        spendableBalance.value = balance.value;
-      }
+      await accountStore.sync(address.value, force);
       await resetLockTimer();
     } catch (e) {
       console.error('Failed to refresh balance', e);
@@ -431,10 +354,8 @@ export const useWalletStore = defineStore('wallet', () => {
     sessionKey = null;
     hasSessionKey.value = false;
     isUnlocked.value = false;
-    balance.value = 0;
-    spendableBalance.value = 0;
     prices.value = { USD: 0, EUR: 0 };
-    transactions.value = [];
+    accountStore.reset();
     clearAuth();
 
     // Selective wipe of peppool-prefixed keys
@@ -462,9 +383,7 @@ export const useWalletStore = defineStore('wallet', () => {
     activeAccountIndex.value = index;
     localStorage.setItem('peppool_active_account', index.toString());
     await syncToChromeStorage();
-    balance.value = 0;
-    spendableBalance.value = 0;
-    transactions.value = [];
+    accountStore.reset();
     inscriptionStore.load(accounts.value[index].address);
     await refreshBalance(true);
   }
@@ -520,8 +439,6 @@ export const useWalletStore = defineStore('wallet', () => {
     isCreated,
     isMnemonicLoaded,
     lockout,
-    balance,
-    spendableBalance,
     balanceFiat,
     selectedCurrency,
     selectedExplorer,
@@ -529,8 +446,6 @@ export const useWalletStore = defineStore('wallet', () => {
     currencySymbol,
     lockDuration,
     prices,
-    transactions,
-    canLoadMore,
     setCurrency,
     setExplorer,
     openExplorerTx,
@@ -540,9 +455,6 @@ export const useWalletStore = defineStore('wallet', () => {
     createWallet,
     importWallet,
     refreshBalance,
-    refreshTransactions,
-    fetchTransaction,
-    fetchMoreTransactions,
     resetLockTimer: debouncedResetLockTimer,
     startPolling,
     stopPolling,

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -43,7 +43,7 @@ describe('Wallet Views Navigation', () => {
     mockAccount = {
       balance: 0,
       transactions: [],
-      canLoadMore: true,
+      canLoadMoreTransactions: false,
       fetchMoreTransactions: vi.fn()
     };
     mockWallet = {
@@ -122,6 +122,7 @@ describe('Wallet Views Navigation', () => {
   it('Dashboard: should show load more button when transactions exist', async () => {
     const tx = new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
     mockAccount.transactions = [tx];
+    mockAccount.canLoadMoreTransactions = true;
     mockAccount.fetchMoreTransactions = vi.fn().mockResolvedValue(true);
 
     const wrapper = mount(DashboardView, { global });

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -36,18 +36,23 @@ const mockRawTx = {
 
 describe('Wallet Views Navigation', () => {
   let mockWallet: any;
+  let mockAccount: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockAccount = {
+      balance: 0,
+      transactions: [],
+      canLoadMore: true,
+      fetchMoreTransactions: vi.fn()
+    };
     mockWallet = {
       isUnlocked: true,
-      balance: 0,
+      address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       balanceFiat: 0,
       currencySymbol: '$',
       selectedCurrency: 'USD',
       prices: { USD: 0, EUR: 0 },
-      transactions: [],
-      canLoadMore: true,
       refreshBalance: vi.fn(),
       startPolling: vi.fn(),
       stopPolling: vi.fn(),
@@ -56,6 +61,7 @@ describe('Wallet Views Navigation', () => {
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      account: mockAccount,
       route: { path: '/dashboard', params: { txid: 'test-tx' } } as any
     });
   });
@@ -95,7 +101,7 @@ describe('Wallet Views Navigation', () => {
 
   it('Dashboard: should render transaction items and show header', async () => {
     const tx = new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
-    mockWallet.transactions = [tx];
+    mockAccount.transactions = [tx];
 
     const wrapper = mount(DashboardView, { global });
 
@@ -105,7 +111,7 @@ describe('Wallet Views Navigation', () => {
   });
 
   it('Dashboard: should hide Recent Activity header when no transactions', async () => {
-    mockWallet.transactions = [];
+    mockAccount.transactions = [];
 
     const wrapper = mount(DashboardView, { global });
 
@@ -115,8 +121,8 @@ describe('Wallet Views Navigation', () => {
 
   it('Dashboard: should show load more button when transactions exist', async () => {
     const tx = new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
-    mockWallet.transactions = [tx];
-    mockWallet.fetchMoreTransactions = vi.fn().mockResolvedValue(true);
+    mockAccount.transactions = [tx];
+    mockAccount.fetchMoreTransactions = vi.fn().mockResolvedValue(true);
 
     const wrapper = mount(DashboardView, { global });
 
@@ -126,11 +132,11 @@ describe('Wallet Views Navigation', () => {
     expect(loadMore?.exists()).toBe(true);
 
     await loadMore?.trigger('click');
-    expect(mockWallet.fetchMoreTransactions).toHaveBeenCalled();
+    expect(mockAccount.fetchMoreTransactions).toHaveBeenCalled();
   });
 
   it('Dashboard: should adjust font size for large balances', async () => {
-    mockWallet.balance = 1000000000000000; // Force very long string
+    mockAccount.balance = 1000000000000000; // Force very long string
     const wrapper = mount(DashboardView, { global });
 
     const balanceSpan = wrapper.find('span.text-offwhite');

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -4,12 +4,12 @@ import { formatFiat, formatAmount } from '@/utils/constants';
 import { useApp } from '@/composables/useApp';
 import { onMounted, computed, ref } from 'vue';
 
-const { router, wallet: walletStore } = useApp();
+const { router, wallet: walletStore, account } = useApp();
 
 const isLoadingMore = ref(false);
 
 const balanceFontSize = computed(() => {
-  const len = formatAmount(walletStore.balance).length;
+  const len = formatAmount(account.balance).length;
 
   switch (true) {
     case len > 16:
@@ -37,7 +37,7 @@ async function handleLoadMore() {
   if (isLoadingMore.value) return;
   isLoadingMore.value = true;
   try {
-    await walletStore.fetchMoreTransactions();
+    await account.fetchMoreTransactions(walletStore.address!);
   } catch (e) {
     // Error handled in store
   } finally {
@@ -65,7 +65,7 @@ async function handleLoadMore() {
       <p class="text-sm font-bold tracking-wider text-slate-400 uppercase">Total Balance</p>
       <div class="flex items-baseline justify-center space-x-2">
         <span class="text-offwhite font-bold transition-all duration-300" :class="balanceFontSize">
-          {{ formatAmount(walletStore.balance) }}
+          {{ formatAmount(account.balance) }}
         </span>
         <span class="text-pep-green-light font-bold">PEP</span>
       </div>
@@ -83,7 +83,7 @@ async function handleLoadMore() {
 
     <!-- Recent Activity -->
     <div
-      v-if="walletStore.transactions.length > 0"
+      v-if="account.transactions.length > 0"
       class="flex min-h-0 flex-1 flex-col space-y-3 overflow-hidden"
     >
       <h3 class="ml-1 text-[10px] font-bold tracking-widest text-slate-500 uppercase">
@@ -93,14 +93,14 @@ async function handleLoadMore() {
       <div class="flex-1 overflow-y-auto pr-1 pb-4">
         <div class="space-y-2">
           <PepTransactionItem
-            v-for="tx in walletStore.transactions"
+            v-for="tx in account.transactions"
             :key="tx.txid"
             :tx="tx"
             @click="openDetail(tx.txid)"
           />
         </div>
 
-        <div v-if="walletStore.canLoadMore" class="mt-4 flex justify-center">
+        <div v-if="account.canLoadMore" class="mt-4 flex justify-center">
           <button
             type="button"
             @click="handleLoadMore"

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -100,7 +100,7 @@ async function handleLoadMore() {
           />
         </div>
 
-        <div v-if="account.canLoadMore" class="mt-4 flex justify-center">
+        <div v-if="account.canLoadMoreTransactions" class="mt-4 flex justify-center">
           <button
             type="button"
             @click="handleLoadMore"

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -78,6 +78,7 @@ const stubs = {
 
 describe('SendView', () => {
   let mockWallet: any;
+  let mockAccount: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -88,13 +89,15 @@ describe('SendView', () => {
     mockSendTransaction.isLoadingFees.value = false;
     mockSendTransaction.isInsufficientFunds.value = false;
 
+    mockAccount = {
+      spendableBalance: 7
+    };
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       isMnemonicLoaded: true,
       selectedCurrency: 'USD',
       currencySymbol: '$',
       balance: 7,
-      spendableBalance: 7,
       prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       openExplorerTx: vi.fn(),
@@ -103,6 +106,7 @@ describe('SendView', () => {
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      account: mockAccount,
       route: { path: '/send' } as any
     });
   });
@@ -173,7 +177,7 @@ describe('SendView', () => {
   });
 
   it('should display spendable balance on the send form', async () => {
-    mockWallet.spendableBalance = 5;
+    mockAccount.spendableBalance = 5;
 
     const wrapper = mount(SendView, { global });
     // @ts-ignore

--- a/src/views/wallet/TransactionDetailView.spec.ts
+++ b/src/views/wallet/TransactionDetailView.spec.ts
@@ -54,28 +54,32 @@ const mockRawTx = {
 
 describe('TransactionDetailView', () => {
   let mockWallet: any;
+  let mockAccount: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.fetchTransaction).mockResolvedValue(mockRawTx as any);
+    mockAccount = reactive({
+      transactions: [],
+      fetchTransaction: vi.fn()
+    });
     mockWallet = reactive({
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       openExplorerTx: vi.fn(),
       refreshBalance: vi.fn(),
-      transactions: [],
       startPolling: vi.fn(),
-      stopPolling: vi.fn(),
-      fetchTransaction: vi.fn()
+      stopPolling: vi.fn()
     });
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      account: mockAccount,
       route: { params: { txid: mockRawTx.txid } } as any
     });
   });
 
   it('should show Network Fee only for outgoing transactions', async () => {
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
 
@@ -90,7 +94,7 @@ describe('TransactionDetailView', () => {
 
     // 2. Incoming
     const incomingRaw = { ...mockRawTx, vin: [] };
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(incomingRaw, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
     // @ts-ignore
@@ -106,7 +110,7 @@ describe('TransactionDetailView', () => {
       vin: [],
       vout: [{ value: 100000000, scriptpubkey_address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU' }]
     };
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(incomingRaw, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
 
@@ -123,7 +127,7 @@ describe('TransactionDetailView', () => {
 
   it('should show unconfirmed status correctly', async () => {
     const unconfirmedRaw = { ...mockRawTx, status: { confirmed: false } };
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(unconfirmedRaw, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
 
@@ -137,7 +141,7 @@ describe('TransactionDetailView', () => {
   });
 
   it('should call openExplorer with correct txid', async () => {
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
 
@@ -154,7 +158,7 @@ describe('TransactionDetailView', () => {
 
   it('should update details when store transaction list changes', async () => {
     const unconfirmedRaw = { ...mockRawTx, status: { confirmed: false } };
-    mockWallet.fetchTransaction.mockResolvedValue(
+    mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(unconfirmedRaw, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
 
@@ -165,7 +169,7 @@ describe('TransactionDetailView', () => {
     expect(wrapper.text()).toContain('In mempool');
 
     // Simulate store updating the transaction list (e.g. after a poll found a new block)
-    mockWallet.transactions = [new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')];
+    mockAccount.transactions = [new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')];
     await wrapper.vm.$nextTick();
 
     expect(wrapper.text()).toContain('Confirmed');

--- a/src/views/wallet/TransactionDetailView.vue
+++ b/src/views/wallet/TransactionDetailView.vue
@@ -3,10 +3,10 @@ import { ref, onMounted, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
 import { Transaction } from '@/models/Transaction';
 
-const { router, route, wallet: walletStore } = useApp();
+const { router, route, wallet: walletStore, account } = useApp();
 
 const txid = route.params.txid as string;
-const txFromList = computed(() => walletStore.transactions.find((t) => t.txid === txid));
+const txFromList = computed(() => account.transactions.find((t) => t.txid === txid));
 const txFetched = ref<Transaction | null>(null);
 
 const txModel = computed(() => txFromList.value || txFetched.value);
@@ -17,7 +17,7 @@ const error = ref('');
 async function loadDetails() {
   isLoading.value = true;
   try {
-    const transaction = await walletStore.fetchTransaction(txid);
+    const transaction = await account.fetchTransaction(txid, walletStore.address || '');
     txFetched.value = transaction;
   } catch (e: any) {
     error.value = e.message || 'Failed to load transaction';

--- a/src/views/wallet/TransactionDetailView.vue
+++ b/src/views/wallet/TransactionDetailView.vue
@@ -6,7 +6,7 @@ import { Transaction } from '@/models/Transaction';
 const { router, route, wallet: walletStore, account } = useApp();
 
 const txid = route.params.txid as string;
-const txFromList = computed(() => account.transactions.find((t) => t.txid === txid));
+const txFromList = computed(() => account.transactions.find((t: Transaction) => t.txid === txid));
 const txFetched = ref<Transaction | null>(null);
 
 const txModel = computed(() => txFromList.value || txFetched.value);

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -10,7 +10,7 @@ import SendStepForm from './SendStepForm.vue';
 import SendStepReview from './SendStepReview.vue';
 import SendStepSuccess from './SendStepSuccess.vue';
 
-const { router, wallet: walletStore } = useApp();
+const { router, wallet: walletStore, account } = useApp();
 const {
   tx,
   txid,
@@ -46,7 +46,7 @@ watch(txid, (newTxid) => {
 if (form.step === 2) form.step = 1;
 
 const displayBalance = computed(() => {
-  const bal = walletStore.spendableBalance;
+  const bal = account.spendableBalance;
   if (form.isFiatMode) {
     const price = walletStore.prices[walletStore.selectedCurrency];
     return `${walletStore.currencySymbol}${formatFiat(bal * price)} ${walletStore.selectedCurrency}`;


### PR DESCRIPTION
## Summary
- Extract account-level state (`balance`, `spendableBalance`, `transactions`, `canLoadMore`) and actions (`sync`, `refreshTransactions`, `fetchMoreTransactions`, `fetchTransaction`, `reset`) into a new `useAccountStore`
- Wallet store becomes a thin orchestrator: auth, prices, session/lock management, account list — delegates account data refresh to `accountStore.sync()`
- All consumers (`DashboardView`, `TransactionDetailView`, `SendView`, `useSendTransaction`) migrated to read account data directly from `useAccountStore` via `useApp().account`

## Test plan
- [x] All 478 tests pass (466 existing + 12 new account store tests)
- [x] `vue-tsc` type check passes
- [x] Vite build succeeds
- [x] Manual: verify dashboard shows balance and transactions
- [x] Manual: verify send flow reads spendable balance correctly
- [x] Manual: verify transaction detail view loads
- [x] Manual: verify account switching resets account data