### PR TITLE
Extract useSessionDraft composable for Send + Import drafts

### DIFF
--- a/src/composables/useImportWallet.spec.ts
+++ b/src/composables/useImportWallet.spec.ts
@@ -87,7 +87,7 @@ describe('useImportWallet Composable', () => {
     vi.mocked(chrome.storage.session.get).mockResolvedValue({
       import_draft: {
         data: { mnemonic: 'stale word' },
-        timestamp: Date.now() - 6 * 60 * 1000
+        timestamp: Date.now() - (5 * 60 * 1000 + 1)
       }
     });
 

--- a/src/composables/useImportWallet.spec.ts
+++ b/src/composables/useImportWallet.spec.ts
@@ -58,8 +58,7 @@ describe('useImportWallet Composable', () => {
 
   it('should restore draft from session storage on mount', async () => {
     vi.mocked(chrome.storage.session.get).mockResolvedValue({
-      import_draft_mnemonic: 'restored word',
-      import_draft_ts: Date.now()
+      import_draft: { data: { mnemonic: 'restored word' }, timestamp: Date.now() }
     });
 
     const [composable] = withSetup(() => useImportWallet());
@@ -75,8 +74,28 @@ describe('useImportWallet Composable', () => {
     await flushPromises();
 
     expect(chrome.storage.session.set).toHaveBeenCalledWith(
-      expect.objectContaining({ import_draft_mnemonic: 'new word' })
+      expect.objectContaining({
+        import_draft: expect.objectContaining({
+          data: { mnemonic: 'new word' },
+          timestamp: expect.any(Number)
+        })
+      })
     );
+  });
+
+  it('should drop draft when older than 5-minute TTL', async () => {
+    vi.mocked(chrome.storage.session.get).mockResolvedValue({
+      import_draft: {
+        data: { mnemonic: 'stale word' },
+        timestamp: Date.now() - 6 * 60 * 1000
+      }
+    });
+
+    const [composable] = withSetup(() => useImportWallet());
+    await flushPromises();
+
+    expect(composable.mnemonic.value).toBe('');
+    expect(chrome.storage.session.remove).toHaveBeenCalledWith('import_draft');
   });
 
   it('should validate mnemonic and word list', () => {

--- a/src/composables/useImportWallet.ts
+++ b/src/composables/useImportWallet.ts
@@ -1,10 +1,9 @@
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed, onMounted } from 'vue';
 import { useApp } from '@/composables/useApp';
+import { useSessionDraft } from '@/composables/useSessionDraft';
 import { validateMnemonic, getInvalidMnemonicWords } from '@/utils/crypto';
 import { validatePasswordMatch } from '@/utils/form';
 
-const SESSION_KEY = 'import_draft_mnemonic';
-const SESSION_TS_KEY = 'import_draft_ts';
 const DRAFT_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 export function useImportWallet() {
@@ -26,33 +25,16 @@ export function useImportWallet() {
     return !!clean && invalidWords.value.length === 0 && validateMnemonic(clean);
   });
 
-  // Persistence logic
+  const draft = useSessionDraft({
+    key: 'import_draft',
+    source: () => ({ mnemonic: mnemonic.value }),
+    ttlMs: DRAFT_TTL_MS
+  });
+
   onMounted(async () => {
-    if (chrome?.storage?.session) {
-      const data = await chrome.storage.session.get([SESSION_KEY, SESSION_TS_KEY]);
-      const savedAt = Number(data[SESSION_TS_KEY]) || 0;
-      if (data[SESSION_KEY] && Date.now() - savedAt < DRAFT_TTL_MS) {
-        mnemonic.value = String(data[SESSION_KEY]);
-      } else {
-        clearSessionDraft();
-      }
-    }
+    const data = await draft.load();
+    if (data?.mnemonic) mnemonic.value = data.mnemonic;
   });
-
-  watch(mnemonic, (val) => {
-    if (chrome?.storage?.session) {
-      chrome.storage.session.set({
-        [SESSION_KEY]: val,
-        [SESSION_TS_KEY]: Date.now()
-      });
-    }
-  });
-
-  function clearSessionDraft() {
-    if (chrome?.storage?.session) {
-      chrome.storage.session.remove([SESSION_KEY, SESSION_TS_KEY]);
-    }
-  }
 
   async function importAction(password: string, confirmPassword: string) {
     const normalizedMnemonic = mnemonic.value.trim().toLowerCase();
@@ -67,7 +49,7 @@ export function useImportWallet() {
     if (passwordErrors.confirmPassword) throw new Error(passwordErrors.confirmPassword);
 
     await walletStore.importWallet(normalizedMnemonic, password);
-    clearSessionDraft();
+    await draft.clear();
     return true;
   }
 

--- a/src/composables/useImportWallet.ts
+++ b/src/composables/useImportWallet.ts
@@ -27,7 +27,7 @@ export function useImportWallet() {
 
   const draft = useSessionDraft({
     key: 'import_draft',
-    source: () => ({ mnemonic: mnemonic.value }),
+    data: () => ({ mnemonic: mnemonic.value }),
     ttlMs: DRAFT_TTL_MS
   });
 

--- a/src/composables/useSessionDraft.spec.ts
+++ b/src/composables/useSessionDraft.spec.ts
@@ -8,11 +8,11 @@ describe('useSessionDraft', () => {
     vi.clearAllMocks();
   });
 
-  it('saves an envelope { data, timestamp } when source changes', async () => {
+  it('saves an envelope { data, timestamp } when data changes', async () => {
     const value = ref('');
     const { load: _load } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value })
+      data: () => ({ value: value.value })
     });
 
     value.value = 'hello';
@@ -37,7 +37,7 @@ describe('useSessionDraft', () => {
     const value = ref('');
     const { load } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value })
+      data: () => ({ value: value.value })
     });
 
     expect(await load()).toEqual({ value: 'restored' });
@@ -51,7 +51,7 @@ describe('useSessionDraft', () => {
     const value = ref('');
     const { load } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value }),
+      data: () => ({ value: value.value }),
       ttlMs: 5_000
     });
 
@@ -65,7 +65,7 @@ describe('useSessionDraft', () => {
     const value = ref('');
     const { load } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value })
+      data: () => ({ value: value.value })
     });
 
     expect(await load()).toBeNull();
@@ -79,7 +79,7 @@ describe('useSessionDraft', () => {
     const value = ref('');
     const { load } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value })
+      data: () => ({ value: value.value })
     });
 
     expect(await load()).toBeNull();
@@ -89,7 +89,7 @@ describe('useSessionDraft', () => {
     const value = ref('');
     const { clear } = useSessionDraft({
       key: 'test_draft',
-      source: () => ({ value: value.value })
+      data: () => ({ value: value.value })
     });
 
     await clear();

--- a/src/composables/useSessionDraft.spec.ts
+++ b/src/composables/useSessionDraft.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ref } from 'vue';
+import { flushPromises } from '@vue/test-utils';
+import { useSessionDraft } from './useSessionDraft';
+
+describe('useSessionDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('saves an envelope { data, timestamp } when source changes', async () => {
+    const value = ref('');
+    const { load: _load } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value })
+    });
+
+    value.value = 'hello';
+    await flushPromises();
+
+    expect(chrome.storage.session.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        test_draft: expect.objectContaining({
+          data: { value: 'hello' },
+          timestamp: expect.any(Number)
+        })
+      })
+    );
+    void _load;
+  });
+
+  it('load returns envelope.data when present', async () => {
+    vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
+      test_draft: { data: { value: 'restored' }, timestamp: Date.now() }
+    });
+
+    const value = ref('');
+    const { load } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value })
+    });
+
+    expect(await load()).toEqual({ value: 'restored' });
+  });
+
+  it('load returns null and clears when ttl exceeded', async () => {
+    vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
+      test_draft: { data: { value: 'stale' }, timestamp: Date.now() - 10_000 }
+    });
+
+    const value = ref('');
+    const { load } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value }),
+      ttlMs: 5_000
+    });
+
+    expect(await load()).toBeNull();
+    expect(chrome.storage.session.remove).toHaveBeenCalledWith('test_draft');
+  });
+
+  it('load returns null when key is missing', async () => {
+    vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({});
+
+    const value = ref('');
+    const { load } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value })
+    });
+
+    expect(await load()).toBeNull();
+  });
+
+  it('load tolerates legacy/malformed payloads (no envelope)', async () => {
+    vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
+      test_draft: { value: 'old-shape-no-envelope' }
+    });
+
+    const value = ref('');
+    const { load } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value })
+    });
+
+    expect(await load()).toBeNull();
+  });
+
+  it('clear removes the key', async () => {
+    const value = ref('');
+    const { clear } = useSessionDraft({
+      key: 'test_draft',
+      source: () => ({ value: value.value })
+    });
+
+    await clear();
+    expect(chrome.storage.session.remove).toHaveBeenCalledWith('test_draft');
+  });
+});

