### PR TITLE
Use ribbits as canonical unit in stores, format at display time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `peppool-wallet` are documented in this file.
 - Inscription data sync with background refresh and cached UTXO exclusion ([#12](https://github.com/mvdnbrk/peppool-wallet/pull/12))
 
 ### Changed
+- Use ribbits as canonical unit in stores and composables; format at display time ([#25](https://github.com/mvdnbrk/peppool-wallet/issues/25))
 - Split wallet store into separate wallet and account stores ([#20](https://github.com/mvdnbrk/peppool-wallet/pull/20))
 - Consolidate price logic into single price module with unified cache key ([#24](https://github.com/mvdnbrk/peppool-wallet/pull/24))
 - Move settings and wallet state to chrome.storage.local with dedicated settings store ([#23](https://github.com/mvdnbrk/peppool-wallet/pull/23))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "peppool-wallet",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2-dev",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/composables/__mocks__/useApp.ts
+++ b/src/composables/__mocks__/useApp.ts
@@ -34,8 +34,8 @@ export const useApp = vi.fn(() => ({
     activeAccountIndex: 0
   },
   account: {
-    balance: 0,
-    spendableBalance: 0,
+    balanceRibbits: 0,
+    spendableBalanceRibbits: 0,
     transactions: [],
     canLoadMoreTransactions: false,
     loadCachedData: vi.fn(),

--- a/src/composables/useApp.spec.ts
+++ b/src/composables/useApp.spec.ts
@@ -43,7 +43,7 @@ describe('useApp Composable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWalletStore = { isUnlocked: false };
-    mockAccountStore = { balance: 0 };
+    mockAccountStore = { balanceRibbits: 0 };
     mockSettingsStore = { settings: { currency: 'USD' } };
     vi.mocked(useWalletStore).mockReturnValue(mockWalletStore);
     vi.mocked(useAccountStore).mockReturnValue(mockAccountStore);

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -46,7 +46,7 @@ describe('useSendTransaction Composable', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccount = {
-      spendableBalance: 5
+      spendableBalanceRibbits: 500_000_000
     };
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
@@ -77,7 +77,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should check insufficient funds against spendable balance', async () => {
-    mockAccount.spendableBalance = 0.001; // 100,000 ribbits
+    mockAccount.spendableBalanceRibbits = 100_000;
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, isLoadingFees, loadFees } = useSendTransaction();
@@ -133,7 +133,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should validate step 1 inputs', async () => {
-    mockAccount.spendableBalance = 100;
+    mockAccount.spendableBalanceRibbits = 10_000_000_000;
     const { validateStep1, tx } = useSendTransaction();
     tx.value.fees = { fastestFee: 1000 } as any;
 
@@ -179,7 +179,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should handle insufficient funds correctly', async () => {
-    mockAccount.spendableBalance = 0.000001; // 100 ribbits
+    mockAccount.spendableBalanceRibbits = 100;
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { isInsufficientFunds, tx, loadFees } = useSendTransaction();
@@ -211,7 +211,7 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('should estimate max amount from wallet balance', async () => {
-    mockAccount.spendableBalance = 10; // 1,000,000,000 ribbits
+    mockAccount.spendableBalanceRibbits = 1_000_000_000;
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
 
     const { maxRibbits, loadFees } = useSendTransaction();

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -29,22 +29,15 @@ export function useSendTransaction() {
   const txid = ref('');
   const isLoadingFees = ref(true);
 
-  const spendableBalanceRibbits = computed(() =>
-    Math.round(account.spendableBalance * RIBBITS_PER_PEP)
-  );
-
-  const currentPrice = computed(() => price.convert(1));
+  const currentPrice = computed(() => price.convert(RIBBITS_PER_PEP));
 
   const isInsufficientFunds = computed(() => {
     if (isLoadingFees.value || tx.value.amountRibbits <= 0) return false;
     const needed = tx.value.amountRibbits + tx.value.estimatedFeeRibbits;
-    return spendableBalanceRibbits.value < needed;
+    return account.spendableBalanceRibbits < needed;
   });
 
-  const displayFee = computed(() => {
-    const feePep = tx.value.estimatedFeeRibbits / RIBBITS_PER_PEP;
-    return `${parseFloat(feePep.toFixed(8))} PEP`;
-  });
+  const displayFee = computed(() => price.formatPep(tx.value.estimatedFeeRibbits));
 
   const maxRibbits = computed(() => {
     const txSize = estimateTxSize(1, 2);
@@ -52,7 +45,7 @@ export function useSendTransaction() {
       ? Math.max(RECOMMENDED_FEE_RATE, tx.value.fees.fastestFee)
       : RECOMMENDED_FEE_RATE;
     const feeRibbits = Math.ceil(txSize * feeRate);
-    return Math.max(0, spendableBalanceRibbits.value - feeRibbits);
+    return Math.max(0, account.spendableBalanceRibbits - feeRibbits);
   });
 
   async function loadFees() {
@@ -90,7 +83,7 @@ export function useSendTransaction() {
     }
 
     const needed = amountRibbits + tx.value.estimatedFeeRibbits;
-    if (spendableBalanceRibbits.value < needed) {
+    if (account.spendableBalanceRibbits < needed) {
       throw new Error('Insufficient balance');
     }
 

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -35,17 +35,17 @@ describe('Account Store', () => {
 
   it('should initialize with zero balance', () => {
     const account = useAccountStore();
-    expect(account.balance).toBe(0);
-    expect(account.spendableBalance).toBe(0);
+    expect(account.balanceRibbits).toBe(0);
+    expect(account.spendableBalanceRibbits).toBe(0);
     expect(account.transactions).toHaveLength(0);
     expect(account.canLoadMoreTransactions).toBe(false);
   });
 
   it('should restore cached balance from localStorage', () => {
-    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 42 }));
+    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 4_200_000_000 }));
     const account = useAccountStore();
     account.loadCachedData(addr);
-    expect(account.balance).toBe(42);
+    expect(account.balanceRibbits).toBe(4_200_000_000);
   });
 
   it('should sync balance from API', async () => {
@@ -54,9 +54,9 @@ describe('Account Store', () => {
 
     await account.sync(addr, true);
 
-    expect(account.balance).toBe(5);
+    expect(account.balanceRibbits).toBe(500_000_000);
     const balanceCache = JSON.parse(localStorage.getItem('peppool_balance')!);
-    expect(balanceCache[addr]).toBe(5);
+    expect(balanceCache[addr]).toBe(500_000_000);
   });
 
   it('should skip sync when tip height unchanged', async () => {
@@ -81,7 +81,7 @@ describe('Account Store', () => {
 
     await account.sync(addr, true);
     expect(api.fetchAddressInfo).toHaveBeenCalled();
-    expect(account.balance).toBe(2);
+    expect(account.balanceRibbits).toBe(200_000_000);
   });
 
   it('should compute spendable balance excluding inscription UTXOs', async () => {
@@ -100,8 +100,8 @@ describe('Account Store', () => {
     const account = useAccountStore();
     await account.sync(addr, true);
 
-    expect(account.balance).toBe(3);
-    expect(account.spendableBalance).toBe(2.9999);
+    expect(account.balanceRibbits).toBe(300_000_000);
+    expect(account.spendableBalanceRibbits).toBe(299_990_000);
   });
 
   it('should fall back to total balance when UTXO fetch fails', async () => {
@@ -111,8 +111,8 @@ describe('Account Store', () => {
     const account = useAccountStore();
     await account.sync(addr, true);
 
-    expect(account.balance).toBe(1);
-    expect(account.spendableBalance).toBe(1);
+    expect(account.balanceRibbits).toBe(100_000_000);
+    expect(account.spendableBalanceRibbits).toBe(100_000_000);
   });
 
   it('should refresh transactions and cache them', async () => {
@@ -214,21 +214,21 @@ describe('Account Store', () => {
 
   it('should reset all state', () => {
     const account = useAccountStore();
-    account.balance = 5;
+    account.balanceRibbits = 500_000_000;
     account.transactions = [{ txid: 'x' } as any];
     account.canLoadMoreTransactions = true;
 
     account.reset();
 
-    expect(account.balance).toBe(0);
-    expect(account.spendableBalance).toBe(0);
+    expect(account.balanceRibbits).toBe(0);
+    expect(account.spendableBalanceRibbits).toBe(0);
     expect(account.transactions).toHaveLength(0);
     expect(account.canLoadMoreTransactions).toBe(false);
   });
 
-  it('should derive spendableBalance from cached balance and inscription value on reload', () => {
+  it('should derive spendableBalanceRibbits from cached balance and inscription value on reload', () => {
     // Simulates popup close/reopen: balance and inscription cache hit before sync runs.
-    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 3 }));
+    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 300_000_000 }));
     localStorage.setItem(
       'peppool_inscriptions',
       JSON.stringify({
@@ -241,7 +241,30 @@ describe('Account Store', () => {
     // Inscription store loads on first sync; pre-load to mimic wallet store init.
     useInscriptionStore().load(addr);
 
-    expect(account.balance).toBe(3);
-    expect(account.spendableBalance).toBe(2.9999);
+    expect(account.balanceRibbits).toBe(300_000_000);
+    expect(account.spendableBalanceRibbits).toBe(299_990_000);
+  });
+
+  it('should keep balanceRibbits as integer math without float drift', async () => {
+    // 0.1 + 0.2 PEP = 0.3 PEP in float math, but ribbits stay exact.
+    // 30_000_000 ribbits = 0.3 PEP. Inscriptions hold 10_000_000 ribbits = 0.1 PEP.
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue(30_000_000);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'a', vout: 0, value: 20_000_000, status: { confirmed: true } },
+      { txid: 'inscribed', vout: 0, value: 10_000_000, status: { confirmed: true } }
+    ]);
+    vi.mocked(api.fetchAddressInscriptions).mockResolvedValue({
+      inscriptions: [],
+      outputs: ['inscribed:0'],
+      total: 0
+    });
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
+    // Pure integer subtraction — no 0.19999999999999998 drift.
+    expect(account.spendableBalanceRibbits).toBe(20_000_000);
+    expect(Number.isInteger(account.balanceRibbits)).toBe(true);
+    expect(Number.isInteger(account.spendableBalanceRibbits)).toBe(true);
   });
 });

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -9,22 +9,23 @@ import {
   isInscriptionUtxo
 } from '@/utils/api';
 import { Transaction } from '@/models/Transaction';
-import { RIBBITS_PER_PEP, TXS_PER_PAGE } from '@/utils/constants';
+import { TXS_PER_PAGE } from '@/utils/constants';
 import { useInscriptionStore } from './inscriptions';
 
 export const useAccountStore = defineStore('account', () => {
   const inscriptionStore = useInscriptionStore();
 
   // ── State ──
-  const balance = ref<number>(0);
+  // Ribbits is the canonical unit (integer). Conversion to PEP/fiat happens at display time.
+  const balanceRibbits = ref<number>(0);
   const transactions = ref<Transaction[]>([]);
   const canLoadMoreTransactions = ref(false);
   let lastTipHeight = 0;
 
   // Spendable = total balance minus value locked in inscription UTXOs.
   // Derived so it survives popup close/reopen: both inputs come from cache.
-  const spendableBalance = computed(() =>
-    Math.max(0, balance.value - inscriptionStore.utxoValueRibbits / RIBBITS_PER_PEP)
+  const spendableBalanceRibbits = computed(() =>
+    Math.max(0, balanceRibbits.value - inscriptionStore.utxoValueRibbits)
   );
 
   // ── Cache (keyed by address) ──
@@ -40,7 +41,7 @@ export const useAccountStore = defineStore('account', () => {
     try {
       const balanceCache = getCache<number>('peppool_balance');
       if (balanceCache[address] != null) {
-        balance.value = balanceCache[address];
+        balanceRibbits.value = balanceCache[address];
       }
 
       const txCache = getCache<unknown[]>('peppool_transactions');
@@ -95,10 +96,9 @@ export const useAccountStore = defineStore('account', () => {
       if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
       lastTipHeight = tipHeight;
 
-      const totalRibbits = await fetchAddressInfo(address);
-      balance.value = totalRibbits / RIBBITS_PER_PEP;
+      balanceRibbits.value = await fetchAddressInfo(address);
       const balanceCache = getCache<number>('peppool_balance');
-      balanceCache[address] = balance.value;
+      balanceCache[address] = balanceRibbits.value;
       localStorage.setItem('peppool_balance', JSON.stringify(balanceCache));
 
       await refreshTransactions(address);
@@ -122,15 +122,15 @@ export const useAccountStore = defineStore('account', () => {
   }
 
   function reset() {
-    balance.value = 0;
+    balanceRibbits.value = 0;
     transactions.value = [];
     canLoadMoreTransactions.value = false;
     lastTipHeight = 0;
   }
 
   return {
-    balance,
-    spendableBalance,
+    balanceRibbits,
+    spendableBalanceRibbits,
     transactions,
     canLoadMoreTransactions,
     loadCachedData,

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -237,7 +237,7 @@ describe('Wallet Store', () => {
       expect.objectContaining({ peppool_active_account: '1' })
     );
     const account = useAccountStore();
-    expect(account.balance).toBe(1); // Should be refreshed on switch
+    expect(account.balanceRibbits).toBe(100_000_000); // Should be refreshed on switch
     expect(account.transactions).toHaveLength(0); // Should be cleared on switch
   });
 
@@ -313,8 +313,8 @@ describe('Wallet Store', () => {
     await store.refreshBalance(true);
 
     const account = useAccountStore();
-    expect(account.balance).toBe(3); // Total balance
-    expect(account.spendableBalance).toBe(2.9999); // Excludes inscription UTXO (10000 ribbits)
+    expect(account.balanceRibbits).toBe(300_000_000); // Total balance
+    expect(account.spendableBalanceRibbits).toBe(299_990_000); // Excludes inscription UTXO (10000 ribbits)
   });
 
   it('should fall back to total balance when inscription fetch fails', async () => {
@@ -334,8 +334,8 @@ describe('Wallet Store', () => {
     await store.refreshBalance(true);
 
     const account = useAccountStore();
-    expect(account.balance).toBe(1);
-    expect(account.spendableBalance).toBe(1); // Falls back to total
+    expect(account.balanceRibbits).toBe(100_000_000);
+    expect(account.spendableBalanceRibbits).toBe(100_000_000); // Falls back to total
   });
 
   it('should trigger lock after timeout', async () => {

--- a/src/utils/price.spec.ts
+++ b/src/utils/price.spec.ts
@@ -14,8 +14,10 @@ import {
   convert,
   format,
   formatFiat,
-  formatAmount
+  formatAmount,
+  formatPep
 } from './price';
+import { RIBBITS_PER_PEP } from './constants';
 
 describe('Price Module', () => {
   beforeEach(() => {
@@ -47,32 +49,32 @@ describe('Price Module', () => {
   });
 
   describe('convert', () => {
-    it('should convert PEP to fiat using current currency setting', async () => {
+    it('should convert ribbits to fiat using current currency setting', async () => {
       await refreshPrices();
-      expect(convert(10)).toBe(5); // 10 PEP * 0.5 USD
+      expect(convert(10 * RIBBITS_PER_PEP)).toBe(5); // 10 PEP * 0.5 USD
     });
 
     it('should respect currency setting', async () => {
       await refreshPrices();
       await saveSettings({ currency: 'EUR' });
-      expect(convert(10)).toBe(4); // 10 PEP * 0.4 EUR
+      expect(convert(10 * RIBBITS_PER_PEP)).toBe(4); // 10 PEP * 0.4 EUR
     });
 
     it('should return 0 when no prices loaded', () => {
-      expect(convert(10)).toBe(0);
+      expect(convert(10 * RIBBITS_PER_PEP)).toBe(0);
     });
   });
 
   describe('format', () => {
-    it('should format PEP amount as fiat string with symbol and code', async () => {
+    it('should format ribbits as fiat string with symbol and code', async () => {
       await refreshPrices();
-      expect(format(10)).toBe('$5.00 USD');
+      expect(format(10 * RIBBITS_PER_PEP)).toBe('$5.00 USD');
     });
 
     it('should format with EUR when currency is EUR', async () => {
       await refreshPrices();
       await saveSettings({ currency: 'EUR' });
-      expect(format(10)).toBe('€4.00 EUR');
+      expect(format(10 * RIBBITS_PER_PEP)).toBe('€4.00 EUR');
     });
 
     it('should handle zero balance', () => {
@@ -82,7 +84,15 @@ describe('Price Module', () => {
     it('should handle tiny values with extra precision', async () => {
       vi.mocked(api.fetchPepPrice).mockResolvedValue({ USD: 0.00001, EUR: 0.000009 });
       await refreshPrices();
-      expect(format(1)).toBe('$0.000010 USD');
+      expect(format(RIBBITS_PER_PEP)).toBe('$0.000010 USD');
+    });
+  });
+
+  describe('formatPep', () => {
+    it('should format ribbits as PEP string', () => {
+      expect(formatPep(RIBBITS_PER_PEP)).toBe('1 PEP');
+      expect(formatPep(123_456_789)).toBe('1.23456789 PEP');
+      expect(formatPep(0)).toBe('0 PEP');
     });
   });
 

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -1,6 +1,7 @@
 import { reactive } from 'vue';
 import { getSettings } from './settings';
 import { fetchPepPrice } from './api';
+import { RIBBITS_PER_PEP } from './constants';
 
 export interface Prices {
   USD: number;
@@ -43,21 +44,29 @@ export function clearPrices(): void {
 }
 
 /**
- * Convert a PEP amount to fiat using the current currency setting.
+ * Convert a ribbits amount to fiat using the current currency setting.
  */
-export function convert(pep: number): number {
+export function convert(ribbits: number): number {
   const { currency } = getSettings();
-  return pep * (prices[currency] || 0);
+  return (ribbits / RIBBITS_PER_PEP) * (prices[currency] || 0);
 }
 
 /**
- * Format a PEP amount as a fiat string using the current currency setting.
+ * Format a ribbits amount as a fiat string using the current currency setting.
  * e.g. "$1.23 USD"
  */
-export function format(pep: number): string {
+export function format(ribbits: number): string {
   const { currency } = getSettings();
   const symbol = CURRENCY_SYMBOLS[currency] || '';
-  return `${symbol}${formatFiat(convert(pep))} ${currency}`;
+  return `${symbol}${formatFiat(convert(ribbits))} ${currency}`;
+}
+
+/**
+ * Format a ribbits amount as a PEP string with comma grouping.
+ * e.g. 100_000_000 → "1 PEP", 123_456_789 → "1.23456789 PEP"
+ */
+export function formatPep(ribbits: number): string {
+  return `${formatAmount(ribbits / RIBBITS_PER_PEP)} PEP`;
 }
 
 /**

--- a/src/views/wallet/DashboardView.spec.ts
+++ b/src/views/wallet/DashboardView.spec.ts
@@ -41,7 +41,7 @@ describe('Wallet Views Navigation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccount = {
-      balance: 0,
+      balanceRibbits: 0,
       transactions: [],
       canLoadMoreTransactions: false,
       fetchMoreTransactions: vi.fn()
@@ -135,7 +135,7 @@ describe('Wallet Views Navigation', () => {
   });
 
   it('Dashboard: should adjust font size for large balances', async () => {
-    mockAccount.balance = 1000000000000000; // Force very long string
+    mockAccount.balanceRibbits = 1e23; // 1e15 PEP — long display string
     const wrapper = mount(DashboardView, { global });
 
     const balanceSpan = wrapper.find('span.text-offwhite');

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -3,13 +3,17 @@ import * as price from '@/utils/price';
 
 import { useApp } from '@/composables/useApp';
 import { onMounted, computed, ref } from 'vue';
+import { RIBBITS_PER_PEP } from '@/utils/constants';
 
 const { router, wallet: walletStore, account } = useApp();
 
 const isLoadingMore = ref(false);
 
+const balancePep = computed(() => account.balanceRibbits / RIBBITS_PER_PEP);
+const balanceDisplay = computed(() => price.formatAmount(balancePep.value));
+
 const balanceFontSize = computed(() => {
-  const len = price.formatAmount(account.balance).length;
+  const len = balanceDisplay.value.length;
 
   switch (true) {
     case len > 16:
@@ -65,12 +69,12 @@ async function handleLoadMore() {
       <p class="text-sm font-bold tracking-wider text-slate-400 uppercase">Total Balance</p>
       <div class="flex items-baseline justify-center space-x-2">
         <span class="text-offwhite font-bold transition-all duration-300" :class="balanceFontSize">
-          {{ price.formatAmount(account.balance) }}
+          {{ balanceDisplay }}
         </span>
         <span class="text-pep-green-light font-bold">PEP</span>
       </div>
       <p class="text-sm font-bold text-slate-500">
-        {{ price.format(account.balance) }}
+        {{ price.format(account.balanceRibbits) }}
       </p>
     </div>
 

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -90,7 +90,7 @@ describe('SendView', () => {
     mockSendTransaction.isInsufficientFunds.value = false;
 
     mockAccount = {
-      spendableBalance: 7
+      spendableBalanceRibbits: 700_000_000
     };
     mockWallet = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
@@ -174,7 +174,7 @@ describe('SendView', () => {
   });
 
   it('should display spendable balance on the send form', async () => {
-    mockAccount.spendableBalance = 5;
+    mockAccount.spendableBalanceRibbits = 500_000_000;
 
     const wrapper = mount(SendView, { global });
     // @ts-ignore

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -48,11 +48,11 @@ watch(txid, (newTxid) => {
 if (form.step === 2) form.step = 1;
 
 const displayBalance = computed(() => {
-  const bal = account.spendableBalance;
+  const ribbits = account.spendableBalanceRibbits;
   if (form.isFiatMode) {
-    return price.format(bal);
+    return price.format(ribbits);
   }
-  return `${parseFloat(bal.toFixed(8))} PEP`;
+  return price.formatPep(ribbits);
 });
 
 const canReview = computed(() => {


### PR DESCRIPTION
Closes #25.

## Summary
- Stores and composables now use ribbits (integers) as the canonical unit. PEP/fiat conversion happens only at display time.
- `account.balance` → `balanceRibbits`, `spendableBalance` → `spendableBalanceRibbits` (computed via integer subtraction, no float drift).
- `useSendTransaction` reads `account.spendableBalanceRibbits` directly — dropped the `Math.round(spendableBalance * RIBBITS_PER_PEP)` round-trip.
- `price.convert` / `price.format` now take ribbits; new `price.formatPep(ribbits)` returns a `"X PEP"` string.
- localStorage cache (`peppool_balance`) now stores integer ribbits.
- Bumped version to `0.2.2-dev` so `wipeCacheOnVersionChange` clears any legacy float-PEP cache on first load.

No behavioural change beyond removing the float round-trip and tightening the integer-balance test surface.

## Test plan
- [x] `vue-tsc -b` passes
- [x] `vitest` — all 507 tests pass
- [x] Added test verifying integer math has no float drift (`account.spec.ts`)
- [x] `vite build` succeeds