### PR TITLE
Extract useSession composable from wallet store

### DIFF
--- a/src/composables/useSession.spec.ts
+++ b/src/composables/useSession.spec.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ref } from 'vue';
+import { useSession } from './useSession';
+
+vi.mock('@/utils/encryption', () => ({
+  importKey: vi.fn(() => Promise.resolve({ type: 'secret' } as CryptoKey)),
+  decryptWithKey: vi.fn(() => Promise.resolve('test mnemonic'))
+}));
+
+import { decryptWithKey } from '@/utils/encryption';
+
+function makeSession(initialMnemonic: string | null = 'pbkdf2:vault') {
+  const encryptedMnemonic = ref<string | null>(initialMnemonic);
+  const session = useSession({
+    encryptedMnemonic,
+    getLockDuration: () => 15
+  });
+  return { session, encryptedMnemonic };
+}
+
+describe('useSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('cacheKeyBytes', () => {
+    it('persists key as hex to chrome.storage.session and zeros input', async () => {
+      const { session } = makeSession();
+      const bytes = new Uint8Array([0x0a, 0xff, 0x10]);
+
+      await session.cacheKeyBytes(bytes);
+
+      expect(chrome.storage.session.set).toHaveBeenCalledWith({ dataKey: '0aff10' });
+      expect(session.hasSessionKey.value).toBe(true);
+      // Input bytes wiped — prevents the raw key from lingering on the heap
+      expect(Array.from(bytes)).toEqual([0, 0, 0]);
+    });
+  });
+
+  describe('checkSession', () => {
+    it('returns false when chrome.storage has no session data', async () => {
+      vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({});
+      const { session } = makeSession();
+
+      const result = await session.checkSession();
+
+      expect(result).toBe(false);
+      expect(session.isUnlocked.value).toBe(false);
+    });
+
+    it('clears entire session and returns false when expired', async () => {
+      // sessionStartTime older than 15 minutes
+      const expiredStart = Date.now() - 16 * 60 * 1000;
+      vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
+        sessionStartTime: expiredStart,
+        dataKey: 'aabb'
+      });
+      const { session } = makeSession();
+
+      const result = await session.checkSession();
+
+      expect(result).toBe(false);
+      // Expiry wipes everything in session storage, not just key/timestamp —
+      // form drafts belong to the same session as the auth key.
+      expect(chrome.storage.session.clear).toHaveBeenCalled();
+    });
+
+    it('restores session when within lock duration', async () => {
+      vi.mocked(chrome.storage.session.get).mockResolvedValueOnce({
+        sessionStartTime: Date.now(),
+        dataKey: '0102030405060708091011121314151617181920212223242526272829303132'
+      });
+      const { session } = makeSession();
+
+      const result = await session.checkSession();
+
+      expect(result).toBe(true);
+      expect(session.isUnlocked.value).toBe(true);
+      expect(session.hasSessionKey.value).toBe(true);
+    });
+  });
+
+  describe('resetLockTimer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('no-ops when wallet is locked', async () => {
+      const { session } = makeSession();
+
+      await session.resetLockTimer();
+
+      expect(chrome.storage.session.set).not.toHaveBeenCalledWith(
+        expect.objectContaining({ sessionStartTime: expect.any(Number) })
+      );
+    });
+
+    it('schedules lock after lockDuration when unlocked', async () => {
+      const { session } = makeSession();
+      session.markUnlocked();
+
+      await session.resetLockTimer();
+      expect(session.isUnlocked.value).toBe(true);
+
+      vi.advanceTimersByTime(14 * 60 * 1000);
+      expect(session.isUnlocked.value).toBe(true);
+
+      vi.advanceTimersByTime(2 * 60 * 1000);
+      // setTimeout fires lock() which is async — flush microtasks
+      await vi.runOnlyPendingTimersAsync();
+      expect(session.isUnlocked.value).toBe(false);
+    });
+
+    it('debouncedResetLockTimer skips while debounce is active', async () => {
+      const { session } = makeSession();
+      session.markUnlocked();
+
+      await session.debouncedResetLockTimer();
+      vi.mocked(chrome.storage.session.set).mockClear();
+
+      // Second call within debounce window should be a no-op
+      await session.debouncedResetLockTimer();
+      expect(chrome.storage.session.set).not.toHaveBeenCalled();
+
+      // After debounce window, calls go through again
+      vi.advanceTimersByTime(1100);
+      await session.debouncedResetLockTimer();
+      expect(chrome.storage.session.set).toHaveBeenCalled();
+    });
+  });
+
+  describe('withMnemonic', () => {
+    it('throws when sessionKey not loaded', async () => {
+      const { session } = makeSession();
+      await expect(session.withMnemonic((m) => m)).rejects.toThrow('Wallet is locked');
+    });
+
+    it('throws when encryptedMnemonic is null', async () => {
+      const { session } = makeSession(null);
+      await session.cacheKeyBytes(new Uint8Array(32));
+      await expect(session.withMnemonic((m) => m)).rejects.toThrow('Wallet is locked');
+    });
+
+    it('decrypts and runs callback with mnemonic when unlocked', async () => {
+      const { session } = makeSession();
+      await session.cacheKeyBytes(new Uint8Array(32));
+
+      const result = await session.withMnemonic((m) => m.toUpperCase());
+
+      expect(decryptWithKey).toHaveBeenCalled();
+      expect(result).toBe('TEST MNEMONIC');
+    });
+  });
+
+  describe('lock', () => {
+    it('clears session storage, state, and resets flags', async () => {
+      const { session } = makeSession();
+      await session.cacheKeyBytes(new Uint8Array(32));
+      session.markUnlocked();
+
+      await session.lock();
+
+      expect(session.isUnlocked.value).toBe(false);
+      expect(session.hasSessionKey.value).toBe(false);
+      // Full clear, not selective remove — drafts and any other session-scoped
+      // state die with the auth session.
+      expect(chrome.storage.session.clear).toHaveBeenCalled();
+    });
+
+    it('subsequent withMnemonic throws after lock', async () => {
+      const { session } = makeSession();
+      await session.cacheKeyBytes(new Uint8Array(32));
+      session.markUnlocked();
+
+      await session.lock();
+
+      await expect(session.withMnemonic((m) => m)).rejects.toThrow('Wallet is locked');
+    });
+  });
+
+  describe('markUnlocked', () => {
+    it('flips isUnlocked to true', () => {
+      const { session } = makeSession();
+      expect(session.isUnlocked.value).toBe(false);
+
+      session.markUnlocked();
+
+      expect(session.isUnlocked.value).toBe(true);
+    });
+  });
+});

