### PR TITLE
Move last route from localStorage to chrome.storage.session

### DIFF
--- a/src/router/index.spec.ts
+++ b/src/router/index.spec.ts
@@ -10,6 +10,7 @@ vi.mock('@/stores/wallet', () => ({
 
 describe('Router Logic', () => {
   let walletStore: any;
+  let sessionStore: Record<string, string>;
 
   beforeEach(() => {
     setActivePinia(createPinia());
@@ -24,7 +25,20 @@ describe('Router Logic', () => {
       checkSession: vi.fn().mockResolvedValue(false)
     };
     vi.mocked(useWalletStore).mockReturnValue(walletStore);
-    localStorage.clear();
+
+    // Back chrome.storage.session with an in-memory map so router reads/writes round-trip
+    sessionStore = {};
+    vi.mocked(chrome.storage.session.get).mockImplementation(async (key: any) => {
+      const k = typeof key === 'string' ? key : key?.[0];
+      return k && sessionStore[k] !== undefined ? { [k]: sessionStore[k] } : {};
+    });
+    vi.mocked(chrome.storage.session.set).mockImplementation(async (items: any) => {
+      Object.assign(sessionStore, items);
+    });
+    vi.mocked(chrome.storage.session.remove).mockImplementation(async (key: any) => {
+      const keys = Array.isArray(key) ? key : [key];
+      for (const k of keys) delete sessionStore[k];
+    });
   });
 
   it('should redirect from dashboard to root if wallet is locked', async () => {
@@ -80,7 +94,7 @@ describe('Router Logic', () => {
   });
 
   it('should auto-restore last route if persistent and unlocked', async () => {
-    localStorage.setItem('peppool_last_route', '/send');
+    sessionStore.last_route = '/send';
     walletStore.isUnlocked = true;
     resetSessionCheck();
 
@@ -90,17 +104,17 @@ describe('Router Logic', () => {
   });
 
   it('should NOT auto-restore if route is NOT persistent', async () => {
-    localStorage.setItem('peppool_last_route', '/settings'); // settings has no persist:true
+    sessionStore.last_route = '/settings'; // settings has no persist:true
     walletStore.isUnlocked = true;
     resetSessionCheck();
 
     await router.push('/');
     expect(router.currentRoute.value.path).toBe('/dashboard');
-    expect(localStorage.getItem('peppool_last_route')).toBeNull();
+    expect(sessionStore.last_route).toBeUndefined();
   });
 
   it('should auto-restore public persistent routes even if locked', async () => {
-    localStorage.setItem('peppool_last_route', '/import'); // /import has persist:true
+    sessionStore.last_route = '/import'; // /import has persist:true
     walletStore.isUnlocked = false;
     resetSessionCheck();
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -80,7 +80,8 @@ router.beforeEach(async (to, _from, next) => {
     sessionChecked = true;
 
     // Auto-restore last route
-    const savedRoute = localStorage.getItem('peppool_last_route');
+    const data = await chrome.storage.session.get('last_route');
+    const savedRoute = data.last_route as string | undefined;
     if (savedRoute && to.path === '/') {
       const resolved = router.resolve(savedRoute);
       const isPersistent = resolved.matched.length > 0 && resolved.meta.persist;
@@ -92,7 +93,7 @@ router.beforeEach(async (to, _from, next) => {
       if (isPersistent && (walletStore.isUnlocked || isPublic)) {
         return next(savedRoute);
       }
-      localStorage.removeItem('peppool_last_route');
+      await chrome.storage.session.remove('last_route');
     }
   }
 
@@ -114,12 +115,12 @@ router.beforeEach(async (to, _from, next) => {
 });
 
 // Save route after each navigation ONLY if persist is true
-router.afterEach((to) => {
+router.afterEach(async (to) => {
   if (to.meta.persist) {
-    localStorage.setItem('peppool_last_route', to.path);
+    await chrome.storage.session.set({ last_route: to.path });
   } else {
     // If we navigate to a non-persistent page (like Settings or Dashboard),
     // clear the last route so we default back to Dashboard next time.
-    localStorage.removeItem('peppool_last_route');
+    await chrome.storage.session.remove('last_route');
   }
 });

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -21,7 +21,6 @@ describe('wipeCacheOnVersionChange', () => {
     localStorage.setItem('peppool_auth_token', 'tok');
     localStorage.setItem('peppool_auth_expires', '999');
     localStorage.setItem('peppool_auth_address', 'Paddr');
-    localStorage.setItem('peppool_last_route', '/send');
 
     const wiped = wipeCacheOnVersionChange();
 
@@ -33,7 +32,6 @@ describe('wipeCacheOnVersionChange', () => {
     expect(localStorage.getItem('peppool_auth_token')).toBeNull();
     expect(localStorage.getItem('peppool_auth_expires')).toBeNull();
     expect(localStorage.getItem('peppool_auth_address')).toBeNull();
-    expect(localStorage.getItem('peppool_last_route')).toBeNull();
   });
 
   it('should preserve vault (only persistent localStorage key)', () => {


### PR DESCRIPTION
## Summary
- Moves the persisted "last route" key (used to restore the user's view on popup reopen) from `localStorage` (`peppool_last_route`) to `chrome.storage.session` (`last_route`), matching the pattern already used for the send draft and import draft.
- Result: route hint clears automatically on browser/extension restart, and no longer leaves a stale entry in `localStorage`.

## Test plan
- [x] `npm run format`
- [x] `npx vitest run --reporter=dot --silent=true` — 505/505 passing
- [x] `npm run build` (vue-tsc + vite) clean
- [ ] Manual: navigate to `/send`, close popup, reopen — restored to `/send`
- [ ] Manual: navigate to `/settings`, close popup, reopen — lands on `/dashboard`
- [ ] Manual: restart browser — lands on `/dashboard` (session cleared)