### PR TITLE
Wipe derived cache on app version change

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { router } from '@/router';
+import { wipeCacheOnVersionChange } from '@/utils/cache';
 import '@tailwindplus/elements';
 import './style.css';
 import App from './App.vue';
+
+// Wipe stale cache before Pinia stores read from localStorage
+wipeCacheOnVersionChange();
 import PepButton from '@/components/ui/PepButton.vue';
 import PepLoadingButton from '@/components/ui/PepLoadingButton.vue';
 import PepInput from '@/components/ui/form/PepInput.vue';

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Must mock constants BEFORE importing cache module
+vi.mock('./constants', () => ({
+  APP_VERSION: '2.0.0'
+}));
+
+import { wipeCacheOnVersionChange } from './cache';
+
+describe('wipeCacheOnVersionChange', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should wipe derived cache keys when version changes', () => {
+    localStorage.setItem('peppool_app_version', '1.0.0');
+    localStorage.setItem('peppool_balance', '42');
+    localStorage.setItem('peppool_transactions', '[{"txid":"1"}]');
+    localStorage.setItem('peppool_price_usd', '0.001');
+    localStorage.setItem('peppool_price_eur', '0.0009');
+    localStorage.setItem('peppool_inscriptions_Paddr1', '{}');
+    localStorage.setItem('peppool_auth_token', 'tok');
+    localStorage.setItem('peppool_auth_expires', '999');
+    localStorage.setItem('peppool_auth_address', 'Paddr');
+    localStorage.setItem('peppool_last_route', '/send');
+    localStorage.setItem('peppool_form_send', '{"recipient":"x"}');
+
+    const wiped = wipeCacheOnVersionChange();
+
+    expect(wiped).toBe(true);
+    expect(localStorage.getItem('peppool_balance')).toBeNull();
+    expect(localStorage.getItem('peppool_transactions')).toBeNull();
+    expect(localStorage.getItem('peppool_price_usd')).toBeNull();
+    expect(localStorage.getItem('peppool_price_eur')).toBeNull();
+    expect(localStorage.getItem('peppool_inscriptions_Paddr1')).toBeNull();
+    expect(localStorage.getItem('peppool_auth_token')).toBeNull();
+    expect(localStorage.getItem('peppool_auth_expires')).toBeNull();
+    expect(localStorage.getItem('peppool_auth_address')).toBeNull();
+    expect(localStorage.getItem('peppool_last_route')).toBeNull();
+    expect(localStorage.getItem('peppool_form_send')).toBeNull();
+  });
+
+  it('should preserve user data and settings', () => {
+    localStorage.setItem('peppool_app_version', '1.0.0');
+    localStorage.setItem('peppool_vault', 'encrypted-mnemonic');
+    localStorage.setItem('peppool_accounts', '[{"address":"P1"}]');
+    localStorage.setItem('peppool_active_account', '0');
+    localStorage.setItem('peppool_currency', 'EUR');
+    localStorage.setItem('peppool_explorer', 'pepeblocks');
+    localStorage.setItem('peppool_lock_duration', '30');
+    localStorage.setItem('peppool_failed_attempts', '2');
+    localStorage.setItem('peppool_lockout_until', '1700000000');
+
+    wipeCacheOnVersionChange();
+
+    expect(localStorage.getItem('peppool_vault')).toBe('encrypted-mnemonic');
+    expect(localStorage.getItem('peppool_accounts')).toBe('[{"address":"P1"}]');
+    expect(localStorage.getItem('peppool_active_account')).toBe('0');
+    expect(localStorage.getItem('peppool_currency')).toBe('EUR');
+    expect(localStorage.getItem('peppool_explorer')).toBe('pepeblocks');
+    expect(localStorage.getItem('peppool_lock_duration')).toBe('30');
+    expect(localStorage.getItem('peppool_failed_attempts')).toBe('2');
+    expect(localStorage.getItem('peppool_lockout_until')).toBe('1700000000');
+  });
+
+  it('should update stored version after wipe', () => {
+    localStorage.setItem('peppool_app_version', '1.0.0');
+
+    wipeCacheOnVersionChange();
+
+    expect(localStorage.getItem('peppool_app_version')).toBe('2.0.0');
+  });
+
+  it('should not wipe when version matches', () => {
+    localStorage.setItem('peppool_app_version', '2.0.0');
+    localStorage.setItem('peppool_balance', '42');
+    localStorage.setItem('peppool_transactions', '[{"txid":"1"}]');
+
+    const wiped = wipeCacheOnVersionChange();
+
+    expect(wiped).toBe(false);
+    expect(localStorage.getItem('peppool_balance')).toBe('42');
+    expect(localStorage.getItem('peppool_transactions')).toBe('[{"txid":"1"}]');
+  });
+
+  it('should wipe on first launch (no stored version)', () => {
+    localStorage.setItem('peppool_balance', '42');
+    localStorage.setItem('peppool_vault', 'keep-me');
+
+    const wiped = wipeCacheOnVersionChange();
+
+    expect(wiped).toBe(true);
+    expect(localStorage.getItem('peppool_balance')).toBeNull();
+    expect(localStorage.getItem('peppool_vault')).toBe('keep-me');
+    expect(localStorage.getItem('peppool_app_version')).toBe('2.0.0');
+  });
+
+  it('should not touch non-peppool keys', () => {
+    localStorage.setItem('peppool_app_version', '1.0.0');
+    localStorage.setItem('some_other_app', 'data');
+
+    wipeCacheOnVersionChange();
+
+    expect(localStorage.getItem('some_other_app')).toBe('data');
+  });
+});

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,45 @@
+import { APP_VERSION } from './constants';
+
+const VERSION_KEY = 'peppool_app_version';
+
+/**
+ * Keys that hold user data or settings — never wiped on version change.
+ * Everything else with a `peppool_` prefix is treated as derived/cached data.
+ */
+const KEEP_PREFIXES = [
+  'peppool_vault',
+  'peppool_accounts',
+  'peppool_active_account',
+  'peppool_currency',
+  'peppool_explorer',
+  'peppool_lock_duration',
+  'peppool_failed_attempts',
+  'peppool_lockout_until',
+  'peppool_app_version'
+];
+
+function shouldKeep(key: string): boolean {
+  return KEEP_PREFIXES.some((prefix) => key === prefix);
+}
+
+/**
+ * Compare stored app version against current. If different, wipe all
+ * derived/cached localStorage keys (balance, transactions, prices, etc.)
+ * while preserving user data and settings. Must run before Pinia stores
+ * initialize, since they read from localStorage in their setup functions.
+ */
+export function wipeCacheOnVersionChange(): boolean {
+  const storedVersion = localStorage.getItem(VERSION_KEY);
+
+  if (storedVersion === APP_VERSION) return false;
+
+  const keys = Object.keys(localStorage);
+  for (const key of keys) {
+    if (key.startsWith('peppool_') && !shouldKeep(key)) {
+      localStorage.removeItem(key);
+    }
+  }
+
+  localStorage.setItem(VERSION_KEY, APP_VERSION);
+  return true;
+}


### PR DESCRIPTION
## Summary
- On app launch, compare `peppool_app_version` in localStorage against `APP_VERSION`
- If different (or missing), wipe all derived/cached `peppool_*` keys (balance, transactions, prices, inscriptions, auth, forms, routes)
- Preserve user data and settings: vault, accounts, active_account, currency, explorer, lock_duration, lockout state
- Runs before Pinia stores initialize so stores read clean state

## Test plan
- [x] 6 dedicated tests covering: version change wipe, settings preservation, version update, no-op on match, first launch, non-peppool keys untouched
- [x] Full test suite passes (472 tests)
- [x] Build passes