### PR TITLE
Move settings and wallet state to chrome.storage.local

### DIFF
--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -7,7 +7,7 @@ import { useApp } from '@/composables/useApp';
 vi.mock('@/composables/useApp', () => ({
   useApp: vi.fn(() => ({
     wallet: {
-      selectedCurrency: 'USD'
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
     }
   }))
 }));

--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -6,7 +6,8 @@ import { useApp } from '@/composables/useApp';
 // Mock useApp
 vi.mock('@/composables/useApp', () => ({
   useApp: vi.fn(() => ({
-    wallet: {
+    wallet: {},
+    settings: {
       settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
     }
   }))

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -115,7 +115,7 @@ function toggleMode() {
     >
       <template #prefix>
         <span class="font-bold text-slate-500">
-          {{ isFiatMode ? walletStore.selectedCurrency : 'PEP' }}
+          {{ isFiatMode ? walletStore.settings.currency : 'PEP' }}
         </span>
       </template>
 

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -28,7 +28,7 @@ const emit = defineEmits<{
   'change-max': [isMax: boolean];
 }>();
 
-const { wallet: walletStore } = useApp();
+const { settings: settingsStore } = useApp();
 
 const inputAmount = ref('');
 let isInternalSync = false;
@@ -115,7 +115,7 @@ function toggleMode() {
     >
       <template #prefix>
         <span class="font-bold text-slate-500">
-          {{ isFiatMode ? walletStore.settings.currency : 'PEP' }}
+          {{ isFiatMode ? settingsStore.settings.currency : 'PEP' }}
         </span>
       </template>
 

--- a/src/composables/__mocks__/useApp.ts
+++ b/src/composables/__mocks__/useApp.ts
@@ -24,7 +24,7 @@ export const useApp = vi.fn(() => ({
     balance: 0,
     balanceFiat: 0,
     prices: { USD: 0, EUR: 0 },
-    selectedCurrency: 'USD',
+    settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
     currencySymbol: '$',
     transactions: [],
     unlock: vi.fn(),

--- a/src/composables/useApp.spec.ts
+++ b/src/composables/useApp.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useApp } from './useApp';
 import { useWalletStore } from '@/stores/wallet';
+import { useSettingsStore } from '@/stores/settings';
 import { mount } from '@vue/test-utils';
 import { defineComponent } from 'vue';
 
@@ -23,23 +24,30 @@ vi.mock('@/stores/wallet', () => ({
   useWalletStore: vi.fn()
 }));
 
+// Mock Settings Store
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: vi.fn()
+}));
+
 describe('useApp Composable', () => {
-  let mockStore: any;
+  let mockWalletStore: any;
+  let mockSettingsStore: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStore = {
-      isUnlocked: false
-    };
-    vi.mocked(useWalletStore).mockReturnValue(mockStore);
+    mockWalletStore = { isUnlocked: false };
+    mockSettingsStore = { settings: { currency: 'USD' } };
+    vi.mocked(useWalletStore).mockReturnValue(mockWalletStore);
+    vi.mocked(useSettingsStore).mockReturnValue(mockSettingsStore);
   });
 
-  it('should return router, route, and wallet', () => {
+  it('should return router, route, wallet, and settings', () => {
     const TestComponent = defineComponent({
       setup() {
         const app = useApp();
         expect(app.router).toBe(mockRouter);
-        expect(app.wallet).toBe(mockStore);
+        expect(app.wallet).toBe(mockWalletStore);
+        expect(app.settings).toBe(mockSettingsStore);
         expect(app.route).toBeDefined();
         return () => null;
       }

--- a/src/composables/useApp.ts
+++ b/src/composables/useApp.ts
@@ -1,18 +1,21 @@
 import { useRouter, useRoute } from 'vue-router';
 import { useWalletStore } from '@/stores/wallet';
+import { useSettingsStore } from '@/stores/settings';
 
 /**
- * Core application hook to provide access to the router and wallet store
- * with common helpers.
+ * Core application hook to provide access to the router, wallet store,
+ * and settings store with common helpers.
  */
 export function useApp() {
   const router = useRouter();
   const route = useRoute();
   const wallet = useWalletStore();
+  const settings = useSettingsStore();
 
   return {
     router,
     route,
-    wallet
+    wallet,
+    settings
   };
 }

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -46,7 +46,7 @@ describe('useSendTransaction Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
-      selectedCurrency: 'USD',
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       currencySymbol: '$',
       balance: 5,
       spendableBalance: 5,

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -46,8 +46,6 @@ describe('useSendTransaction Composable', () => {
     vi.clearAllMocks();
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
-      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-      currencySymbol: '$',
       balance: 5,
       spendableBalance: 5,
       prices: { USD: 10, EUR: 8 },
@@ -56,7 +54,11 @@ describe('useSendTransaction Composable', () => {
       withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic')))
     };
     vi.mocked(useApp).mockReturnValue({
-      wallet: mockWallet
+      wallet: mockWallet,
+      settings: {
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+        currencySymbol: '$'
+      }
     } as any);
   });
 

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -22,7 +22,7 @@ import { SendTransaction } from '@/models/SendTransaction';
 import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
 export function useSendTransaction() {
-  const { wallet: walletStore } = useApp();
+  const { wallet: walletStore, settings: settingsStore } = useApp();
   const inscriptionStore = useInscriptionStore();
   const tx = ref(new SendTransaction(walletStore.address!));
   const txid = ref('');
@@ -32,7 +32,7 @@ export function useSendTransaction() {
     Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
   );
 
-  const currentPrice = computed(() => walletStore.prices[walletStore.settings.currency]);
+  const currentPrice = computed(() => walletStore.prices[settingsStore.settings.currency]);
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -32,7 +32,7 @@ export function useSendTransaction() {
     Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
   );
 
-  const currentPrice = computed(() => walletStore.prices[walletStore.selectedCurrency]);
+  const currentPrice = computed(() => walletStore.prices[walletStore.settings.currency]);
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,16 @@ import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import { router } from '@/router';
 import { wipeCacheOnVersionChange } from '@/utils/cache';
+import { loadSettings } from '@/utils/settings';
 import '@tailwindplus/elements';
 import './style.css';
 import App from './App.vue';
 
 // Wipe stale cache before Pinia stores read from localStorage
 wipeCacheOnVersionChange();
+
+// Load settings from chrome.storage.local before Pinia stores initialize
+await loadSettings();
 import PepButton from '@/components/ui/PepButton.vue';
 import PepLoadingButton from '@/components/ui/PepLoadingButton.vue';
 import PepInput from '@/components/ui/form/PepInput.vue';

--- a/src/stores/lockout.spec.ts
+++ b/src/stores/lockout.spec.ts
@@ -118,7 +118,7 @@ describe('Lockout Store', () => {
 
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({
-        peppool_failed_attempts: 1
+        peppool_lockout: { attempts: 1, until: 0 }
       })
     );
   });

--- a/src/stores/lockout.ts
+++ b/src/stores/lockout.ts
@@ -25,10 +25,7 @@ function getFailureTier(attempts: number): FailureTier | null {
 }
 
 // ── Storage helpers (chrome.storage.local with localStorage fallback) ─────
-const LOCKOUT_KEYS = {
-  attempts: 'peppool_failed_attempts',
-  until: 'peppool_lockout_until'
-} as const;
+const STORAGE_KEY = 'peppool_lockout';
 
 function hasChromeStorage() {
   return typeof chrome !== 'undefined' && chrome.storage?.local;
@@ -36,36 +33,39 @@ function hasChromeStorage() {
 
 async function loadState(): Promise<{ attempts: number; until: number }> {
   if (hasChromeStorage()) {
-    const data = await chrome.storage.local.get([LOCKOUT_KEYS.attempts, LOCKOUT_KEYS.until]);
-    return {
-      attempts: Number(data[LOCKOUT_KEYS.attempts]) || 0,
-      until: Number(data[LOCKOUT_KEYS.until]) || 0
-    };
+    const data = await chrome.storage.local.get(STORAGE_KEY);
+    const lockout = data[STORAGE_KEY] as { attempts?: number; until?: number } | undefined;
+    if (lockout) {
+      return { attempts: Number(lockout.attempts) || 0, until: Number(lockout.until) || 0 };
+    }
+    return { attempts: 0, until: 0 };
   }
-  return {
-    attempts: Number(localStorage.getItem(LOCKOUT_KEYS.attempts)) || 0,
-    until: Number(localStorage.getItem(LOCKOUT_KEYS.until)) || 0
-  };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const lockout = JSON.parse(raw);
+      return { attempts: Number(lockout.attempts) || 0, until: Number(lockout.until) || 0 };
+    }
+  } catch {
+    /* ignore */
+  }
+  return { attempts: 0, until: 0 };
 }
 
 async function saveState(attempts: number, until: number) {
+  const lockout = { attempts, until };
   if (hasChromeStorage()) {
-    await chrome.storage.local.set({
-      [LOCKOUT_KEYS.attempts]: attempts,
-      [LOCKOUT_KEYS.until]: until
-    });
+    await chrome.storage.local.set({ [STORAGE_KEY]: lockout });
   } else {
-    localStorage.setItem(LOCKOUT_KEYS.attempts, attempts.toString());
-    localStorage.setItem(LOCKOUT_KEYS.until, until.toString());
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(lockout));
   }
 }
 
 async function clearState() {
   if (hasChromeStorage()) {
-    await chrome.storage.local.remove([LOCKOUT_KEYS.attempts, LOCKOUT_KEYS.until]);
+    await chrome.storage.local.remove(STORAGE_KEY);
   } else {
-    localStorage.removeItem(LOCKOUT_KEYS.attempts);
-    localStorage.removeItem(LOCKOUT_KEYS.until);
+    localStorage.removeItem(STORAGE_KEY);
   }
 }
 

--- a/src/stores/settings.spec.ts
+++ b/src/stores/settings.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useSettingsStore } from './settings';
+import { resetSettingsState } from '@/utils/settings';
+import { pepeExplorer } from '@/utils/explorer';
+
+describe('Settings Store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    resetSettingsState();
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with defaults', () => {
+    const store = useSettingsStore();
+    expect(store.settings.currency).toBe('USD');
+    expect(store.settings.explorer).toBe('peppool');
+    expect(store.currencySymbol).toBe('$');
+  });
+
+  it('should handle currency changes correctly', async () => {
+    const store = useSettingsStore();
+    expect(store.settings.currency).toBe('USD');
+
+    await store.setCurrency('EUR');
+    expect(store.settings.currency).toBe('EUR');
+    expect(store.currencySymbol).toBe('€');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ peppool_settings: expect.objectContaining({ currency: 'EUR' }) })
+    );
+  });
+
+  it('should handle explorer changes correctly', async () => {
+    const store = useSettingsStore();
+    expect(store.settings.explorer).toBe('peppool');
+
+    await store.setExplorer('pepeblocks');
+    expect(store.settings.explorer).toBe('pepeblocks');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peppool_settings: expect.objectContaining({ explorer: 'pepeblocks' })
+      })
+    );
+  });
+
+  it('should open explorer links based on selected explorer', async () => {
+    const store = useSettingsStore();
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    pepeExplorer.openTx(store.settings.explorer, 'tx123');
+    expect(openSpy).toHaveBeenCalledWith('https://peppool.space/tx/tx123', '_blank');
+
+    await store.setExplorer('pepeblocks');
+    pepeExplorer.openAddress(store.settings.explorer, 'addr123');
+    expect(openSpy).toHaveBeenCalledWith('https://pepeblocks.com/address/addr123', '_blank');
+
+    openSpy.mockRestore();
+  });
+});

--- a/src/stores/settings.spec.ts
+++ b/src/stores/settings.spec.ts
@@ -43,6 +43,19 @@ describe('Settings Store', () => {
     );
   });
 
+  it('should update and persist lock duration', async () => {
+    const store = useSettingsStore();
+    expect(store.settings.lockDuration).toBe(15);
+
+    await store.setLockDuration(180);
+    expect(store.settings.lockDuration).toBe(180);
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peppool_settings: expect.objectContaining({ lockDuration: 180 })
+      })
+    );
+  });
+
   it('should open explorer links based on selected explorer', async () => {
     const store = useSettingsStore();
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia';
+import { computed } from 'vue';
+import { getSettings, saveSettings } from '@/utils/settings';
+import { EXPLORERS, type ExplorerId } from '@/utils/explorer';
+
+export const useSettingsStore = defineStore('settings', () => {
+  const settings = getSettings();
+
+  const currencySymbol = computed(() => (settings.currency === 'USD' ? '$' : '€'));
+
+  async function setCurrency(currency: 'USD' | 'EUR') {
+    await saveSettings({ currency });
+  }
+
+  async function setExplorer(explorer: ExplorerId) {
+    await saveSettings({ explorer });
+  }
+
+  return {
+    settings,
+    EXPLORERS,
+    currencySymbol,
+    setCurrency,
+    setExplorer
+  };
+});

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -16,11 +16,16 @@ export const useSettingsStore = defineStore('settings', () => {
     await saveSettings({ explorer });
   }
 
+  async function setLockDuration(minutes: number) {
+    await saveSettings({ lockDuration: minutes });
+  }
+
   return {
     settings,
     EXPLORERS,
     currencySymbol,
     setCurrency,
-    setExplorer
+    setExplorer,
+    setLockDuration
   };
 });

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -5,6 +5,8 @@ import { useLockoutStore } from './lockout';
 
 import { Transaction } from '@/models/Transaction';
 import * as api from '@/utils/api';
+import * as settings from '@/utils/settings';
+import { resetSettingsState } from '@/utils/settings';
 
 // Mock the API and Crypto utils
 vi.mock('@/utils/api', async (importOriginal) => {
@@ -34,6 +36,7 @@ describe('Wallet Store', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();
+    resetSettingsState();
     vi.clearAllMocks();
   });
 
@@ -55,7 +58,9 @@ describe('Wallet Store', () => {
     expect(store.accounts[0].label).toBe('Account 1');
     expect(store.accounts[0].path).toBe("m/44'/3434'/0'/0/0");
     expect(localStorage.getItem('peppool_vault')).not.toBeNull();
-    expect(localStorage.getItem('peppool_accounts')).not.toBeNull();
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ peppool_accounts: expect.any(String) })
+    );
   });
 
   it('should sync accounts to chrome.storage.local on wallet creation', async () => {
@@ -107,26 +112,20 @@ describe('Wallet Store', () => {
     await store.createWallet('password123');
     store.lock();
 
-    // Manually corrupt the stored accounts in localStorage
-    localStorage.setItem(
-      'peppool_accounts',
-      JSON.stringify([
-        {
-          address: 'PcorruptedAddress',
-          path: "m/44'/3434'/0'/0/0",
-          label: 'Account 1'
-        }
-      ])
-    );
-    localStorage.setItem('peppool_active_account', '0');
+    // Mock getWalletState to return corrupted accounts for re-init
+    const spy = vi.spyOn(settings, 'getWalletState').mockReturnValue({
+      accounts: [{ address: 'PcorruptedAddress', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }],
+      activeAccountIndex: 0
+    });
 
-    // Re-init store from corrupted localStorage
+    // Re-init store from corrupted state
     setActivePinia(createPinia());
     const freshStore = useWalletStore();
 
     const success = await freshStore.unlock('password123');
     expect(success).toBe(false);
     expect(freshStore.isUnlocked).toBe(false);
+    spy.mockRestore();
   });
 
   it('should handle failed unlock and trigger lockout after 5 attempts', async () => {
@@ -147,11 +146,10 @@ describe('Wallet Store', () => {
 
   it('should auto-unlock via checkSession if chrome.storage has mnemonic', async () => {
     localStorage.setItem('peppool_vault', 'any-vault');
-    localStorage.setItem(
-      'peppool_accounts',
-      JSON.stringify([{ address: 'any-addr', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }])
-    );
-    localStorage.setItem('peppool_active_account', '0');
+    vi.spyOn(settings, 'getWalletState').mockReturnValue({
+      accounts: [{ address: 'any-addr', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }],
+      activeAccountIndex: 0
+    });
 
     // Mock chrome.storage.session.get — store returns sessionStartTime and dataKey
     (global.chrome.storage.session.get as any).mockResolvedValue({
@@ -195,7 +193,15 @@ describe('Wallet Store', () => {
     expect(store.prices.USD).toBe(0);
     expect(localStorage.getItem('peppool_vault')).toBeNull();
     expect(localStorage.getItem('other_app_key')).toBe('keep-me');
-    expect(chrome.storage.local.remove).toHaveBeenCalledWith('peppool_permissions');
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      'peppool_settings',
+      'peppool_accounts',
+      'peppool_active_account'
+    ]);
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      'peppool_permissions',
+      'peppool_lockout'
+    ]);
     expect(chrome.storage.session.remove).toHaveBeenCalledWith(['sessionStartTime', 'dataKey']);
   });
 
@@ -228,7 +234,9 @@ describe('Wallet Store', () => {
 
     await store.switchAccount(1);
     expect(store.address).toBe('addr2');
-    expect(localStorage.getItem('peppool_active_account')).toBe('1');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ peppool_active_account: '1' })
+    );
     expect(store.balance).toBe(1); // Should be refreshed on switch
     expect(store.transactions).toHaveLength(0); // Should be cleared on switch
   });
@@ -260,8 +268,11 @@ describe('Wallet Store', () => {
 
     await store.renameAccount(0, 'New Name');
     expect(store.accounts[0].label).toBe('New Name');
-    expect(JSON.parse(localStorage.getItem('peppool_accounts')!).length).toBe(1);
-    expect(JSON.parse(localStorage.getItem('peppool_accounts')!)[0].label).toBe('New Name');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peppool_accounts: expect.stringContaining('New Name')
+      })
+    );
   });
 
   it('should sync accounts to chrome.storage.local on changes', async () => {
@@ -290,10 +301,10 @@ describe('Wallet Store', () => {
 
     await store.refreshBalance();
 
-    store.setCurrency('USD');
+    await store.setCurrency('USD');
     expect(store.balanceFiat).toBe(0.5); // 1 PEP * 0.5 USD
 
-    store.setCurrency('EUR');
+    await store.setCurrency('EUR');
     expect(store.balanceFiat).toBe(0.4); // 1 PEP * 0.4 EUR
   });
 
@@ -346,46 +357,56 @@ describe('Wallet Store', () => {
     expect(store.spendableBalance).toBe(1); // Falls back to total
   });
 
-  it('should handle currency changes correctly', () => {
+  it('should handle currency changes correctly', async () => {
     const store = useWalletStore();
     expect(store.selectedCurrency).toBe('USD');
 
-    store.setCurrency('EUR');
+    await store.setCurrency('EUR');
     expect(store.selectedCurrency).toBe('EUR');
     expect(store.currencySymbol).toBe('€');
-    expect(localStorage.getItem('peppool_currency')).toBe('EUR');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ peppool_settings: expect.objectContaining({ currency: 'EUR' }) })
+    );
   });
 
-  it('should handle explorer changes correctly', () => {
+  it('should handle explorer changes correctly', async () => {
     const store = useWalletStore();
     expect(store.selectedExplorer).toBe('peppool');
 
-    store.setExplorer('pepeblocks');
+    await store.setExplorer('pepeblocks');
     expect(store.selectedExplorer).toBe('pepeblocks');
-    expect(localStorage.getItem('peppool_explorer')).toBe('pepeblocks');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peppool_settings: expect.objectContaining({ explorer: 'pepeblocks' })
+      })
+    );
   });
 