--- a/src/composables/useSessionDraft.ts
+++ b/src/composables/useSessionDraft.ts
@@ -7,7 +7,7 @@ interface DraftEnvelope<T> {
 
 interface UseSessionDraftOptions<T> {
   key: string;
-  source: () => T;
+  data: () => T;
   ttlMs?: number;
 }
 
@@ -25,7 +25,7 @@ export function useSessionDraft<T extends object>(opts: UseSessionDraftOptions<T
 
   async function save() {
     await chrome.storage.session.set({
-      [opts.key]: { data: opts.source(), timestamp: Date.now() }
+      [opts.key]: { data: opts.data(), timestamp: Date.now() }
     });
   }
 
@@ -33,7 +33,7 @@ export function useSessionDraft<T extends object>(opts: UseSessionDraftOptions<T
     await chrome.storage.session.remove(opts.key);
   }
 
-  watch(opts.source, save);
+  watch(opts.data, save);
 
   return { load, clear };
 }

--- a/src/composables/useSessionDraft.ts
+++ b/src/composables/useSessionDraft.ts
@@ -1,0 +1,39 @@
+import { watch } from 'vue';
+
+interface DraftEnvelope<T> {
+  data: T;
+  timestamp: number;
+}
+
+interface UseSessionDraftOptions<T> {
+  key: string;
+  source: () => T;
+  ttlMs?: number;
+}
+
+export function useSessionDraft<T extends object>(opts: UseSessionDraftOptions<T>) {
+  async function load(): Promise<T | null> {
+    const result = await chrome.storage.session.get(opts.key);
+    const envelope = result[opts.key] as DraftEnvelope<T> | undefined;
+    if (!envelope || typeof envelope !== 'object' || !('data' in envelope)) return null;
+    if (opts.ttlMs && Date.now() - (envelope.timestamp ?? 0) > opts.ttlMs) {
+      await clear();
+      return null;
+    }
+    return envelope.data;
+  }
+
+  async function save() {
+    await chrome.storage.session.set({
+      [opts.key]: { data: opts.source(), timestamp: Date.now() }
+    });
+  }
+
+  async function clear() {
+    await chrome.storage.session.remove(opts.key);
+  }
+
+  watch(opts.source, save);
+
+  return { load, clear };
+}

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -217,7 +217,7 @@ describe('SendView', () => {
     vi.mocked(isValidAddress).mockReturnValue(false);
 
     vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
-      send_draft: { recipient: 'invalid-addr' }
+      send_draft: { data: { recipient: 'invalid-addr' }, timestamp: Date.now() }
     });
 
     const wrapper = mount(SendView, { global });

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -41,7 +41,7 @@ const form = useForm({
 // restart. Password is in-memory only — never written to storage.
 const draft = useSessionDraft({
   key: 'send_draft',
-  source: () => ({
+  data: () => ({
     recipient: form.recipient,
     amountRibbits: form.amountRibbits,
     isFiatMode: form.isFiatMode,

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, nextTick, onMounted, watch } from 'vue';
 import { useApp } from '@/composables/useApp';
 import { useSendTransaction } from '@/composables/useSendTransaction';
+import { useSessionDraft } from '@/composables/useSessionDraft';
 import { isValidAddress } from '@/utils/crypto';
 import { useForm } from '@/utils/form';
 import { UX_DELAY_FAST, UX_DELAY_SLOW } from '@/utils/constants';
@@ -38,34 +39,17 @@ const form = useForm({
 
 // Draft persists across popup close in chrome.storage.session, dies on browser
 // restart. Password is in-memory only — never written to storage.
-const SESSION_KEY = 'send_draft';
-const DRAFT_FIELDS = ['recipient', 'amountRibbits', 'isFiatMode', 'isMax', 'step', 'txid'] as const;
-
-async function loadDraft() {
-  if (!chrome?.storage?.session) return;
-  const data = await chrome.storage.session.get(SESSION_KEY);
-  const draft = data[SESSION_KEY] as Record<string, unknown> | undefined;
-  if (!draft) return;
-  for (const field of DRAFT_FIELDS) {
-    if (draft[field] !== undefined) (form as any)[field] = draft[field];
-  }
-  // Step 2 can't survive remount — password isn't persisted
-  if (form.step === 2) form.step = 1;
-}
-
-function saveDraft() {
-  if (!chrome?.storage?.session) return;
-  const draft: Record<string, unknown> = {};
-  for (const field of DRAFT_FIELDS) draft[field] = (form as any)[field];
-  chrome.storage.session.set({ [SESSION_KEY]: draft });
-}
-
-function clearDraft() {
-  if (!chrome?.storage?.session) return;
-  chrome.storage.session.remove(SESSION_KEY);
-}
-
-watch(() => DRAFT_FIELDS.map((f) => (form as any)[f]), saveDraft);
+const draft = useSessionDraft({
+  key: 'send_draft',
+  source: () => ({
+    recipient: form.recipient,
+    amountRibbits: form.amountRibbits,
+    isFiatMode: form.isFiatMode,
+    isMax: form.isMax,
+    step: form.step,
+    txid: form.txid
+  })
+});
 
 // Sync txid from composable to persisted form
 watch(txid, (newTxid) => {
@@ -177,13 +161,13 @@ async function handleSend() {
 
 function handleCancel() {
   form.reset();
-  clearDraft();
+  draft.clear();
   router.push('/dashboard');
 }
 
 function handleClose() {
   form.reset();
-  clearDraft();
+  draft.clear();
   router.push('/dashboard');
 }
 
@@ -192,9 +176,19 @@ function openExplorer() {
 }
 
 onMounted(async () => {
-  await loadDraft();
+  const data = await draft.load();
+  if (data) {
+    for (const [key, value] of Object.entries(data)) {
+      if (value !== undefined) (form as any)[key] = value;
+    }
+    // Step 2 can't survive remount — password isn't persisted
+    if (form.step === 2) form.step = 1;
+  }
 
-  // Sync persisted form data to tx object on mount
+  // Let the form's auto-clear-error watcher flush against the restored
+  // values before we run validation, so handleAddressBlur's error sticks.
+  await nextTick();
+
   if (form.recipient) {
     tx.value.recipient = form.recipient;
     handleAddressBlur();


### PR DESCRIPTION
Closes #28

## Summary
- New composable `src/composables/useSessionDraft.ts` wraps the load/save/clear/TTL pattern that `SendView` and `useImportWallet` were both implementing inline.
- Storage shape unified: every draft is now stored as a single `{ data, timestamp }` envelope under one key.
- Import draft collapses two keys (`import_draft_mnemonic` + `import_draft_ts`) into one (`import_draft`). Eliminates the race where one key could exist without the other.
- Renames the timestamp field from the cryptic `ts` to `timestamp` — easier to read in DevTools' storage panel.

## Behavioural notes
- Send still has no TTL and clears on cancel/close/lock.
- Import still has its 5-minute TTL and clears on success.
- `wallet.lock()` still wipes `send_draft` (key didn't change).
- Old session keys (`import_draft_mnemonic` / `import_draft_ts`) become orphans on first open after upgrade — `chrome.storage.session` is wiped on browser restart, so this self-heals.

## Test plan
- [x] `npx vitest run` — 512 passed (up from 505: +6 new composable tests, +1 new TTL test for import)
- [x] `npx vue-tsc -b` — clean
- [x] `npx vite build --logLevel warn` — builds
- [ ] Manual: type recipient/amount in Send → close popup → reopen → restored
- [ ] Manual: lock wallet → reopen Send → draft cleared
- [ ] Manual: type mnemonic on Import → close popup → reopen within 5 min → restored
- [ ] Manual: type mnemonic on Import → wait >5 min → reopen → cleared