--- a/src/composables/useSession.ts
+++ b/src/composables/useSession.ts
@@ -1,0 +1,145 @@
+import { ref, type Ref } from 'vue';
+import { decryptWithKey, importKey } from '@/utils/encryption';
+
+interface UseSessionOptions {
+  encryptedMnemonic: Ref<string | null>;
+  getLockDuration: () => number;
+}
+
+async function setAutoLockAlarm(delayMinutes: number) {
+  if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
+    try {
+      await chrome.runtime.sendMessage({ type: 'set-auto-lock', delayMinutes });
+    } catch {
+      /* background worker unavailable */
+    }
+  }
+}
+
+async function clearAutoLockAlarm() {
+  if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
+    try {
+      await chrome.runtime.sendMessage({ type: 'clear-auto-lock' });
+    } catch {
+      /* background worker unavailable */
+    }
+  }
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+export function useSession(opts: UseSessionOptions) {
+  let sessionKey: CryptoKey | null = null;
+  const hasSessionKey = ref(false);
+  const isUnlocked = ref(false);
+
+  let lockTimer: ReturnType<typeof setTimeout> | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function cacheKeyBytes(keyBytes: Uint8Array) {
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.set({ dataKey: toHex(keyBytes) });
+    }
+    sessionKey = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
+    hasSessionKey.value = true;
+    keyBytes.fill(0);
+  }
+
+  async function resetLockTimer() {
+    if (!isUnlocked.value) return;
+
+    const durationMs = opts.getLockDuration() * 60 * 1000;
+
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.set({ sessionStartTime: Date.now() });
+    }
+
+    if (lockTimer) clearTimeout(lockTimer);
+    lockTimer = setTimeout(() => lock(), durationMs);
+    await setAutoLockAlarm(opts.getLockDuration());
+  }
+
+  async function debouncedResetLockTimer() {
+    if (!isUnlocked.value || debounceTimer) return;
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null;
+    }, 1000);
+    await resetLockTimer();
+  }
+
+  async function checkSession(): Promise<boolean> {
+    if (typeof chrome === 'undefined' || !chrome.storage?.session) return false;
+
+    const sessionData = await chrome.storage.session.get(['sessionStartTime', 'dataKey']);
+    const sessionStart = sessionData.sessionStartTime as number | undefined;
+    const hex = sessionData.dataKey as string | undefined;
+
+    if (!sessionStart || !hex) return false;
+
+    const elapsed = Date.now() - sessionStart;
+    if (elapsed >= opts.getLockDuration() * 60 * 1000) {
+      await chrome.storage.session.clear();
+      return false;
+    }
+
+    try {
+      const rawBytes = fromHex(hex);
+      sessionKey = await importKey(rawBytes.buffer as ArrayBuffer, ['decrypt']);
+      rawBytes.fill(0);
+      hasSessionKey.value = true;
+      isUnlocked.value = true;
+    } catch {
+      isUnlocked.value = false;
+      return false;
+    }
+
+    await resetLockTimer();
+    return true;
+  }
+
+  async function withMnemonic<T>(fn: (mnemonic: string) => T | Promise<T>): Promise<T> {
+    if (!sessionKey || !opts.encryptedMnemonic.value) {
+      throw new Error('Wallet is locked');
+    }
+    const mnemonic = await decryptWithKey(opts.encryptedMnemonic.value, sessionKey);
+    return fn(mnemonic);
+  }
+
+  async function lock() {
+    isUnlocked.value = false;
+    sessionKey = null;
+    hasSessionKey.value = false;
+    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
+      await chrome.storage.session.clear();
+    }
+    if (lockTimer) clearTimeout(lockTimer);
+    lockTimer = null;
+    await clearAutoLockAlarm();
+  }
+
+  function markUnlocked() {
+    isUnlocked.value = true;
+  }
+
+  return {
+    hasSessionKey,
+    isUnlocked,
+    cacheKeyBytes,
+    resetLockTimer,
+    debouncedResetLockTimer,
+    checkSession,
+    withMnemonic,
+    lock,
+    markUnlocked
+  };
+}

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -201,11 +201,7 @@ describe('Wallet Store', () => {
       'peppool_permissions',
       'peppool_lockout'
     ]);
