### PR TITLE
Refactor: consolidate price logic into price module

### DIFF
--- a/scripts/seed-demo-data.ts
+++ b/scripts/seed-demo-data.ts
@@ -143,9 +143,7 @@ export function seedDemoData(store: any) {
     localStorage.setItem('peppool_balance', '69');
 
     // Set prices
-    store.prices = { USD: 0.0042, EUR: 0.0039 };
-    localStorage.setItem('peppool_price_usd', '0.0042');
-    localStorage.setItem('peppool_price_eur', '0.0039');
+    localStorage.setItem('peppool_prices', JSON.stringify({ USD: 0.0042, EUR: 0.0039 }));
 
     // Set transactions (2 incoming + 1 outgoing + 1 unconfirmed)
     const address = store.address || DEMO_ADDRESS;

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -2,7 +2,8 @@
 import { ref, watch, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
 
-import { RIBBITS_PER_PEP, formatFiat } from '@/utils/constants';
+import { RIBBITS_PER_PEP } from '@/utils/constants';
+import { formatFiat } from '@/utils/fiat';
 import PepInput from './PepInput.vue';
 import PepIcon from '@/components/ui/PepIcon.vue';
 

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -3,7 +3,7 @@ import { ref, watch, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
 
 import { RIBBITS_PER_PEP } from '@/utils/constants';
-import { formatFiat } from '@/utils/fiat';
+import { formatFiat } from '@/utils/price';
 import PepInput from './PepInput.vue';
 import PepIcon from '@/components/ui/PepIcon.vue';
 

--- a/src/composables/__mocks__/useApp.ts
+++ b/src/composables/__mocks__/useApp.ts
@@ -22,10 +22,6 @@ export const useApp = vi.fn(() => ({
     isMnemonicLoaded: true,
     lockout: { lockoutUntil: 0, failedAttempts: 0, isLockedOut: false, attemptsRemaining: 3 },
     balance: 0,
-    balanceFiat: 0,
-    prices: { USD: 0, EUR: 0 },
-    settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-    currencySymbol: '$',
     transactions: [],
     unlock: vi.fn(),
     updateVault: vi.fn(),
@@ -33,11 +29,16 @@ export const useApp = vi.fn(() => ({
     refreshBalance: vi.fn(),
     startPolling: vi.fn(),
     stopPolling: vi.fn(),
-    openExplorerTx: vi.fn(),
     lock: vi.fn(),
     resetWallet: vi.fn(),
     resetLockTimer: vi.fn(),
     accounts: [],
     activeAccountIndex: 0
+  },
+  settings: {
+    settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
+    setCurrency: vi.fn(),
+    setExplorer: vi.fn(),
+    setLockDuration: vi.fn()
   }
 }));

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -48,7 +48,6 @@ describe('useSendTransaction Composable', () => {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       balance: 5,
       spendableBalance: 5,
-      prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn(),
       isMnemonicLoaded: true,
       withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic')))
@@ -56,8 +55,7 @@ describe('useSendTransaction Composable', () => {
     vi.mocked(useApp).mockReturnValue({
       wallet: mockWallet,
       settings: {
-        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-        currencySymbol: '$'
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
       }
     } as any);
   });

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -1,5 +1,6 @@
 import { ref, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
+import * as fiat from '@/utils/fiat';
 import {
   fetchUtxos,
   broadcastTx,
@@ -22,7 +23,7 @@ import { SendTransaction } from '@/models/SendTransaction';
 import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
 export function useSendTransaction() {
-  const { wallet: walletStore, settings: settingsStore } = useApp();
+  const { wallet: walletStore } = useApp();
   const inscriptionStore = useInscriptionStore();
   const tx = ref(new SendTransaction(walletStore.address!));
   const txid = ref('');
@@ -32,7 +33,7 @@ export function useSendTransaction() {
     Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
   );
 
-  const currentPrice = computed(() => walletStore.prices[settingsStore.settings.currency]);
+  const currentPrice = computed(() => fiat.convert(1));
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -1,6 +1,6 @@
 import { ref, computed } from 'vue';
 import { useApp } from '@/composables/useApp';
-import * as fiat from '@/utils/fiat';
+import * as price from '@/utils/price';
 import {
   fetchUtxos,
   broadcastTx,
@@ -33,7 +33,7 @@ export function useSendTransaction() {
     Math.round(walletStore.spendableBalance * RIBBITS_PER_PEP)
   );
 
-  const currentPrice = computed(() => fiat.convert(1));
+  const currentPrice = computed(() => price.convert(1));
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;

--- a/src/stores/settings.spec.ts
+++ b/src/stores/settings.spec.ts
@@ -15,7 +15,6 @@ describe('Settings Store', () => {
     const store = useSettingsStore();
     expect(store.settings.currency).toBe('USD');
     expect(store.settings.explorer).toBe('peppool');
-    expect(store.currencySymbol).toBe('$');
   });
 
   it('should handle currency changes correctly', async () => {
@@ -24,7 +23,6 @@ describe('Settings Store', () => {
 
     await store.setCurrency('EUR');
     expect(store.settings.currency).toBe('EUR');
-    expect(store.currencySymbol).toBe('€');
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({ peppool_settings: expect.objectContaining({ currency: 'EUR' }) })
     );

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,12 +1,9 @@
 import { defineStore } from 'pinia';
-import { computed } from 'vue';
 import { getSettings, saveSettings } from '@/utils/settings';
 import { EXPLORERS, type ExplorerId } from '@/utils/explorer';
 
 export const useSettingsStore = defineStore('settings', () => {
   const settings = getSettings();
-
-  const currencySymbol = computed(() => (settings.currency === 'USD' ? '$' : '€'));
 
   async function setCurrency(currency: 'USD' | 'EUR') {
     await saveSettings({ currency });
@@ -23,7 +20,6 @@ export const useSettingsStore = defineStore('settings', () => {
   return {
     settings,
     EXPLORERS,
-    currencySymbol,
     setCurrency,
     setExplorer,
     setLockDuration

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 import { useWalletStore } from './wallet';
-import { useSettingsStore } from './settings';
 import { useLockoutStore } from './lockout';
 
 import { Transaction } from '@/models/Transaction';
@@ -183,15 +182,12 @@ describe('Wallet Store', () => {
     const store = useWalletStore();
     localStorage.setItem('other_app_key', 'keep-me');
     await store.createWallet('password123');
-    store.prices.USD = 10;
-
     expect(store.isCreated).toBe(true);
     await store.resetWallet();
 
     expect(store.address).toBeNull();
     expect(store.accounts).toHaveLength(0);
     expect(store.isCreated).toBe(false);
-    expect(store.prices.USD).toBe(0);
     expect(localStorage.getItem('peppool_vault')).toBeNull();
     expect(localStorage.getItem('other_app_key')).toBe('keep-me');
     expect(chrome.storage.local.remove).toHaveBeenCalledWith([
@@ -286,29 +282,6 @@ describe('Wallet Store', () => {
         peppool_active_account: '0'
       })
     );
-  });
-
-  it('should calculate fiat balance correctly', async () => {
-    const store = useWalletStore();
-    // Mock an account
-    store.accounts = [
-      {
-        address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
-        path: "m/44'/3434'/0'/0/0",
-        label: 'Account 1'
-      }
-    ];
-    store.activeAccountIndex = 0;
-
-    await store.refreshBalance();
-
-    const settingsStore = useSettingsStore();
-
-    await settingsStore.setCurrency('USD');
-    expect(store.balanceFiat).toBe(0.5); // 1 PEP * 0.5 USD
-
-    await settingsStore.setCurrency('EUR');
-    expect(store.balanceFiat).toBe(0.4); // 1 PEP * 0.4 EUR
   });
 
   it('should compute spendable balance excluding inscription UTXOs', async () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -13,7 +13,6 @@ import {
   hasAddressActivity,
   fetchTransactions,
   fetchTransaction as apiFetchTransaction,
-  fetchPepPrice,
   fetchTipHeight,
   fetchUtxos,
   filterSpendableUtxos
@@ -21,6 +20,7 @@ import {
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
 import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
+import { refreshPrices, clearPrices } from '@/utils/fiat';
 import { getWalletState, saveWalletState, clearAllSettings } from '@/utils/settings';
 import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';
@@ -70,10 +70,6 @@ export const useWalletStore = defineStore('wallet', () => {
   const isUnlocked = ref(false);
   const balance = ref<number>(Number(localStorage.getItem('peppool_balance')) || 0);
   const spendableBalance = ref<number>(0);
-  const prices = ref({
-    USD: Number(localStorage.getItem('peppool_price_usd')) || 0,
-    EUR: Number(localStorage.getItem('peppool_price_eur')) || 0
-  });
 
   const transactions = ref<Transaction[]>([]);
   const canLoadMore = ref(true);
@@ -85,7 +81,6 @@ export const useWalletStore = defineStore('wallet', () => {
   const isMnemonicLoaded = computed(() => hasSessionKey.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
-  const balanceFiat = computed(() => balance.value * (prices.value[settings.currency] || 0));
 
   // Initialize transactions from cache
   try {
@@ -214,10 +209,7 @@ export const useWalletStore = defineStore('wallet', () => {
     if (!address.value) return;
     try {
       await refreshAuth();
-      const currentPrices = await fetchPepPrice();
-      prices.value = currentPrices;
-      localStorage.setItem('peppool_price_usd', currentPrices.USD.toString());
-      localStorage.setItem('peppool_price_eur', currentPrices.EUR.toString());
+      await refreshPrices();
 
       const tipHeight = await fetchTipHeight();
       if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
@@ -391,7 +383,7 @@ export const useWalletStore = defineStore('wallet', () => {
     isUnlocked.value = false;
     balance.value = 0;
     spendableBalance.value = 0;
-    prices.value = { USD: 0, EUR: 0 };
+    clearPrices();
     transactions.value = [];
     clearAuth();
 
@@ -479,8 +471,6 @@ export const useWalletStore = defineStore('wallet', () => {
     lockout,
     balance,
     spendableBalance,
-    balanceFiat,
-    prices,
     transactions,
     canLoadMore,
     checkSession,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -20,7 +20,7 @@ import {
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { Transaction } from '@/models/Transaction';
 import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
-import { refreshPrices, clearPrices } from '@/utils/fiat';
+import { refreshPrices, clearPrices } from '@/utils/price';
 import { getWalletState, saveWalletState, clearAllSettings } from '@/utils/settings';
 import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -16,8 +16,7 @@ describe('wipeCacheOnVersionChange', () => {
     localStorage.setItem('peppool_app_version', '1.0.0');
     localStorage.setItem('peppool_balance', '42');
     localStorage.setItem('peppool_transactions', '[{"txid":"1"}]');
-    localStorage.setItem('peppool_price_usd', '0.001');
-    localStorage.setItem('peppool_price_eur', '0.0009');
+    localStorage.setItem('peppool_prices', '{"USD":0.001,"EUR":0.0009}');
     localStorage.setItem('peppool_inscriptions_Paddr1', '{}');
     localStorage.setItem('peppool_auth_token', 'tok');
     localStorage.setItem('peppool_auth_expires', '999');
@@ -30,8 +29,7 @@ describe('wipeCacheOnVersionChange', () => {
     expect(wiped).toBe(true);
     expect(localStorage.getItem('peppool_balance')).toBeNull();
     expect(localStorage.getItem('peppool_transactions')).toBeNull();
-    expect(localStorage.getItem('peppool_price_usd')).toBeNull();
-    expect(localStorage.getItem('peppool_price_eur')).toBeNull();
+    expect(localStorage.getItem('peppool_prices')).toBeNull();
     expect(localStorage.getItem('peppool_inscriptions_Paddr1')).toBeNull();
     expect(localStorage.getItem('peppool_auth_token')).toBeNull();
     expect(localStorage.getItem('peppool_auth_expires')).toBeNull();

--- a/src/utils/constants.spec.ts
+++ b/src/utils/constants.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatAmount, formatFiat, truncateId } from './constants';
+import { formatAmount, truncateId } from './constants';
 
 describe('Constants Utilities', () => {
   describe('formatAmount', () => {
@@ -17,22 +17,6 @@ describe('Constants Utilities', () => {
 
     it('should handle zero correctly', () => {
       expect(formatAmount(0)).toBe('0');
-    });
-  });
-
-  describe('formatFiat', () => {
-    it('should format standard amounts with 2 decimals', () => {
-      expect(formatFiat(12.3456)).toBe('12.35');
-    });
-
-    it('should format tiny amounts with extra precision', () => {
-      expect(formatFiat(0.0001234)).toBe('0.00012');
-    });
-
-    it('should return 0.00 for NaN, Infinity, and -Infinity to avoid displaying garbage', () => {
-      expect(formatFiat(NaN)).toBe('0.00');
-      expect(formatFiat(Infinity)).toBe('0.00');
-      expect(formatFiat(-Infinity)).toBe('0.00');
     });
   });
 

--- a/src/utils/constants.spec.ts
+++ b/src/utils/constants.spec.ts
@@ -1,25 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { formatAmount, truncateId } from './constants';
+import { truncateId } from './constants';
 
 describe('Constants Utilities', () => {
-  describe('formatAmount', () => {
-    it('should format small numbers with full precision', () => {
-      expect(formatAmount(1234.56789)).toBe('1,234.56789');
-    });
-
-    it('should format millions with 2 decimals', () => {
-      expect(formatAmount(1234567.89123)).toBe('1,234,567.89');
-    });
-
-    it('should format billions with 0 decimals', () => {
-      expect(formatAmount(3643664907.738473)).toBe('3,643,664,908');
-    });
-
-    it('should handle zero correctly', () => {
-      expect(formatAmount(0)).toBe('0');
-    });
-  });
-
   describe('truncateId', () => {
     it('should split a long id into start and end', () => {
       const result = truncateId('abcdefghijklmnop');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,20 +38,6 @@ export function formatAmount(value: number): string {
 }
 
 /**
- * Format a fiat value with enough precision to be meaningful.
- * For values ≥ 0.01 → 2 decimals ($1.23)
- * For tiny values → extends until 2 significant digits ($0.0023)
- */
-export function formatFiat(value: number): string {
-  if (value === 0 || !Number.isFinite(value)) return '0.00';
-  const abs = Math.abs(value);
-  if (abs >= 0.01) return value.toFixed(2);
-  // Count leading zeros after decimal point, then show 2 significant digits
-  const decimals = Math.max(2, -Math.floor(Math.log10(abs)) + 1);
-  return value.toFixed(decimals);
-}
-
-/**
  * Truncates a long ID (like a TXID or address) for display.
  * Returns an object with start and end pieces.
  */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,27 +15,6 @@ export const TXS_PER_PAGE = 25;
 export const UX_DELAY_FAST = 1000;
 export const UX_DELAY_NORMAL = 2000;
 export const UX_DELAY_SLOW = 3000;
-/**
- * Format a crypto amount with commas and smart decimal reduction for large numbers.
- * e.g. 1234.56789 -> "1,234.56789"
- * e.g. 1234567.89 -> "1,234,567.89"
- * e.g. 1234567890 -> "1,234,567,890" (0 decimals for billions)
- */
-export function formatAmount(value: number): string {
-  if (value === 0) return '0';
-
-  let decimals = 8;
-  if (value >= 1_000_000_000) decimals = 0;
-  else if (value >= 1_000_000) decimals = 2;
-
-  // Use Intl.NumberFormat for reliable comma separators
-  const formatter = new Intl.NumberFormat('en-US', {
-    minimumFractionDigits: 0,
-    maximumFractionDigits: decimals
-  });
-
-  return formatter.format(value);
-}
 
 /**
  * Truncates a long ID (like a TXID or address) for display.

--- a/src/utils/fiat.spec.ts
+++ b/src/utils/fiat.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as api from './api';
+import { resetSettingsState, saveSettings } from './settings';
+
+vi.mock('./api', () => ({
+  fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0.5, EUR: 0.4 }))
+}));
+
+// Must import after mocks are set up
+import { getPrices, refreshPrices, clearPrices, convert, format, formatFiat } from './fiat';
+
+describe('Fiat Module', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearPrices();
+    resetSettingsState();
+    vi.clearAllMocks();
+  });
+
+  describe('refreshPrices', () => {
+    it('should fetch and cache prices', async () => {
+      await refreshPrices();
+      const prices = getPrices();
+      expect(prices.USD).toBe(0.5);
+      expect(prices.EUR).toBe(0.4);
+      expect(localStorage.getItem('peppool_prices')).toBe('{"USD":0.5,"EUR":0.4}');
+    });
+  });
+
+  describe('clearPrices', () => {
+    it('should reset prices and remove cache', async () => {
+      await refreshPrices();
+      clearPrices();
+      const prices = getPrices();
+      expect(prices.USD).toBe(0);
+      expect(prices.EUR).toBe(0);
+      expect(localStorage.getItem('peppool_prices')).toBeNull();
+    });
+  });
+
+  describe('convert', () => {
+    it('should convert PEP to fiat using current currency setting', async () => {
+      await refreshPrices();
+      expect(convert(10)).toBe(5); // 10 PEP * 0.5 USD
+    });
+
+    it('should respect currency setting', async () => {
+      await refreshPrices();
+      await saveSettings({ currency: 'EUR' });
+      expect(convert(10)).toBe(4); // 10 PEP * 0.4 EUR
+    });
+
+    it('should return 0 when no prices loaded', () => {
+      expect(convert(10)).toBe(0);
+    });
+  });
+
+  describe('format', () => {
+    it('should format PEP amount as fiat string with symbol and code', async () => {
+      await refreshPrices();
+      expect(format(10)).toBe('$5.00 USD');
+    });
+
+    it('should format with EUR when currency is EUR', async () => {
+      await refreshPrices();
+      await saveSettings({ currency: 'EUR' });
+      expect(format(10)).toBe('€4.00 EUR');
+    });
+
+    it('should handle zero balance', () => {
+      expect(format(0)).toBe('$0.00 USD');
+    });
+
+    it('should handle tiny values with extra precision', async () => {
+      vi.mocked(api.fetchPepPrice).mockResolvedValue({ USD: 0.00001, EUR: 0.000009 });
+      await refreshPrices();
+      expect(format(1)).toBe('$0.000010 USD');
+    });
+  });
+
+  describe('formatFiat', () => {
+    it('should format standard amounts with 2 decimals', () => {
+      expect(formatFiat(12.3456)).toBe('12.35');
+    });
+
+    it('should format tiny amounts with extra precision', () => {
+      expect(formatFiat(0.0001234)).toBe('0.00012');
+    });
+
+    it('should return 0.00 for NaN, Infinity, and -Infinity to avoid displaying garbage', () => {
+      expect(formatFiat(NaN)).toBe('0.00');
+      expect(formatFiat(Infinity)).toBe('0.00');
+      expect(formatFiat(-Infinity)).toBe('0.00');
+    });
+  });
+});

--- a/src/utils/fiat.ts
+++ b/src/utils/fiat.ts
@@ -1,0 +1,74 @@
+import { reactive } from 'vue';
+import { getSettings } from './settings';
+import { fetchPepPrice } from './api';
+
+export interface Prices {
+  USD: number;
+  EUR: number;
+}
+
+const CURRENCY_SYMBOLS: Record<string, string> = { USD: '$', EUR: '€' };
+const STORAGE_KEY = 'peppool_prices';
+
+const prices: Prices = reactive({ USD: 0, EUR: 0 });
+
+function loadFromCache(): void {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw) {
+    try {
+      const cached = JSON.parse(raw);
+      Object.assign(prices, cached);
+    } catch {
+      /* ignore corrupt cache */
+    }
+  }
+}
+
+loadFromCache();
+
+export function getPrices(): Prices {
+  return prices;
+}
+
+export async function refreshPrices(): Promise<void> {
+  const fetched = await fetchPepPrice();
+  Object.assign(prices, fetched);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...prices }));
+}
+
+export function clearPrices(): void {
+  prices.USD = 0;
+  prices.EUR = 0;
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/**
+ * Convert a PEP amount to fiat using the current currency setting.
+ */
+export function convert(pep: number): number {
+  const { currency } = getSettings();
+  return pep * (prices[currency] || 0);
+}
+
+/**
+ * Format a PEP amount as a fiat string using the current currency setting.
+ * e.g. "$1.23 USD"
+ */
+export function format(pep: number): string {
+  const { currency } = getSettings();
+  const symbol = CURRENCY_SYMBOLS[currency] || '';
+  return `${symbol}${formatFiat(convert(pep))} ${currency}`;
+}
+
+/**
+ * Format a raw fiat value with enough precision to be meaningful.
+ * For values ≥ 0.01 → 2 decimals ($1.23)
+ * For tiny values → extends until 2 significant digits ($0.0023)
+ */
+export function formatFiat(value: number): string {
+  if (value === 0 || !Number.isFinite(value)) return '0.00';
+  const abs = Math.abs(value);
+  if (abs >= 0.01) return value.toFixed(2);
+  const decimals = Math.max(2, -Math.floor(Math.log10(abs)) + 1);
+  return value.toFixed(decimals);
+}

--- a/src/utils/price.spec.ts
+++ b/src/utils/price.spec.ts
@@ -7,9 +7,17 @@ vi.mock('./api', () => ({
 }));
 
 // Must import after mocks are set up
-import { getPrices, refreshPrices, clearPrices, convert, format, formatFiat } from './fiat';
+import {
+  getPrices,
+  refreshPrices,
+  clearPrices,
+  convert,
+  format,
+  formatFiat,
+  formatAmount
+} from './price';
 
-describe('Fiat Module', () => {
+describe('Price Module', () => {
   beforeEach(() => {
     localStorage.clear();
     clearPrices();
@@ -91,6 +99,24 @@ describe('Fiat Module', () => {
       expect(formatFiat(NaN)).toBe('0.00');
       expect(formatFiat(Infinity)).toBe('0.00');
       expect(formatFiat(-Infinity)).toBe('0.00');
+    });
+  });
+
+  describe('formatAmount', () => {
+    it('should format small numbers with full precision', () => {
+      expect(formatAmount(1234.56789)).toBe('1,234.56789');
+    });
+
+    it('should format millions with 2 decimals', () => {
+      expect(formatAmount(1234567.89123)).toBe('1,234,567.89');
+    });
+
+    it('should format billions with 0 decimals', () => {
+      expect(formatAmount(3643664907.738473)).toBe('3,643,664,908');
+    });
+
+    it('should handle zero correctly', () => {
+      expect(formatAmount(0)).toBe('0');
     });
   });
 });

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -61,6 +61,27 @@ export function format(pep: number): string {
 }
 
 /**
+ * Format a PEP amount with commas and smart decimal reduction for large numbers.
+ * e.g. 1234.56789 -> "1,234.56789"
+ * e.g. 1234567.89 -> "1,234,567.89"
+ * e.g. 1234567890 -> "1,234,567,890" (0 decimals for billions)
+ */
+export function formatAmount(value: number): string {
+  if (value === 0) return '0';
+
+  let decimals = 8;
+  if (value >= 1_000_000_000) decimals = 0;
+  else if (value >= 1_000_000) decimals = 2;
+
+  const formatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals
+  });
+
+  return formatter.format(value);
+}
+
+/**
  * Format a raw fiat value with enough precision to be meaningful.
  * For values ≥ 0.01 → 2 decimals ($1.23)
  * For tiny values → extends until 2 significant digits ($0.0023)

--- a/src/views/settings/SettingsDetailViews.spec.ts
+++ b/src/views/settings/SettingsDetailViews.spec.ts
@@ -34,7 +34,7 @@ describe('Settings Detail Views', () => {
     vi.useFakeTimers();
     mockSettings = {
       settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-      currencySymbol: '$',
+
       setCurrency: vi.fn(),
       setExplorer: vi.fn(),
       setLockDuration: vi.fn()

--- a/src/views/settings/SettingsView.spec.ts
+++ b/src/views/settings/SettingsView.spec.ts
@@ -37,7 +37,7 @@ describe('Settings Views Navigation', () => {
       wallet: mockWallet,
       settings: {
         settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-        currencySymbol: '$',
+
         setCurrency: vi.fn(),
         setExplorer: vi.fn()
       },

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -42,8 +42,6 @@ describe('Wallet Views Navigation', () => {
     mockWallet = {
       isUnlocked: true,
       balance: 0,
-      balanceFiat: 0,
-      prices: { USD: 0, EUR: 0 },
       transactions: [],
       canLoadMore: true,
       refreshBalance: vi.fn(),
@@ -54,8 +52,7 @@ describe('Wallet Views Navigation', () => {
       router: { push: pushMock } as any,
       wallet: mockWallet,
       settings: {
-        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-        currencySymbol: '$'
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
       },
       route: { path: '/dashboard', params: { txid: 'test-tx' } } as any
     } as any);

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { formatFiat, formatAmount } from '@/utils/constants';
+import { formatAmount } from '@/utils/constants';
+import * as fiat from '@/utils/fiat';
 
 import { useApp } from '@/composables/useApp';
 import { onMounted, computed, ref } from 'vue';
 
-const { router, wallet: walletStore, settings: settingsStore } = useApp();
+const { router, wallet: walletStore } = useApp();
 
 const isLoadingMore = ref(false);
 
@@ -70,8 +71,7 @@ async function handleLoadMore() {
         <span class="text-pep-green-light font-bold">PEP</span>
       </div>
       <p class="text-sm font-bold text-slate-500">
-        {{ settingsStore.currencySymbol }}{{ formatFiat(walletStore.balanceFiat) }}
-        {{ settingsStore.settings.currency }}
+        {{ fiat.format(walletStore.balance) }}
       </p>
     </div>
 

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
-import { formatAmount } from '@/utils/constants';
-import * as fiat from '@/utils/fiat';
+import * as price from '@/utils/price';
 
 import { useApp } from '@/composables/useApp';
 import { onMounted, computed, ref } from 'vue';
@@ -10,7 +9,7 @@ const { router, wallet: walletStore } = useApp();
 const isLoadingMore = ref(false);
 
 const balanceFontSize = computed(() => {
-  const len = formatAmount(walletStore.balance).length;
+  const len = price.formatAmount(walletStore.balance).length;
 
   switch (true) {
     case len > 16:
@@ -66,12 +65,12 @@ async function handleLoadMore() {
       <p class="text-sm font-bold tracking-wider text-slate-400 uppercase">Total Balance</p>
       <div class="flex items-baseline justify-center space-x-2">
         <span class="text-offwhite font-bold transition-all duration-300" :class="balanceFontSize">
-          {{ formatAmount(walletStore.balance) }}
+          {{ price.formatAmount(walletStore.balance) }}
         </span>
         <span class="text-pep-green-light font-bold">PEP</span>
       </div>
       <p class="text-sm font-bold text-slate-500">
-        {{ fiat.format(walletStore.balance) }}
+        {{ price.format(walletStore.balance) }}
       </p>
     </div>
 

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -93,15 +93,13 @@ describe('SendView', () => {
       isMnemonicLoaded: true,
       balance: 7,
       spendableBalance: 7,
-      prices: { USD: 10, EUR: 8 },
       refreshBalance: vi.fn()
     };
     vi.mocked(useApp).mockReturnValue({
       router: { push: pushMock } as any,
       wallet: mockWallet,
       settings: {
-        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 },
-        currencySymbol: '$'
+        settings: { currency: 'USD', explorer: 'peppool', lockDuration: 15 }
       },
       route: { path: '/send' } as any
     } as any);

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -4,8 +4,9 @@ import { useApp } from '@/composables/useApp';
 import { useSendTransaction } from '@/composables/useSendTransaction';
 import { isValidAddress } from '@/utils/crypto';
 import { useForm } from '@/utils/form';
-import { UX_DELAY_FAST, UX_DELAY_SLOW, formatFiat } from '@/utils/constants';
+import { UX_DELAY_FAST, UX_DELAY_SLOW } from '@/utils/constants';
 import { pepeExplorer } from '@/utils/explorer';
+import * as fiat from '@/utils/fiat';
 
 import SendStepForm from './SendStepForm.vue';
 import SendStepReview from './SendStepReview.vue';
@@ -49,8 +50,7 @@ if (form.step === 2) form.step = 1;
 const displayBalance = computed(() => {
   const bal = walletStore.spendableBalance;
   if (form.isFiatMode) {
-    const price = walletStore.prices[settingsStore.settings.currency];
-    return `${settingsStore.currencySymbol}${formatFiat(bal * price)} ${settingsStore.settings.currency}`;
+    return fiat.format(bal);
   }
   return `${parseFloat(bal.toFixed(8))} PEP`;
 });

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -6,7 +6,7 @@ import { isValidAddress } from '@/utils/crypto';
 import { useForm } from '@/utils/form';
 import { UX_DELAY_FAST, UX_DELAY_SLOW } from '@/utils/constants';
 import { pepeExplorer } from '@/utils/explorer';
-import * as fiat from '@/utils/fiat';
+import * as price from '@/utils/price';
 
 import SendStepForm from './SendStepForm.vue';
 import SendStepReview from './SendStepReview.vue';
@@ -50,7 +50,7 @@ if (form.step === 2) form.step = 1;
 const displayBalance = computed(() => {
   const bal = walletStore.spendableBalance;
   if (form.isFiatMode) {
-    return fiat.format(bal);
+    return price.format(bal);
   }
   return `${parseFloat(bal.toFixed(8))} PEP`;
 });


### PR DESCRIPTION
## Summary
- Create `src/utils/price.ts` — single module for price fetching, caching, conversion, and formatting
- Replace two localStorage keys (`peppool_price_usd`/`peppool_price_eur`) with single `peppool_prices`
- Remove `prices`, `balanceFiat`, `currencySymbol` from wallet/settings stores — consumers use `price.convert()` and `price.format()` which read the currency setting internally
- Move `formatAmount` and `formatFiat` from `constants.ts` into `price.ts`

## Test plan
- [x] All 491 tests pass
- [x] `vue-tsc -b` clean
- [x] Production build passes