-  it('should open explorer links through actions', () => {
+  it('should open explorer links through actions', async () => {
     const store = useWalletStore();
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
     store.openExplorerTx('tx123');
     expect(openSpy).toHaveBeenCalledWith('https://peppool.space/tx/tx123', '_blank');
 
-    store.setExplorer('pepeblocks');
+    await store.setExplorer('pepeblocks');
     store.openExplorerAddress('addr123');
     expect(openSpy).toHaveBeenCalledWith('https://pepeblocks.com/address/addr123', '_blank');
 
     openSpy.mockRestore();
   });
 
-  it('should update and persist lock duration', () => {
+  it('should update and persist lock duration', async () => {
     const store = useWalletStore();
     expect(store.lockDuration).toBe(15);
 
-    store.setLockDuration(180);
+    await store.setLockDuration(180);
     expect(store.lockDuration).toBe(180);
-    expect(localStorage.getItem('peppool_lock_duration')).toBe('180');
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        peppool_settings: expect.objectContaining({ lockDuration: 180 })
+      })
+    );
   });
 
   it('should trigger lock after timeout', async () => {
@@ -467,18 +488,18 @@ describe('Wallet Store', () => {
 
     it('should restore transactions from cache on initialization', () => {
       localStorage.setItem('peppool_transactions', JSON.stringify([mockTx]));
-      localStorage.setItem('peppool_active_account', '0');
-      localStorage.setItem(
-        'peppool_accounts',
-        JSON.stringify([
+      vi.spyOn(settings, 'getWalletState').mockReturnValue({
+        accounts: [
           {
             address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
             path: "m/44'/3434'/0'/0/0",
             label: 'Account 1'
           }
-        ])
-      );
+        ],
+        activeAccountIndex: 0
+      });
 
+      setActivePinia(createPinia());
       const store = useWalletStore();
       expect(store.transactions).toHaveLength(1);
       expect(store.transactions[0]!.txid).toBe(mockTx.txid);

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useWalletStore } from './wallet';
+import { useSettingsStore } from './settings';
 import { useLockoutStore } from './lockout';
 
 import { Transaction } from '@/models/Transaction';
@@ -301,10 +302,12 @@ describe('Wallet Store', () => {
 
     await store.refreshBalance();
 
-    await store.setCurrency('USD');
+    const settingsStore = useSettingsStore();
+
+    await settingsStore.setCurrency('USD');
     expect(store.balanceFiat).toBe(0.5); // 1 PEP * 0.5 USD
 
-    await store.setCurrency('EUR');
+    await settingsStore.setCurrency('EUR');
     expect(store.balanceFiat).toBe(0.4); // 1 PEP * 0.4 EUR
   });
 
@@ -357,51 +360,13 @@ describe('Wallet Store', () => {
     expect(store.spendableBalance).toBe(1); // Falls back to total
   });
 
-  it('should handle currency changes correctly', async () => {
-    const store = useWalletStore();
-    expect(store.settings.currency).toBe('USD');
-
-    await store.setCurrency('EUR');
-    expect(store.settings.currency).toBe('EUR');
-    expect(store.currencySymbol).toBe('€');
-    expect(chrome.storage.local.set).toHaveBeenCalledWith(
-      expect.objectContaining({ peppool_settings: expect.objectContaining({ currency: 'EUR' }) })
-    );
-  });
-
-  it('should handle explorer changes correctly', async () => {
-    const store = useWalletStore();
-    expect(store.settings.explorer).toBe('peppool');
-
-    await store.setExplorer('pepeblocks');
-    expect(store.settings.explorer).toBe('pepeblocks');
-    expect(chrome.storage.local.set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        peppool_settings: expect.objectContaining({ explorer: 'pepeblocks' })
-      })
-    );
-  });
-
-  it('should open explorer links through actions', async () => {
-    const store = useWalletStore();
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-
-    store.openExplorerTx('tx123');
-    expect(openSpy).toHaveBeenCalledWith('https://peppool.space/tx/tx123', '_blank');
-
-    await store.setExplorer('pepeblocks');
-    store.openExplorerAddress('addr123');
-    expect(openSpy).toHaveBeenCalledWith('https://pepeblocks.com/address/addr123', '_blank');
-
-    openSpy.mockRestore();
-  });
-
   it('should update and persist lock duration', async () => {
     const store = useWalletStore();
-    expect(store.settings.lockDuration).toBe(15);
+    const settingsStore = useSettingsStore();
+    expect(settingsStore.settings.lockDuration).toBe(15);
 
     await store.setLockDuration(180);
-    expect(store.settings.lockDuration).toBe(180);
+    expect(settingsStore.settings.lockDuration).toBe(180);
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({
         peppool_settings: expect.objectContaining({ lockDuration: 180 })

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -360,25 +360,10 @@ describe('Wallet Store', () => {
     expect(store.spendableBalance).toBe(1); // Falls back to total
   });
 
-  it('should update and persist lock duration', async () => {
-    const store = useWalletStore();
-    const settingsStore = useSettingsStore();
-    expect(settingsStore.settings.lockDuration).toBe(15);
-
-    await store.setLockDuration(180);
-    expect(settingsStore.settings.lockDuration).toBe(180);
-    expect(chrome.storage.local.set).toHaveBeenCalledWith(
-      expect.objectContaining({
-        peppool_settings: expect.objectContaining({ lockDuration: 180 })
-      })
-    );
-  });
-
   it('should trigger lock after timeout', async () => {
     vi.useFakeTimers();
     const store = useWalletStore();
     store.isUnlocked = true;
-    store.setLockDuration(15);
     await store.resetLockTimer();
 
     vi.advanceTimersByTime(14 * 60 * 1000);

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -359,10 +359,10 @@ describe('Wallet Store', () => {
 
   it('should handle currency changes correctly', async () => {
     const store = useWalletStore();
-    expect(store.selectedCurrency).toBe('USD');
+    expect(store.settings.currency).toBe('USD');
 
     await store.setCurrency('EUR');
-    expect(store.selectedCurrency).toBe('EUR');
+    expect(store.settings.currency).toBe('EUR');
     expect(store.currencySymbol).toBe('€');
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({ peppool_settings: expect.objectContaining({ currency: 'EUR' }) })
@@ -371,10 +371,10 @@ describe('Wallet Store', () => {
 
   it('should handle explorer changes correctly', async () => {
     const store = useWalletStore();
-    expect(store.selectedExplorer).toBe('peppool');
+    expect(store.settings.explorer).toBe('peppool');
 
     await store.setExplorer('pepeblocks');
-    expect(store.selectedExplorer).toBe('pepeblocks');
+    expect(store.settings.explorer).toBe('pepeblocks');
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({
         peppool_settings: expect.objectContaining({ explorer: 'pepeblocks' })
@@ -398,10 +398,10 @@ describe('Wallet Store', () => {
 
   it('should update and persist lock duration', async () => {
     const store = useWalletStore();
-    expect(store.lockDuration).toBe(15);
+    expect(store.settings.lockDuration).toBe(15);
 
     await store.setLockDuration(180);
-    expect(store.lockDuration).toBe(180);
+    expect(store.settings.lockDuration).toBe(180);
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({
         peppool_settings: expect.objectContaining({ lockDuration: 180 })

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -21,15 +21,9 @@ import {
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
 import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
-import { EXPLORERS, type ExplorerId, pepeExplorer } from '@/utils/explorer';
-import {
-  getSettings,
-  getWalletState,
-  saveSettings,
-  saveWalletState,
-  clearAllSettings
-} from '@/utils/settings';
+import { getWalletState, saveSettings, saveWalletState, clearAllSettings } from '@/utils/settings';
 import { useLockoutStore } from './lockout';
+import { useSettingsStore } from './settings';
 import { useInscriptionStore } from './inscriptions';
 
 export interface Account {
@@ -61,10 +55,11 @@ async function clearAutoLockAlarm() {
 
 export const useWalletStore = defineStore('wallet', () => {
   const lockout = useLockoutStore();
+  const settingsStore = useSettingsStore();
   const inscriptionStore = useInscriptionStore();
 
   // ── State ──
-  const settings = getSettings();
+  const { settings } = settingsStore;
   const walletStateData = getWalletState();
 
   const accounts = ref<Account[]>(walletStateData.accounts);
@@ -91,7 +86,6 @@ export const useWalletStore = defineStore('wallet', () => {
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
   const balanceFiat = computed(() => balance.value * (prices.value[settings.currency] || 0));
-  const currencySymbol = computed(() => (settings.currency === 'USD' ? '$' : '€'));
 
   // Initialize transactions from cache
   try {
@@ -106,22 +100,6 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   // ── Actions ──
-  async function setCurrency(currency: 'USD' | 'EUR') {
-    await saveSettings({ currency });
-  }
-
-  async function setExplorer(explorer: ExplorerId) {
-    await saveSettings({ explorer });
-  }
-
-  function openExplorerTx(txid: string) {
-    pepeExplorer.openTx(settings.explorer, txid);
-  }
-
-  function openExplorerAddress(address: string) {
-    pepeExplorer.openAddress(settings.explorer, address);
-  }
-
   async function setLockDuration(minutes: number) {
     await saveSettings({ lockDuration: minutes });
     resetLockTimer();
@@ -507,16 +485,9 @@ export const useWalletStore = defineStore('wallet', () => {
     balance,
     spendableBalance,
     balanceFiat,
-    settings,
-    EXPLORERS,
-    currencySymbol,
     prices,
     transactions,
     canLoadMore,
-    setCurrency,
-    setExplorer,
-    openExplorerTx,
-    openExplorerAddress,
     setLockDuration,
     checkSession,
     createWallet,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -22,6 +22,13 @@ import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
 import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
 import { EXPLORERS, type ExplorerId, pepeExplorer } from '@/utils/explorer';
+import {
+  getSettings,
+  getWalletState,
+  saveSettings,
+  saveWalletState,
+  clearAllSettings
+} from '@/utils/settings';
 import { useLockoutStore } from './lockout';
 import { useInscriptionStore } from './inscriptions';
 
@@ -57,27 +64,24 @@ export const useWalletStore = defineStore('wallet', () => {
   const inscriptionStore = useInscriptionStore();
 
   // ── State ──
-  const accounts = ref<Account[]>(JSON.parse(localStorage.getItem('peppool_accounts') || '[]'));
-  const activeAccountIndex = ref<number>(
-    parseInt(localStorage.getItem('peppool_active_account') || '0')
-  );
+  const settingsData = getSettings();
+  const walletStateData = getWalletState();
+
+  const accounts = ref<Account[]>(walletStateData.accounts);
+  const activeAccountIndex = ref<number>(walletStateData.activeAccountIndex);
   const encryptedMnemonic = ref<string | null>(localStorage.getItem('peppool_vault'));
   let sessionKey: CryptoKey | null = null;
   const hasSessionKey = ref(false);
   const isUnlocked = ref(false);
-  const lockDuration = ref<number>(parseInt(localStorage.getItem('peppool_lock_duration') || '15'));
+  const lockDuration = ref<number>(settingsData.lockDuration);
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
   const spendableBalance = ref<number>(0);
   const prices = ref({
     USD: Number(localStorage.getItem('peppool_price_usd')) || 0,
     EUR: Number(localStorage.getItem('peppool_price_eur')) || 0
   });
-  const selectedCurrency = ref<'USD' | 'EUR'>(
-    (localStorage.getItem('peppool_currency') as 'USD' | 'EUR') || 'USD'
-  );
-  const selectedExplorer = ref<ExplorerId>(
-    (localStorage.getItem('peppool_explorer') as ExplorerId) || 'peppool'
-  );
+  const selectedCurrency = ref<'USD' | 'EUR'>(settingsData.currency);
+  const selectedExplorer = ref<ExplorerId>(settingsData.explorer);
 
   const transactions = ref<Transaction[]>([]);
   const canLoadMore = ref(true);
@@ -105,23 +109,14 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   // ── Actions ──
-  async function syncToChromeStorage() {
-    if (typeof chrome !== 'undefined' && chrome.storage?.local) {
-      await chrome.storage.local.set({
-        peppool_accounts: JSON.stringify(accounts.value),
-        peppool_active_account: activeAccountIndex.value.toString()
-      });
-    }
-  }
-
-  function setCurrency(currency: 'USD' | 'EUR') {
+  async function setCurrency(currency: 'USD' | 'EUR') {
     selectedCurrency.value = currency;
-    localStorage.setItem('peppool_currency', currency);
+    await saveSettings({ currency });
   }
 
-  function setExplorer(explorer: ExplorerId) {
+  async function setExplorer(explorer: ExplorerId) {
     selectedExplorer.value = explorer;
-    localStorage.setItem('peppool_explorer', explorer);
+    await saveSettings({ explorer });
   }
 
   function openExplorerTx(txid: string) {
@@ -132,9 +127,9 @@ export const useWalletStore = defineStore('wallet', () => {
     pepeExplorer.openAddress(selectedExplorer.value, address);
   }
 
-  function setLockDuration(minutes: number) {
+  async function setLockDuration(minutes: number) {
     lockDuration.value = minutes;
-    localStorage.setItem('peppool_lock_duration', minutes.toString());
+    await saveSettings({ lockDuration: minutes });
     resetLockTimer();
   }
 
@@ -331,10 +326,7 @@ export const useWalletStore = defineStore('wallet', () => {
     isUnlocked.value = true;
 
     localStorage.setItem('peppool_vault', encrypted);
-    localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
-    localStorage.setItem('peppool_active_account', '0');
-
-    await syncToChromeStorage();
+    await saveWalletState({ accounts: accounts.value, activeAccountIndex: 0 });
 
     await resetLockTimer();
     await lockout.reset();
@@ -362,8 +354,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
     if (foundAccounts.length > 0) {
       accounts.value = [...accounts.value, ...foundAccounts];
-      localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
-      await syncToChromeStorage();
+      await saveWalletState({ accounts: accounts.value });
     }
   }
 
@@ -437,7 +428,7 @@ export const useWalletStore = defineStore('wallet', () => {
     transactions.value = [];
     clearAuth();
 
-    // Selective wipe of peppool-prefixed keys
+    // Wipe all peppool localStorage keys (cache + vault)
     const keys = Object.keys(localStorage);
     for (const key of keys) {
       if (key.startsWith('peppool_')) {
@@ -445,8 +436,10 @@ export const useWalletStore = defineStore('wallet', () => {
       }
     }
 
+    // Wipe chrome.storage (settings, accounts, permissions, session)
+    await clearAllSettings();
     if (typeof chrome !== 'undefined' && chrome.storage) {
-      await chrome.storage.local.remove('peppool_permissions');
+      await chrome.storage.local.remove(['peppool_permissions', 'peppool_lockout']);
       await chrome.storage.session?.remove(['sessionStartTime', 'dataKey']);
     }
 
@@ -460,8 +453,7 @@ export const useWalletStore = defineStore('wallet', () => {
   async function switchAccount(index: number) {
     if (!accounts.value[index]) return;
     activeAccountIndex.value = index;
-    localStorage.setItem('peppool_active_account', index.toString());
-    await syncToChromeStorage();
+    await saveWalletState({ activeAccountIndex: index });
     balance.value = 0;
     spendableBalance.value = 0;
     transactions.value = [];
@@ -482,8 +474,7 @@ export const useWalletStore = defineStore('wallet', () => {
         label: label || `Account ${nextIndex + 1}`
       };
       accounts.value.push(newAccount);
-      localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
-      await syncToChromeStorage();
+      await saveWalletState({ accounts: accounts.value });
       await switchAccount(nextIndex);
     });
   }
@@ -491,8 +482,7 @@ export const useWalletStore = defineStore('wallet', () => {
   async function renameAccount(index: number, label: string) {
     if (!accounts.value[index]) return;
     accounts.value[index].label = label;
-    localStorage.setItem('peppool_accounts', JSON.stringify(accounts.value));
-    await syncToChromeStorage();
+    await saveWalletState({ accounts: accounts.value });
   }
 
   function updateVault(encrypted: string) {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -64,7 +64,7 @@ export const useWalletStore = defineStore('wallet', () => {
   const inscriptionStore = useInscriptionStore();
 
   // ── State ──
-  const settingsData = getSettings();
+  const settings = getSettings();
   const walletStateData = getWalletState();
 
   const accounts = ref<Account[]>(walletStateData.accounts);
@@ -73,15 +73,12 @@ export const useWalletStore = defineStore('wallet', () => {
   let sessionKey: CryptoKey | null = null;
   const hasSessionKey = ref(false);
   const isUnlocked = ref(false);
-  const lockDuration = ref<number>(settingsData.lockDuration);
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
   const spendableBalance = ref<number>(0);
   const prices = ref({
     USD: Number(localStorage.getItem('peppool_price_usd')) || 0,
     EUR: Number(localStorage.getItem('peppool_price_eur')) || 0
   });
-  const selectedCurrency = ref<'USD' | 'EUR'>(settingsData.currency);
-  const selectedExplorer = ref<ExplorerId>(settingsData.explorer);
 
   const transactions = ref<Transaction[]>([]);
   const canLoadMore = ref(true);
@@ -93,8 +90,8 @@ export const useWalletStore = defineStore('wallet', () => {
   const isMnemonicLoaded = computed(() => hasSessionKey.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
-  const balanceFiat = computed(() => balance.value * (prices.value[selectedCurrency.value] || 0));
-  const currencySymbol = computed(() => (selectedCurrency.value === 'USD' ? '$' : '€'));
+  const balanceFiat = computed(() => balance.value * (prices.value[settings.currency] || 0));
+  const currencySymbol = computed(() => (settings.currency === 'USD' ? '$' : '€'));
 
   // Initialize transactions from cache
   try {
@@ -110,25 +107,22 @@ export const useWalletStore = defineStore('wallet', () => {
 
   // ── Actions ──
   async function setCurrency(currency: 'USD' | 'EUR') {
-    selectedCurrency.value = currency;
     await saveSettings({ currency });
   }
 
   async function setExplorer(explorer: ExplorerId) {
-    selectedExplorer.value = explorer;
     await saveSettings({ explorer });
   }
 
   function openExplorerTx(txid: string) {
-    pepeExplorer.openTx(selectedExplorer.value, txid);
+    pepeExplorer.openTx(settings.explorer, txid);
   }
 
   function openExplorerAddress(address: string) {
-    pepeExplorer.openAddress(selectedExplorer.value, address);
+    pepeExplorer.openAddress(settings.explorer, address);
   }
 
   async function setLockDuration(minutes: number) {
-    lockDuration.value = minutes;
     await saveSettings({ lockDuration: minutes });
     resetLockTimer();
   }
@@ -144,7 +138,7 @@ export const useWalletStore = defineStore('wallet', () => {
     if (!sessionStart || !hex) return false;
 
     const elapsed = Date.now() - sessionStart;
-    if (elapsed >= lockDuration.value * 60 * 1000) {
+    if (elapsed >= settings.lockDuration * 60 * 1000) {
       await chrome.storage.session.remove(['sessionStartTime', 'dataKey']);
       return false;
     }
@@ -167,7 +161,7 @@ export const useWalletStore = defineStore('wallet', () => {
   async function resetLockTimer() {
     if (!isUnlocked.value) return;
 
-    const durationMs = lockDuration.value * 60 * 1000;
+    const durationMs = settings.lockDuration * 60 * 1000;
 
     if (typeof chrome !== 'undefined' && chrome.storage?.session) {
       await chrome.storage.session.set({ sessionStartTime: Date.now() });
@@ -175,7 +169,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
     if (lockTimer) clearTimeout(lockTimer);
     lockTimer = setTimeout(() => lock(), durationMs);
-    await setAutoLockAlarm(lockDuration.value);
+    await setAutoLockAlarm(settings.lockDuration);
   }
 
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -513,11 +507,9 @@ export const useWalletStore = defineStore('wallet', () => {
     balance,
     spendableBalance,
     balanceFiat,
-    selectedCurrency,
-    selectedExplorer,
+    settings,
     EXPLORERS,
     currencySymbol,
-    lockDuration,
     prices,
     transactions,
     canLoadMore,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -21,7 +21,7 @@ import {
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
 import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
-import { getWalletState, saveSettings, saveWalletState, clearAllSettings } from '@/utils/settings';
+import { getWalletState, saveWalletState, clearAllSettings } from '@/utils/settings';
 import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';
 import { useInscriptionStore } from './inscriptions';
@@ -100,11 +100,6 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   // ── Actions ──
-  async function setLockDuration(minutes: number) {
-    await saveSettings({ lockDuration: minutes });
-    resetLockTimer();
-  }
-
   async function checkSession() {
     await lockout.restore();
     if (typeof chrome === 'undefined' || !chrome.storage?.session) return false;
@@ -488,7 +483,6 @@ export const useWalletStore = defineStore('wallet', () => {
     prices,
     transactions,
     canLoadMore,
-    setLockDuration,
     checkSession,
     createWallet,
     importWallet,

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useWalletStore } from './wallet';
+import { resetSettingsState } from '@/utils/settings';
 
 // Mock crypto
 vi.mock('../utils/crypto', async (importOriginal) => {
@@ -35,6 +36,7 @@ describe('Wallet Lock vs Reset Behavior', () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();
+    resetSettingsState();
     vi.clearAllMocks();
   });
 
@@ -73,7 +75,6 @@ describe('Wallet Lock vs Reset Behavior', () => {
     // 1. Setup a wallet and some mock session data
     await store.importWallet('mnemonic', 'password');
     localStorage.setItem('peppool_transactions', '[{"txid":"1"}]');
-    localStorage.setItem('peppool_currency', 'EUR');
 
     expect(store.isCreated).toBe(true);
 
@@ -86,8 +87,14 @@ describe('Wallet Lock vs Reset Behavior', () => {
     expect(store.address).toBeNull();
     expect(store.accounts).toHaveLength(0);
 
-    // CHECK: Even general settings are wiped
-    expect(localStorage.getItem('peppool_currency')).toBeNull();
+    // CHECK: Cache is wiped
     expect(localStorage.getItem('peppool_transactions')).toBeNull();
+
+    // CHECK: Settings wiped from chrome.storage.local
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+      'peppool_settings',
+      'peppool_accounts',
+      'peppool_active_account'
+    ]);
   });
 });

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -40,27 +40,13 @@ describe('wipeCacheOnVersionChange', () => {
     expect(localStorage.getItem('peppool_form_send')).toBeNull();
   });
 
-  it('should preserve user data and settings', () => {
+  it('should preserve vault (only persistent localStorage key)', () => {
     localStorage.setItem('peppool_app_version', '1.0.0');
     localStorage.setItem('peppool_vault', 'encrypted-mnemonic');
-    localStorage.setItem('peppool_accounts', '[{"address":"P1"}]');
-    localStorage.setItem('peppool_active_account', '0');
-    localStorage.setItem('peppool_currency', 'EUR');
-    localStorage.setItem('peppool_explorer', 'pepeblocks');
-    localStorage.setItem('peppool_lock_duration', '30');
-    localStorage.setItem('peppool_failed_attempts', '2');
-    localStorage.setItem('peppool_lockout_until', '1700000000');
 
     wipeCacheOnVersionChange();
 
     expect(localStorage.getItem('peppool_vault')).toBe('encrypted-mnemonic');
-    expect(localStorage.getItem('peppool_accounts')).toBe('[{"address":"P1"}]');
-    expect(localStorage.getItem('peppool_active_account')).toBe('0');
-    expect(localStorage.getItem('peppool_currency')).toBe('EUR');
-    expect(localStorage.getItem('peppool_explorer')).toBe('pepeblocks');
-    expect(localStorage.getItem('peppool_lock_duration')).toBe('30');
-    expect(localStorage.getItem('peppool_failed_attempts')).toBe('2');
-    expect(localStorage.getItem('peppool_lockout_until')).toBe('1700000000');
   });
 
   it('should update stored version after wipe', () => {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -3,23 +3,13 @@ import { APP_VERSION } from './constants';
 const VERSION_KEY = 'peppool_app_version';
 
 /**
- * Keys that hold user data or settings — never wiped on version change.
- * Everything else with a `peppool_` prefix is treated as derived/cached data.
+ * Keys to preserve on version change. Settings and wallet state live in
+ * chrome.storage.local — only the vault and version marker remain in localStorage.
  */
-const KEEP_PREFIXES = [
-  'peppool_vault',
-  'peppool_accounts',
-  'peppool_active_account',
-  'peppool_currency',
-  'peppool_explorer',
-  'peppool_lock_duration',
-  'peppool_failed_attempts',
-  'peppool_lockout_until',
-  'peppool_app_version'
-];
+const KEEP_KEYS = ['peppool_vault', 'peppool_app_version'];
 
 function shouldKeep(key: string): boolean {
-  return KEEP_PREFIXES.some((prefix) => key === prefix);
+  return KEEP_KEYS.includes(key);
 }
 
 /**

--- a/src/utils/settings.spec.ts
+++ b/src/utils/settings.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  loadSettings,
+  getSettings,
+  getWalletState,
+  saveSettings,
+  saveWalletState,
+  clearAllSettings,
+  resetSettingsState
+} from './settings';
+
+describe('Settings Module', () => {
+  beforeEach(() => {
+    resetSettingsState();
+    vi.mocked(chrome.storage.local.get).mockResolvedValue({});
+    vi.mocked(chrome.storage.local.set).mockResolvedValue(undefined);
+    vi.mocked(chrome.storage.local.remove).mockResolvedValue(undefined);
+  });
+
+  describe('getSettings', () => {
+    it('should return defaults before loadSettings is called', () => {
+      const s = getSettings();
+      expect(s.currency).toBe('USD');
+      expect(s.explorer).toBe('peppool');
+      expect(s.lockDuration).toBe(15);
+    });
+  });
+
+  describe('getWalletState', () => {
+    it('should return defaults before loadSettings is called', () => {
+      const ws = getWalletState();
+      expect(ws.accounts).toEqual([]);
+      expect(ws.activeAccountIndex).toBe(0);
+    });
+  });
+
+  describe('loadSettings', () => {
+    it('should load settings from chrome.storage.local', async () => {
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({
+        peppool_settings: { currency: 'EUR', explorer: 'pepeblocks', lockDuration: 30 }
+      });
+
+      await loadSettings();
+
+      const s = getSettings();
+      expect(s.currency).toBe('EUR');
+      expect(s.explorer).toBe('pepeblocks');
+      expect(s.lockDuration).toBe(30);
+    });
+
+    it('should load wallet state from chrome.storage.local', async () => {
+      const accounts = [{ address: 'P1', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({
+        peppool_accounts: JSON.stringify(accounts),
+        peppool_active_account: '0'
+      });
+
+      await loadSettings();
+
+      const ws = getWalletState();
+      expect(ws.accounts).toEqual(accounts);
+      expect(ws.activeAccountIndex).toBe(0);
+    });
+
+    it('should merge partial settings with defaults', async () => {
+      vi.mocked(chrome.storage.local.get).mockResolvedValue({
+        peppool_settings: { currency: 'EUR' }
+      });
+
+      await loadSettings();
+
+      const s = getSettings();
+      expect(s.currency).toBe('EUR');
+      expect(s.explorer).toBe('peppool');
+      expect(s.lockDuration).toBe(15);
+    });
+
+    it('should use defaults when chrome.storage.local is empty', async () => {
+      await loadSettings();
+
+      const s = getSettings();
+      expect(s.currency).toBe('USD');
+      expect(s.explorer).toBe('peppool');
+      expect(s.lockDuration).toBe(15);
+    });
+  });
+
+  describe('saveSettings', () => {
+    it('should update in-memory settings and persist to chrome.storage.local', async () => {
+      await saveSettings({ currency: 'EUR' });
+
+      expect(getSettings().currency).toBe('EUR');
+      expect(getSettings().explorer).toBe('peppool');
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+        peppool_settings: { currency: 'EUR', explorer: 'peppool', lockDuration: 15 }
+      });
+    });
+  });
+
+  describe('saveWalletState', () => {
+    it('should persist accounts to chrome.storage.local', async () => {
+      const accounts = [{ address: 'P1', path: "m/44'/3434'/0'/0/0", label: 'Test' }];
+      await saveWalletState({ accounts });
+
+      expect(getWalletState().accounts).toEqual(accounts);
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+        peppool_accounts: JSON.stringify(accounts)
+      });
+    });
+
+    it('should persist activeAccountIndex to chrome.storage.local', async () => {
+      await saveWalletState({ activeAccountIndex: 2 });
+
+      expect(getWalletState().activeAccountIndex).toBe(2);
+      expect(chrome.storage.local.set).toHaveBeenCalledWith({
+        peppool_active_account: '2'
+      });
+    });
+  });
+
+  describe('clearAllSettings', () => {
+    it('should reset state and remove from chrome.storage.local', async () => {
+      await saveSettings({ currency: 'EUR', lockDuration: 30 });
+      await saveWalletState({
+        accounts: [{ address: 'P1', path: 'm/0', label: 'X' }],
+        activeAccountIndex: 1
+      });
+
+      await clearAllSettings();
+
+      expect(getSettings().currency).toBe('USD');
+      expect(getSettings().lockDuration).toBe(15);
+      expect(getWalletState().accounts).toEqual([]);
+      expect(getWalletState().activeAccountIndex).toBe(0);
+      expect(chrome.storage.local.remove).toHaveBeenCalledWith([
+        'peppool_settings',
+        'peppool_accounts',
+        'peppool_active_account'
+      ]);
+    });
+  });
+});

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,3 +1,4 @@
+import { reactive } from 'vue';
 import type { ExplorerId } from './explorer';
 import type { Account } from '@/stores/wallet';
 
@@ -15,8 +16,8 @@ export interface WalletState {
 const SETTINGS_DEFAULTS: Settings = { currency: 'USD', explorer: 'peppool', lockDuration: 15 };
 const WALLET_STATE_DEFAULTS: WalletState = { accounts: [], activeAccountIndex: 0 };
 
-let settings: Settings = { ...SETTINGS_DEFAULTS };
-let walletState: WalletState = { ...WALLET_STATE_DEFAULTS };
+const settings: Settings = reactive({ ...SETTINGS_DEFAULTS });
+const walletState: WalletState = reactive({ ...WALLET_STATE_DEFAULTS });
 
 function hasChromeStorage(): boolean {
   return typeof chrome !== 'undefined' && !!chrome.storage?.local;
@@ -36,7 +37,7 @@ export async function loadSettings(): Promise<void> {
   ]);
 
   if (data.peppool_settings) {
-    settings = { ...SETTINGS_DEFAULTS, ...data.peppool_settings };
+    Object.assign(settings, SETTINGS_DEFAULTS, data.peppool_settings);
   }
 
   if (data.peppool_accounts) {
@@ -94,6 +95,7 @@ export async function clearAllSettings(): Promise<void> {
  * and in test teardown to prevent state leaking between tests.
  */
 export function resetSettingsState(): void {
-  settings = { ...SETTINGS_DEFAULTS };
-  walletState = { ...WALLET_STATE_DEFAULTS };
+  Object.assign(settings, SETTINGS_DEFAULTS);
+  walletState.accounts = [];
+  walletState.activeAccountIndex = 0;
 }

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,99 @@
+import type { ExplorerId } from './explorer';
+import type { Account } from '@/stores/wallet';
+
+export interface Settings {
+  currency: 'USD' | 'EUR';
+  explorer: ExplorerId;
+  lockDuration: number;
+}
+
+export interface WalletState {
+  accounts: Account[];
+  activeAccountIndex: number;
+}
+
+const SETTINGS_DEFAULTS: Settings = { currency: 'USD', explorer: 'peppool', lockDuration: 15 };
+const WALLET_STATE_DEFAULTS: WalletState = { accounts: [], activeAccountIndex: 0 };
+
+let settings: Settings = { ...SETTINGS_DEFAULTS };
+let walletState: WalletState = { ...WALLET_STATE_DEFAULTS };
+
+function hasChromeStorage(): boolean {
+  return typeof chrome !== 'undefined' && !!chrome.storage?.local;
+}
+
+/**
+ * Load settings and wallet state from chrome.storage.local into memory.
+ * Must be called before Pinia stores initialize.
+ */
+export async function loadSettings(): Promise<void> {
+  if (!hasChromeStorage()) return;
+
+  const data = await chrome.storage.local.get([
+    'peppool_settings',
+    'peppool_accounts',
+    'peppool_active_account'
+  ]);
+
+  if (data.peppool_settings) {
+    settings = { ...SETTINGS_DEFAULTS, ...data.peppool_settings };
+  }
+
+  if (data.peppool_accounts) {
+    const raw = data.peppool_accounts;
+    walletState.accounts = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  }
+
+  if (data.peppool_active_account != null) {
+    walletState.activeAccountIndex = parseInt(String(data.peppool_active_account)) || 0;
+  }
+}
+
+export function getSettings(): Settings {
+  return settings;
+}
+
+export function getWalletState(): WalletState {
+  return walletState;
+}
+
+export async function saveSettings(partial: Partial<Settings>): Promise<void> {
+  Object.assign(settings, partial);
+  if (hasChromeStorage()) {
+    await chrome.storage.local.set({ peppool_settings: { ...settings } });
+  }
+}
+
+export async function saveWalletState(state: Partial<WalletState>): Promise<void> {
+  Object.assign(walletState, state);
+  if (hasChromeStorage()) {
+    const update: Record<string, any> = {};
+    if (state.accounts !== undefined) {
+      update.peppool_accounts = JSON.stringify(walletState.accounts);
+    }
+    if (state.activeAccountIndex !== undefined) {
+      update.peppool_active_account = walletState.activeAccountIndex.toString();
+    }
+    await chrome.storage.local.set(update);
+  }
+}
+
+export async function clearAllSettings(): Promise<void> {
+  resetSettingsState();
+  if (hasChromeStorage()) {
+    await chrome.storage.local.remove([
+      'peppool_settings',
+      'peppool_accounts',
+      'peppool_active_account'
+    ]);
+  }
+}
+
+/**
+ * Reset in-memory settings to defaults. Used by clearAllSettings()
+ * and in test teardown to prevent state leaking between tests.
+ */
+export function resetSettingsState(): void {
+  settings = { ...SETTINGS_DEFAULTS };
+  walletState = { ...WALLET_STATE_DEFAULTS };
+}

--- a/src/views/settings/AutoLockView.vue
+++ b/src/views/settings/AutoLockView.vue
@@ -10,8 +10,9 @@ const options = [
   { label: '3 Hours', value: 180 }
 ];
 
-function selectDuration(val: number) {
-  walletStore.setLockDuration(val);
+async function selectDuration(val: number) {
+  await settingsStore.setLockDuration(val);
+  walletStore.resetLockTimer();
   setTimeout(() => router.back(), 200);
 }
 </script>

--- a/src/views/settings/AutoLockView.vue
+++ b/src/views/settings/AutoLockView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useApp } from '@/composables/useApp';
 
-const { router, wallet: walletStore } = useApp();
+const { router, wallet: walletStore, settings: settingsStore } = useApp();
 
 const options = [
   { label: '15 Minutes', value: 15 },
@@ -27,7 +27,7 @@ function selectDuration(val: number) {
       </p>
 
       <PepRadioList
-        :modelValue="walletStore.settings.lockDuration"
+        :modelValue="settingsStore.settings.lockDuration"
         :options="options"
         name="auto-lock"
         @update:modelValue="selectDuration"

--- a/src/views/settings/AutoLockView.vue
+++ b/src/views/settings/AutoLockView.vue
@@ -27,7 +27,7 @@ function selectDuration(val: number) {
       </p>
 
       <PepRadioList
-        v-model="walletStore.lockDuration"
+        :modelValue="walletStore.settings.lockDuration"
         :options="options"
         name="auto-lock"
         @update:modelValue="selectDuration"

--- a/src/views/settings/CurrencyView.vue
+++ b/src/views/settings/CurrencyView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useApp } from '@/composables/useApp';
 
-const { router, wallet: walletStore } = useApp();
+const { router, settings: settingsStore } = useApp();
 
 const options = [
   { label: 'US DOLLAR', value: 'USD' },
@@ -9,7 +9,7 @@ const options = [
 ] as const;
 
 function selectCurrency(code: 'USD' | 'EUR') {
-  walletStore.setCurrency(code);
+  settingsStore.setCurrency(code);
   setTimeout(() => router.back(), 200);
 }
 </script>
@@ -25,7 +25,7 @@ function selectCurrency(code: 'USD' | 'EUR') {
       </p>
 
       <PepRadioList
-        :modelValue="walletStore.settings.currency"
+        :modelValue="settingsStore.settings.currency"
         :options="options"
         name="currency"
         @update:modelValue="selectCurrency"

--- a/src/views/settings/CurrencyView.vue
+++ b/src/views/settings/CurrencyView.vue
@@ -25,7 +25,7 @@ function selectCurrency(code: 'USD' | 'EUR') {
       </p>
 
       <PepRadioList
-        v-model="walletStore.selectedCurrency"
+        :modelValue="walletStore.settings.currency"
         :options="options"
         name="currency"
         @update:modelValue="selectCurrency"

--- a/src/views/settings/PreferencesView.vue
+++ b/src/views/settings/PreferencesView.vue
@@ -26,7 +26,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium uppercase">{{
-              walletStore.selectedCurrency
+              walletStore.settings.currency
             }}</span>
           </template>
         </PepListItem>
@@ -39,7 +39,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium">{{
-              EXPLORERS[walletStore.selectedExplorer].name
+              EXPLORERS[walletStore.settings.explorer].name
             }}</span>
           </template>
         </PepListItem>
@@ -52,7 +52,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium">{{
-              getDurationLabel(walletStore.lockDuration)
+              getDurationLabel(walletStore.settings.lockDuration)
             }}</span>
           </template>
         </PepListItem>

--- a/src/views/settings/PreferencesView.vue
+++ b/src/views/settings/PreferencesView.vue
@@ -3,7 +3,7 @@ import { useApp } from '@/composables/useApp';
 
 import { EXPLORERS } from '@/utils/explorer';
 
-const { router, wallet: walletStore } = useApp();
+const { router, settings: settingsStore } = useApp();
 
 function getDurationLabel(val: number) {
   if (val < 60) return `${val} Minutes`;
@@ -26,7 +26,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium uppercase">{{
-              walletStore.settings.currency
+              settingsStore.settings.currency
             }}</span>
           </template>
         </PepListItem>
@@ -39,7 +39,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium">{{
-              EXPLORERS[walletStore.settings.explorer].name
+              EXPLORERS[settingsStore.settings.explorer].name
             }}</span>
           </template>
         </PepListItem>
@@ -52,7 +52,7 @@ function getDurationLabel(val: number) {
         >
           <template #right>
             <span class="text-offwhite text-sm font-medium">{{
-              getDurationLabel(walletStore.settings.lockDuration)
+              getDurationLabel(settingsStore.settings.lockDuration)
             }}</span>
           </template>
         </PepListItem>

--- a/src/views/settings/PreferredExplorerView.spec.ts
+++ b/src/views/settings/PreferredExplorerView.spec.ts
@@ -16,7 +16,7 @@ describe('PreferredExplorerView', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockWallet = {
-      selectedExplorer: 'peppool',
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       setExplorer: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({

--- a/src/views/settings/PreferredExplorerView.spec.ts
+++ b/src/views/settings/PreferredExplorerView.spec.ts
@@ -10,18 +10,19 @@ const backMock = vi.fn();
 vi.mock('@/composables/useApp');
 
 describe('PreferredExplorerView', () => {
-  let mockWallet: any;
+  let mockSettings: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockWallet = {
+    mockSettings = {
       settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       setExplorer: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock, back: backMock } as any,
-      wallet: mockWallet,
+      wallet: {} as any,
+      settings: mockSettings,
       route: { path: '/settings/explorer' } as any
     } as any);
   });
@@ -39,7 +40,7 @@ describe('PreferredExplorerView', () => {
     const radioList = wrapper.findComponent(PepRadioList);
     await radioList.vm.$emit('update:modelValue', 'pepeblocks');
 
-    expect(mockWallet.setExplorer).toHaveBeenCalledWith('pepeblocks');
+    expect(mockSettings.setExplorer).toHaveBeenCalledWith('pepeblocks');
     vi.advanceTimersByTime(200);
     expect(backMock).toHaveBeenCalled();
   });

--- a/src/views/settings/PreferredExplorerView.vue
+++ b/src/views/settings/PreferredExplorerView.vue
@@ -27,7 +27,7 @@ function selectExplorer(id: ExplorerId) {
       </p>
 
       <PepRadioList
-        v-model="walletStore.selectedExplorer"
+        :modelValue="walletStore.settings.explorer"
         :options="options"
         name="explorer"
         @update:modelValue="selectExplorer"

--- a/src/views/settings/PreferredExplorerView.vue
+++ b/src/views/settings/PreferredExplorerView.vue
@@ -3,7 +3,7 @@ import { useApp } from '@/composables/useApp';
 
 import { EXPLORERS, type ExplorerId } from '@/utils/explorer';
 
-const { router, wallet: walletStore } = useApp();
+const { router, settings: settingsStore } = useApp();
 
 const options = Object.entries(EXPLORERS).map(([id, data]) => ({
   value: id as ExplorerId,
@@ -11,7 +11,7 @@ const options = Object.entries(EXPLORERS).map(([id, data]) => ({
 }));
 
 function selectExplorer(id: ExplorerId) {
-  walletStore.setExplorer(id);
+  settingsStore.setExplorer(id);
   setTimeout(() => router.back(), 200);
 }
 </script>
@@ -27,7 +27,7 @@ function selectExplorer(id: ExplorerId) {
       </p>
 
       <PepRadioList
-        :modelValue="walletStore.settings.explorer"
+        :modelValue="settingsStore.settings.explorer"
         :options="options"
         name="explorer"
         @update:modelValue="selectExplorer"

--- a/src/views/settings/SettingsDetailViews.spec.ts
+++ b/src/views/settings/SettingsDetailViews.spec.ts
@@ -32,9 +32,7 @@ describe('Settings Detail Views', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     mockWallet = {
-      selectedCurrency: 'USD',
-      selectedExplorer: 'peppool',
-      lockDuration: 15,
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       setCurrency: vi.fn(),
       setLockDuration: vi.fn()
     };
@@ -53,11 +51,11 @@ describe('Settings Detail Views', () => {
     });
 
     it('should handle labels for hours correctly', async () => {
-      mockWallet.lockDuration = 60;
+      mockWallet.settings.lockDuration = 60;
       const wrapper = mount(PreferencesView, { global });
       expect(wrapper.text()).toContain('1 Hour');
 
-      mockWallet.lockDuration = 180;
+      mockWallet.settings.lockDuration = 180;
       const wrapper2 = mount(PreferencesView, { global });
       expect(wrapper2.text()).toContain('3 Hours');
     });

--- a/src/views/settings/SettingsDetailViews.spec.ts
+++ b/src/views/settings/SettingsDetailViews.spec.ts
@@ -36,10 +36,11 @@ describe('Settings Detail Views', () => {
       settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       currencySymbol: '$',
       setCurrency: vi.fn(),
-      setExplorer: vi.fn()
+      setExplorer: vi.fn(),
+      setLockDuration: vi.fn()
     };
     mockWallet = {
-      setLockDuration: vi.fn()
+      resetLockTimer: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock, back: backMock } as any,
@@ -87,7 +88,8 @@ describe('Settings Detail Views', () => {
 
       await radioList.vm.$emit('update:modelValue', 60);
 
-      expect(mockWallet.setLockDuration).toHaveBeenCalledWith(60);
+      expect(mockSettings.setLockDuration).toHaveBeenCalledWith(60);
+      expect(mockWallet.resetLockTimer).toHaveBeenCalled();
       vi.advanceTimersByTime(200);
       expect(backMock).toHaveBeenCalled();
     });

--- a/src/views/settings/SettingsDetailViews.spec.ts
+++ b/src/views/settings/SettingsDetailViews.spec.ts
@@ -27,18 +27,24 @@ const global = {
 
 describe('Settings Detail Views', () => {
   let mockWallet: any;
+  let mockSettings: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    mockWallet = {
+    mockSettings = {
       settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+      currencySymbol: '$',
       setCurrency: vi.fn(),
+      setExplorer: vi.fn()
+    };
+    mockWallet = {
       setLockDuration: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock, back: backMock } as any,
       wallet: mockWallet,
+      settings: mockSettings,
       route: { path: '/settings' } as any
     } as any);
   });
@@ -51,11 +57,11 @@ describe('Settings Detail Views', () => {
     });
 
     it('should handle labels for hours correctly', async () => {
-      mockWallet.settings.lockDuration = 60;
+      mockSettings.settings.lockDuration = 60;
       const wrapper = mount(PreferencesView, { global });
       expect(wrapper.text()).toContain('1 Hour');
 
-      mockWallet.settings.lockDuration = 180;
+      mockSettings.settings.lockDuration = 180;
       const wrapper2 = mount(PreferencesView, { global });
       expect(wrapper2.text()).toContain('3 Hours');
     });
@@ -94,7 +100,7 @@ describe('Settings Detail Views', () => {
 
       await radioList.vm.$emit('update:modelValue', 'EUR');
 
-      expect(mockWallet.setCurrency).toHaveBeenCalledWith('EUR');
+      expect(mockSettings.setCurrency).toHaveBeenCalledWith('EUR');
       vi.advanceTimersByTime(200);
       expect(backMock).toHaveBeenCalled();
     });

--- a/src/views/settings/SettingsView.spec.ts
+++ b/src/views/settings/SettingsView.spec.ts
@@ -29,17 +29,20 @@ describe('Settings Views Navigation', () => {
     vi.clearAllMocks();
     mockWallet = {
       isUnlocked: true,
-      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       lock: vi.fn(),
-      resetWallet: vi.fn(),
-      openExplorerTx: vi.fn(),
-      openExplorerAddress: vi.fn()
+      resetWallet: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock, back: backMock } as any,
       wallet: mockWallet,
+      settings: {
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+        currencySymbol: '$',
+        setCurrency: vi.fn(),
+        setExplorer: vi.fn()
+      },
       route: { path: '/settings' } as any
-    });
+    } as any);
   });
 
   const global = {

--- a/src/views/settings/SettingsView.spec.ts
+++ b/src/views/settings/SettingsView.spec.ts
@@ -29,9 +29,7 @@ describe('Settings Views Navigation', () => {
     vi.clearAllMocks();
     mockWallet = {
       isUnlocked: true,
-      selectedCurrency: 'USD',
-      selectedExplorer: 'peppool',
-      lockDuration: 15,
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       lock: vi.fn(),
       resetWallet: vi.fn(),
       openExplorerTx: vi.fn(),

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -43,21 +43,22 @@ describe('Wallet Views Navigation', () => {
       isUnlocked: true,
       balance: 0,
       balanceFiat: 0,
-      currencySymbol: '$',
-      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       prices: { USD: 0, EUR: 0 },
       transactions: [],
       canLoadMore: true,
       refreshBalance: vi.fn(),
       startPolling: vi.fn(),
-      stopPolling: vi.fn(),
-      openExplorerTx: vi.fn()
+      stopPolling: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      settings: {
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+        currencySymbol: '$'
+      },
       route: { path: '/dashboard', params: { txid: 'test-tx' } } as any
-    });
+    } as any);
   });
 
   const global = {

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -44,7 +44,7 @@ describe('Wallet Views Navigation', () => {
       balance: 0,
       balanceFiat: 0,
       currencySymbol: '$',
-      selectedCurrency: 'USD',
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       prices: { USD: 0, EUR: 0 },
       transactions: [],
       canLoadMore: true,

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -71,7 +71,7 @@ async function handleLoadMore() {
       </div>
       <p class="text-sm font-bold text-slate-500">
         {{ walletStore.currencySymbol }}{{ formatFiat(walletStore.balanceFiat) }}
-        {{ walletStore.selectedCurrency }}
+        {{ walletStore.settings.currency }}
       </p>
     </div>
 

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -4,7 +4,7 @@ import { formatFiat, formatAmount } from '@/utils/constants';
 import { useApp } from '@/composables/useApp';
 import { onMounted, computed, ref } from 'vue';
 
-const { router, wallet: walletStore } = useApp();
+const { router, wallet: walletStore, settings: settingsStore } = useApp();
 
 const isLoadingMore = ref(false);
 
@@ -70,8 +70,8 @@ async function handleLoadMore() {
         <span class="text-pep-green-light font-bold">PEP</span>
       </div>
       <p class="text-sm font-bold text-slate-500">
-        {{ walletStore.currencySymbol }}{{ formatFiat(walletStore.balanceFiat) }}
-        {{ walletStore.settings.currency }}
+        {{ settingsStore.currencySymbol }}{{ formatFiat(walletStore.balanceFiat) }}
+        {{ settingsStore.settings.currency }}
       </p>
     </div>
 

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -91,7 +91,7 @@ describe('SendView', () => {
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       isMnemonicLoaded: true,
-      selectedCurrency: 'USD',
+      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
       currencySymbol: '$',
       balance: 7,
       spendableBalance: 7,

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -91,20 +91,20 @@ describe('SendView', () => {
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       isMnemonicLoaded: true,
-      settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-      currencySymbol: '$',
       balance: 7,
       spendableBalance: 7,
       prices: { USD: 10, EUR: 8 },
-      refreshBalance: vi.fn(),
-      openExplorerTx: vi.fn(),
-      openExplorerTxLink: vi.fn()
+      refreshBalance: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      settings: {
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+        currencySymbol: '$'
+      },
       route: { path: '/send' } as any
-    });
+    } as any);
   });
 
   const global = {
@@ -357,7 +357,8 @@ describe('SendView', () => {
     expect(pushMock).toHaveBeenCalledWith('/dashboard');
   });
 
-  it('openExplorer should call store.openExplorerTx', () => {
+  it('openExplorer should open explorer link', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const wrapper = mount(SendView, { global });
     // @ts-ignore
     wrapper.vm.form.txid = 'test-txid';
@@ -365,6 +366,7 @@ describe('SendView', () => {
     // @ts-ignore
     wrapper.vm.openExplorer();
 
-    expect(mockWallet.openExplorerTx).toHaveBeenCalledWith('test-txid');
+    expect(openSpy).toHaveBeenCalledWith('https://peppool.space/tx/test-txid', '_blank');
+    openSpy.mockRestore();
   });
 });

--- a/src/views/wallet/TransactionDetailView.spec.ts
+++ b/src/views/wallet/TransactionDetailView.spec.ts
@@ -60,7 +60,6 @@ describe('TransactionDetailView', () => {
     vi.mocked(api.fetchTransaction).mockResolvedValue(mockRawTx as any);
     mockWallet = reactive({
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
-      openExplorerTx: vi.fn(),
       refreshBalance: vi.fn(),
       transactions: [],
       startPolling: vi.fn(),
@@ -70,8 +69,11 @@ describe('TransactionDetailView', () => {
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
+      settings: {
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
+      },
       route: { params: { txid: mockRawTx.txid } } as any
-    });
+    } as any);
   });
 
   it('should show Network Fee only for outgoing transactions', async () => {
@@ -137,6 +139,7 @@ describe('TransactionDetailView', () => {
   });
 
   it('should call openExplorer with correct txid', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     mockWallet.fetchTransaction.mockResolvedValue(
       new Transaction(mockRawTx, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
@@ -149,7 +152,8 @@ describe('TransactionDetailView', () => {
 
     await wrapper.find('#view-on-explorer').trigger('click');
 
-    expect(mockWallet.openExplorerTx).toHaveBeenCalledWith(mockRawTx.txid);
+    expect(openSpy).toHaveBeenCalledWith(`https://peppool.space/tx/${mockRawTx.txid}`, '_blank');
+    openSpy.mockRestore();
   });
 
   it('should update details when store transaction list changes', async () => {

--- a/src/views/wallet/TransactionDetailView.vue
+++ b/src/views/wallet/TransactionDetailView.vue
@@ -2,8 +2,9 @@
 import { ref, onMounted, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
 import { Transaction } from '@/models/Transaction';
+import { pepeExplorer } from '@/utils/explorer';
 
-const { router, route, wallet: walletStore } = useApp();
+const { router, route, wallet: walletStore, settings: settingsStore } = useApp();
 
 const txid = route.params.txid as string;
 const txFromList = computed(() => walletStore.transactions.find((t) => t.txid === txid));
@@ -31,7 +32,7 @@ onMounted(() => {
 });
 
 function openExplorer() {
-  walletStore.openExplorerTx(txid);
+  pepeExplorer.openTx(settingsStore.settings.explorer, txid);
 }
 </script>
 

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -5,12 +5,13 @@ import { useSendTransaction } from '@/composables/useSendTransaction';
 import { isValidAddress } from '@/utils/crypto';
 import { useForm } from '@/utils/form';
 import { UX_DELAY_FAST, UX_DELAY_SLOW, formatFiat } from '@/utils/constants';
+import { pepeExplorer } from '@/utils/explorer';
 
 import SendStepForm from './SendStepForm.vue';
 import SendStepReview from './SendStepReview.vue';
 import SendStepSuccess from './SendStepSuccess.vue';
 
-const { router, wallet: walletStore } = useApp();
+const { router, wallet: walletStore, settings: settingsStore } = useApp();
 const {
   tx,
   txid,
@@ -48,8 +49,8 @@ if (form.step === 2) form.step = 1;
 const displayBalance = computed(() => {
   const bal = walletStore.spendableBalance;
   if (form.isFiatMode) {
-    const price = walletStore.prices[walletStore.settings.currency];
-    return `${walletStore.currencySymbol}${formatFiat(bal * price)} ${walletStore.settings.currency}`;
+    const price = walletStore.prices[settingsStore.settings.currency];
+    return `${settingsStore.currencySymbol}${formatFiat(bal * price)} ${settingsStore.settings.currency}`;
   }
   return `${parseFloat(bal.toFixed(8))} PEP`;
 });
@@ -160,7 +161,7 @@ function handleClose() {
 }
 
 function openExplorer() {
-  walletStore.openExplorerTx(form.txid);
+  pepeExplorer.openTx(settingsStore.settings.explorer, form.txid);
 }
 
 onMounted(async () => {

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -48,8 +48,8 @@ if (form.step === 2) form.step = 1;
 const displayBalance = computed(() => {
   const bal = walletStore.spendableBalance;
   if (form.isFiatMode) {
-    const price = walletStore.prices[walletStore.selectedCurrency];
-    return `${walletStore.currencySymbol}${formatFiat(bal * price)} ${walletStore.selectedCurrency}`;
+    const price = walletStore.prices[walletStore.settings.currency];
+    return `${walletStore.currencySymbol}${formatFiat(bal * price)} ${walletStore.settings.currency}`;
   }
   return `${parseFloat(bal.toFixed(8))} PEP`;
 });


### PR DESCRIPTION
## Summary
- Settings (currency, explorer, lockDuration) stored as single `peppool_settings` object in `chrome.storage.local`
- Accounts and active index read from `chrome.storage.local` via async bootstrap before Pinia init
- Lockout keys consolidated from `peppool_failed_attempts` + `peppool_lockout_until` into single `peppool_lockout` object
- Cache wipe allowlist simplified to just `peppool_vault` and `peppool_app_version`
- New `src/utils/settings.ts` module bridges async chrome.storage.local with synchronous store init
- New `src/stores/settings.ts` — dedicated `useSettingsStore` Pinia store extracted from wallet store
  - Owns all preference state and setters: `setCurrency`, `setExplorer`, `setLockDuration`
  - Wallet store reads settings reactively but never writes them
- `openExplorerTx` / `openExplorerAddress` removed from wallet store — components call `pepeExplorer` directly
- `useApp` composable now exposes `settings` alongside `wallet`

## Test plan
- [x] 10 settings module tests (load, save, defaults, clear)
- [x] 5 settings store tests (defaults, currency, explorer, lock duration, explorer links)
- [x] Updated lockout spec for consolidated key
- [x] Updated wallet/wallet_lock specs for chrome.storage.local assertions
- [x] Simplified cache spec (settings no longer in localStorage)
- [x] Updated all component and composable specs for new store split
- [x] Full test suite passes (483 tests)
- [x] Build passes (`vue-tsc` + Vite)

Closes #21