-    expect(chrome.storage.session.remove).toHaveBeenCalledWith([
-      'sessionStartTime',
-      'dataKey',
-      'send_draft'
-    ]);
+    expect(chrome.storage.session.clear).toHaveBeenCalled();
   });
 
   it('encryptedMnemonic should be exposed as readonly', async () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -7,11 +7,12 @@ import {
   getDerivationPath,
   parseDerivationPath
 } from '@/utils/crypto';
-import { encrypt, decrypt, deriveKeyBytes, decryptWithKey, importKey } from '@/utils/encryption';
+import { encrypt, decrypt, deriveKeyBytes } from '@/utils/encryption';
 import { hasAddressActivity } from '@/utils/api';
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { refreshPrices, clearPrices } from '@/utils/price';
 import { getWalletState, saveWalletState, clearAllSettings } from '@/utils/settings';
+import { useSession } from '@/composables/useSession';
 import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';
 import { useInscriptionStore } from './inscriptions';
@@ -21,27 +22,6 @@ export interface Account {
   address: string;
   path: string;
   label: string;
-}
-
-// ── Background worker messaging ────────────────────────────────────────────
-async function setAutoLockAlarm(delayMinutes: number) {
-  if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
-    try {
-      await chrome.runtime.sendMessage({ type: 'set-auto-lock', delayMinutes });
-    } catch {
-      /* background worker unavailable */
-    }
-  }
-}
-
-async function clearAutoLockAlarm() {
-  if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
-    try {
-      await chrome.runtime.sendMessage({ type: 'clear-auto-lock' });
-    } catch {
-      /* background worker unavailable */
-    }
-  }
 }
 
 export const useWalletStore = defineStore('wallet', () => {
@@ -57,15 +37,15 @@ export const useWalletStore = defineStore('wallet', () => {
   const accounts = ref<Account[]>(walletStateData.accounts);
   const activeAccountIndex = ref<number>(walletStateData.activeAccountIndex);
   const encryptedMnemonic = ref<string | null>(localStorage.getItem('peppool_vault'));
-  let sessionKey: CryptoKey | null = null;
-  const hasSessionKey = ref(false);
-  const isUnlocked = ref(false);
 
-  let lockTimer: ReturnType<typeof setTimeout> | null = null;
+  const session = useSession({
+    encryptedMnemonic,
+    getLockDuration: () => settings.lockDuration
+  });
 
   // ── Computed ──
   const isCreated = computed(() => !!encryptedMnemonic.value);
-  const isMnemonicLoaded = computed(() => hasSessionKey.value);
+  const isMnemonicLoaded = computed(() => session.hasSessionKey.value);
   const activeAccount = computed(() => accounts.value[activeAccountIndex.value] || null);
   const address = computed(() => activeAccount.value?.address || null);
 
@@ -78,71 +58,13 @@ export const useWalletStore = defineStore('wallet', () => {
   // ── Actions ──
   async function checkSession() {
     await lockout.restore();
-    if (typeof chrome === 'undefined' || !chrome.storage?.session) return false;
-
-    const sessionData = await chrome.storage.session.get(['sessionStartTime', 'dataKey']);
-    const sessionStart = sessionData.sessionStartTime as number | undefined;
-    const hex = sessionData.dataKey as string | undefined;
-
-    if (!sessionStart || !hex) return false;
-
-    const elapsed = Date.now() - sessionStart;
-    if (elapsed >= settings.lockDuration * 60 * 1000) {
-      await chrome.storage.session.remove(['sessionStartTime', 'dataKey']);
-      return false;
-    }
-
-    try {
-      const rawBytes = fromHex(hex);
-      sessionKey = await importKey(rawBytes.buffer as ArrayBuffer, ['decrypt']);
-      rawBytes.fill(0);
-      hasSessionKey.value = true;
-      isUnlocked.value = true;
-    } catch {
-      isUnlocked.value = false;
-      return false;
-    }
-
-    resetLockTimer();
-    return true;
-  }
-
-  async function resetLockTimer() {
-    if (!isUnlocked.value) return;
-
-    const durationMs = settings.lockDuration * 60 * 1000;
-
-    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-      await chrome.storage.session.set({ sessionStartTime: Date.now() });
-    }
-
-    if (lockTimer) clearTimeout(lockTimer);
-    lockTimer = setTimeout(() => lock(), durationMs);
-    await setAutoLockAlarm(settings.lockDuration);
-  }
-
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  async function debouncedResetLockTimer() {
-    if (!isUnlocked.value || debounceTimer) return;
-    debounceTimer = setTimeout(() => {
-      debounceTimer = null;
-    }, 1000);
-    await resetLockTimer();
-  }
-
-  async function withMnemonic<T>(fn: (mnemonic: string) => T | Promise<T>): Promise<T> {
-    if (!sessionKey || !encryptedMnemonic.value) {
-      throw new Error('Wallet is locked');
-    }
-    const mnemonic = await decryptWithKey(encryptedMnemonic.value, sessionKey);
-    return fn(mnemonic);
+    return session.checkSession();
   }
 
   async function refreshAuth() {
-    if (!sessionKey) return;
+    if (!session.hasSessionKey.value) return;
     try {
-      await withMnemonic(async (mnemonic) => {
+      await session.withMnemonic(async (mnemonic) => {
         const authKey = deriveAuthKeyPair(mnemonic);
         await ensureAuth(authKey.address, authKey.privateKey, authKey.compressed);
       });
@@ -158,7 +80,7 @@ export const useWalletStore = defineStore('wallet', () => {
       await refreshPrices();
 
       await accountStore.sync(address.value, force);
-      await resetLockTimer();
+      await session.resetLockTimer();
     } catch (e) {
       console.error('Failed to refresh balance', e);
     }
@@ -169,33 +91,12 @@ export const useWalletStore = defineStore('wallet', () => {
     await importWallet(mnemonic, password);
   }
 
-  function toHex(bytes: Uint8Array): string {
-    return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
-  }
-
-  function fromHex(hex: string): Uint8Array {
-    const bytes = new Uint8Array(hex.length / 2);
-    for (let i = 0; i < hex.length; i += 2) {
-      bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
-    }
-    return bytes;
-  }
-
-  async function cacheKeyBytes(keyBytes: Uint8Array) {
-    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-      await chrome.storage.session.set({ dataKey: toHex(keyBytes) });
-    }
-    sessionKey = await importKey(keyBytes.buffer as ArrayBuffer, ['decrypt']);
-    hasSessionKey.value = true;
-    keyBytes.fill(0);
-  }
-
   async function importWallet(mnemonic: string, password: string) {
     const walletAddress = deriveAddress(mnemonic, 0, 0);
     const encrypted = await encrypt(mnemonic, password);
 
     encryptedMnemonic.value = encrypted;
-    await cacheKeyBytes(await deriveKeyBytes(password, encrypted));
+    await session.cacheKeyBytes(await deriveKeyBytes(password, encrypted));
 
     const initialAccount: Account = {
       address: walletAddress,
@@ -205,12 +106,12 @@ export const useWalletStore = defineStore('wallet', () => {
 
     accounts.value = [initialAccount];
     activeAccountIndex.value = 0;
-    isUnlocked.value = true;
+    session.markUnlocked();
 
     localStorage.setItem('peppool_vault', encrypted);
     await saveWalletState({ accounts: accounts.value, activeAccountIndex: 0 });
 
-    await resetLockTimer();
+    await session.resetLockTimer();
     await lockout.reset();
     await refreshBalance(true);
     await discoverAccounts(mnemonic);
@@ -267,9 +168,9 @@ export const useWalletStore = defineStore('wallet', () => {
       const mnemonic = await decrypt(encryptedMnemonic.value, password);
       verifyVaultIntegrity(mnemonic);
 
-      await cacheKeyBytes(await deriveKeyBytes(password, encryptedMnemonic.value));
-      isUnlocked.value = true;
-      await resetLockTimer();
+      await session.cacheKeyBytes(await deriveKeyBytes(password, encryptedMnemonic.value));
+      session.markUnlocked();
+      await session.resetLockTimer();
       await lockout.reset();
       await refreshBalance(true);
       return true;
@@ -283,25 +184,16 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   async function lock() {
-    isUnlocked.value = false;
-    sessionKey = null;
-    hasSessionKey.value = false;
-    if (typeof chrome !== 'undefined' && chrome.storage?.session) {
-      await chrome.storage.session.remove(['sessionStartTime', 'dataKey', 'send_draft']);
-    }
-    if (lockTimer) clearTimeout(lockTimer);
-    lockTimer = null;
+    await session.lock();
     localStorage.removeItem('peppool_transactions');
-    await clearAutoLockAlarm();
   }
 
   async function resetWallet() {
+    await session.lock();
+
     accounts.value = [];
     activeAccountIndex.value = 0;
     encryptedMnemonic.value = null;
-    sessionKey = null;
-    hasSessionKey.value = false;
-    isUnlocked.value = false;
     clearPrices();
     accountStore.reset();
     clearAuth();
@@ -314,18 +206,13 @@ export const useWalletStore = defineStore('wallet', () => {
       }
     }
 
-    // Wipe chrome.storage (settings, accounts, permissions, session)
+    // Wipe chrome.storage (settings, accounts, permissions)
     await clearAllSettings();
     if (typeof chrome !== 'undefined' && chrome.storage) {
       await chrome.storage.local.remove(['peppool_permissions', 'peppool_lockout']);
-      await chrome.storage.session?.remove(['sessionStartTime', 'dataKey', 'send_draft']);
     }
 
-    if (lockTimer) clearTimeout(lockTimer);
-    lockTimer = null;
-
     lockout.reset();
-    clearAutoLockAlarm();
   }
 
   async function switchAccount(index: number) {
@@ -338,10 +225,10 @@ export const useWalletStore = defineStore('wallet', () => {
   }
 
   async function addAccount(label?: string) {
-    if (!sessionKey) {
+    if (!session.hasSessionKey.value) {
       throw new Error('Wallet is locked. Please re-authenticate.');
     }
-    await withMnemonic(async (mnemonic) => {
+    await session.withMnemonic(async (mnemonic) => {
       const nextIndex = accounts.value.length;
       const newAddress = deriveAddress(mnemonic, nextIndex, 0);
       const newAccount: Account = {
@@ -382,7 +269,7 @@ export const useWalletStore = defineStore('wallet', () => {
     activeAccount,
     address,
     encryptedMnemonic: readonly(encryptedMnemonic),
-    isUnlocked,
+    isUnlocked: session.isUnlocked,
     isCreated,
     isMnemonicLoaded,
     lockout,
@@ -390,7 +277,7 @@ export const useWalletStore = defineStore('wallet', () => {
     createWallet,
     importWallet,
     refreshBalance,
-    resetLockTimer: debouncedResetLockTimer,
+    resetLockTimer: session.debouncedResetLockTimer,
     startPolling,
     stopPolling,
     unlock,
@@ -399,7 +286,7 @@ export const useWalletStore = defineStore('wallet', () => {
     switchAccount,
     addAccount,
     renameAccount,
-    withMnemonic,
+    withMnemonic: session.withMnemonic,
     updateVault
   };
 });

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -64,12 +64,9 @@ describe('Wallet Lock vs Reset Behavior', () => {
     expect(store.isMnemonicLoaded).toBe(false);
     expect(localStorage.getItem('peppool_transactions')).toBeNull();
 
-    // CHECK: Send draft wiped from chrome.storage.session for privacy
-    expect(chrome.storage.session.remove).toHaveBeenCalledWith([
-      'sessionStartTime',
-      'dataKey',
-      'send_draft'
-    ]);
+    // CHECK: Entire session storage wiped — lock ends the session, so any draft
+    // (send, import, etc.) goes with it. Avoids hardcoding a per-form key allowlist.
+    expect(chrome.storage.session.clear).toHaveBeenCalled();
   });
 
   it('resetWallet() should wipe EVERYTHING', async () => {

--- a/src/vitest-setup.ts
+++ b/src/vitest-setup.ts
@@ -17,7 +17,8 @@ const chromeMock = {
     session: {
       get: vi.fn().mockResolvedValue({}),
       set: vi.fn().mockResolvedValue(undefined),
-      remove: vi.fn().mockResolvedValue(undefined)
+      remove: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined)
     }
   },
   runtime: {


### PR DESCRIPTION
## Summary
- Extracts session/lock concerns from `src/stores/wallet.ts` (sessionKey, lock timer, debounce, `chrome.storage.session` reads, bg auto-lock alarm, hex helpers) into a new `src/composables/useSession.ts`.
- `wallet.ts` shrinks from 405 → ~245 lines; remaining store is vault lifecycle + active-account view.
- **Behavior change:** `lock()` now calls `chrome.storage.session.clear()` instead of selectively removing `['sessionStartTime', 'dataKey', 'send_draft']`. Lock = session end, so all session-scoped state (including form drafts from any feature) goes with it. No more hardcoded per-form key allowlist.
- Same change in `checkSession`'s expiry branch.

## Test plan
- [x] `npx vitest run` — 525/525 passing (13 new tests for useSession)
- [x] `vue-tsc -b` clean
- [x] `npm run build` clean
- [ ] Manual: unlock → fill send draft → lock → unlock → verify draft is gone