### PR TITLE
Centralize storage keys

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -10,6 +10,7 @@
  */
 
 import { loadPermissions, savePermissions, hasPermission, revokeOrigin } from '@/utils/permissions';
+import { CHROME_STORAGE_KEYS } from '@/constants/storage';
 
 const ALARM_NAME_AUTOLOCK = 'peppool-inactivity-lock';
 
@@ -183,11 +184,11 @@ async function handleDappRequest(
  * Returns the active account's address from chrome.storage, or null.
  */
 async function getActiveAddress(): Promise<string | null> {
-  const activeData = (await chrome.storage.local.get('peppool_active_account')) as any;
-  const activeAccountIndex = parseInt(activeData.peppool_active_account || '0');
+  const activeData = (await chrome.storage.local.get(CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT)) as any;
+  const activeAccountIndex = parseInt(activeData[CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT] || '0');
 
-  const accountsData = (await chrome.storage.local.get('peppool_accounts')) as any;
-  const accountsRaw = accountsData.peppool_accounts as string | undefined;
+  const accountsData = (await chrome.storage.local.get(CHROME_STORAGE_KEYS.ACCOUNTS)) as any;
+  const accountsRaw = accountsData[CHROME_STORAGE_KEYS.ACCOUNTS] as string | undefined;
   const accounts = accountsRaw ? JSON.parse(accountsRaw) : [];
   return accounts[activeAccountIndex]?.address || null;
 }

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,34 @@
+/**
+ * All persistent storage keys used by the wallet.
+ *
+ * Centralizing keys here prevents cross-file drift (e.g. a wipe path that
+ * misses a renamed key) and makes the storage surface easy to audit.
+ *
+ * Session storage keys (chrome.storage.session) are intentionally excluded —
+ * they are short-lived, scoped to a single composable's call sites, and
+ * don't share the cross-file consumer pattern.
+ */
+
+export const STORAGE_PREFIX = 'peppool_';
+
+// Persisted in browser localStorage (synchronous, survives extension reload).
+export const LOCAL_STORAGE_KEYS = {
+  VAULT: 'peppool_vault',
+  TRANSACTIONS: 'peppool_transactions',
+  BALANCE: 'peppool_balance',
+  PRICES: 'peppool_prices',
+  INSCRIPTIONS: 'peppool_inscriptions',
+  APP_VERSION: 'peppool_app_version',
+  AUTH_TOKEN: 'peppool_auth_token',
+  AUTH_EXPIRES: 'peppool_auth_expires',
+  AUTH_ADDRESS: 'peppool_auth_address'
+} as const;
+
+// Persisted in chrome.storage.local (async, accessible from background worker).
+export const CHROME_STORAGE_KEYS = {
+  LOCKOUT: 'peppool_lockout',
+  PERMISSIONS: 'peppool_permissions',
+  SETTINGS: 'peppool_settings',
+  ACCOUNTS: 'peppool_accounts',
+  ACTIVE_ACCOUNT: 'peppool_active_account'
+} as const;

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -11,6 +11,7 @@ import {
 import { Transaction } from '@/models/Transaction';
 import { TXS_PER_PAGE } from '@/utils/constants';
 import { useInscriptionStore } from './inscriptions';
+import { LOCAL_STORAGE_KEYS } from '@/constants/storage';
 
 export const useAccountStore = defineStore('account', () => {
   const inscriptionStore = useInscriptionStore();
@@ -39,12 +40,12 @@ export const useAccountStore = defineStore('account', () => {
 
   function loadCachedData(address: string) {
     try {
-      const balanceCache = getCache<number>('peppool_balance');
+      const balanceCache = getCache<number>(LOCAL_STORAGE_KEYS.BALANCE);
       if (balanceCache[address] != null) {
         balanceRibbits.value = balanceCache[address];
       }
 
-      const txCache = getCache<unknown[]>('peppool_transactions');
+      const txCache = getCache<unknown[]>(LOCAL_STORAGE_KEYS.TRANSACTIONS);
       if (txCache[address]) {
         transactions.value = txCache[address].map((raw: any) => new Transaction(raw, address));
       }
@@ -59,9 +60,9 @@ export const useAccountStore = defineStore('account', () => {
       const rawTxs = await fetchTransactions(address);
       transactions.value = rawTxs.map((raw) => new Transaction(raw, address));
       canLoadMoreTransactions.value = rawTxs.length >= TXS_PER_PAGE;
-      const txCache = getCache<unknown[]>('peppool_transactions');
+      const txCache = getCache<unknown[]>(LOCAL_STORAGE_KEYS.TRANSACTIONS);
       txCache[address] = rawTxs.slice(0, 20);
-      localStorage.setItem('peppool_transactions', JSON.stringify(txCache));
+      localStorage.setItem(LOCAL_STORAGE_KEYS.TRANSACTIONS, JSON.stringify(txCache));
     } catch (e) {
       console.error('Failed to fetch transactions', e);
     }
@@ -97,9 +98,9 @@ export const useAccountStore = defineStore('account', () => {
       lastTipHeight = tipHeight;
 
       balanceRibbits.value = await fetchAddressInfo(address);
-      const balanceCache = getCache<number>('peppool_balance');
+      const balanceCache = getCache<number>(LOCAL_STORAGE_KEYS.BALANCE);
       balanceCache[address] = balanceRibbits.value;
-      localStorage.setItem('peppool_balance', JSON.stringify(balanceCache));
+      localStorage.setItem(LOCAL_STORAGE_KEYS.BALANCE, JSON.stringify(balanceCache));
 
       await refreshTransactions(address);
       await inscriptionStore.sync(address, tipHeight);

--- a/src/stores/inscriptions.ts
+++ b/src/stores/inscriptions.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { ref, readonly } from 'vue';
 import { fetchAddressInscriptions, fetchInscription, fetchInscriptionOutputs } from '@/utils/api';
 import type { Inscription } from '@/models/Inscription';
+import { LOCAL_STORAGE_KEYS } from '@/constants/storage';
 
 const BATCH_SIZE = 5;
 
@@ -12,10 +13,9 @@ interface PersistedData {
   utxoValueRibbits?: number;
 }
 
-const STORAGE_KEY = 'peppool_inscriptions';
 function getCache(): Record<string, PersistedData> {
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    return JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEYS.INSCRIPTIONS) || '{}');
   } catch {
     return {};
   }
@@ -28,7 +28,7 @@ function loadFromStorage(address: string): PersistedData {
 function saveToStorage(address: string, data: PersistedData): void {
   const cache = getCache();
   cache[address] = data;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  localStorage.setItem(LOCAL_STORAGE_KEYS.INSCRIPTIONS, JSON.stringify(cache));
 }
 
 export const useInscriptionStore = defineStore('inscriptions', () => {

--- a/src/stores/lockout.ts
+++ b/src/stores/lockout.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
+import { CHROME_STORAGE_KEYS } from '@/constants/storage';
 
 // ── Escalating lockout tiers ───────────────────────────────────────────────
 // Each tier defines when it activates and how long the lockout lasts.
@@ -25,11 +26,11 @@ function getFailureTier(attempts: number): FailureTier | null {
 }
 
 // ── Storage helpers ──────────────────────────────────────────────────────
-const STORAGE_KEY = 'peppool_lockout';
-
 async function loadState(): Promise<{ attempts: number; until: number }> {
-  const data = await chrome.storage.local.get(STORAGE_KEY);
-  const lockout = data[STORAGE_KEY] as { attempts?: number; until?: number } | undefined;
+  const data = await chrome.storage.local.get(CHROME_STORAGE_KEYS.LOCKOUT);
+  const lockout = data[CHROME_STORAGE_KEYS.LOCKOUT] as
+    | { attempts?: number; until?: number }
+    | undefined;
   if (lockout) {
     return { attempts: Number(lockout.attempts) || 0, until: Number(lockout.until) || 0 };
   }
@@ -37,11 +38,11 @@ async function loadState(): Promise<{ attempts: number; until: number }> {
 }
 
 async function saveState(attempts: number, until: number) {
-  await chrome.storage.local.set({ [STORAGE_KEY]: { attempts, until } });
+  await chrome.storage.local.set({ [CHROME_STORAGE_KEYS.LOCKOUT]: { attempts, until } });
 }
 
 async function clearState() {
-  await chrome.storage.local.remove(STORAGE_KEY);
+  await chrome.storage.local.remove(CHROME_STORAGE_KEYS.LOCKOUT);
 }
 
 export const useLockoutStore = defineStore('lockout', () => {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -17,6 +17,7 @@ import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';
 import { useInscriptionStore } from './inscriptions';
 import { useAccountStore } from './account';
+import { LOCAL_STORAGE_KEYS, CHROME_STORAGE_KEYS, STORAGE_PREFIX } from '@/constants/storage';
 
 export interface Account {
   address: string;
@@ -36,7 +37,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   const accounts = ref<Account[]>(walletStateData.accounts);
   const activeAccountIndex = ref<number>(walletStateData.activeAccountIndex);
-  const encryptedMnemonic = ref<string | null>(localStorage.getItem('peppool_vault'));
+  const encryptedMnemonic = ref<string | null>(localStorage.getItem(LOCAL_STORAGE_KEYS.VAULT));
 
   const session = useSession({
     encryptedMnemonic,
@@ -108,7 +109,7 @@ export const useWalletStore = defineStore('wallet', () => {
     activeAccountIndex.value = 0;
     session.markUnlocked();
 
-    localStorage.setItem('peppool_vault', encrypted);
+    localStorage.setItem(LOCAL_STORAGE_KEYS.VAULT, encrypted);
     await saveWalletState({ accounts: accounts.value, activeAccountIndex: 0 });
 
     await session.resetLockTimer();
@@ -185,7 +186,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   async function lock() {
     await session.lock();
-    localStorage.removeItem('peppool_transactions');
+    localStorage.removeItem(LOCAL_STORAGE_KEYS.TRANSACTIONS);
   }
 
   async function resetWallet() {
@@ -201,14 +202,17 @@ export const useWalletStore = defineStore('wallet', () => {
     // Wipe all peppool localStorage keys (cache + vault)
     const keys = Object.keys(localStorage);
     for (const key of keys) {
-      if (key.startsWith('peppool_')) {
+      if (key.startsWith(STORAGE_PREFIX)) {
         localStorage.removeItem(key);
       }
     }
 
     // Wipe chrome.storage (settings, accounts, permissions)
     await clearAllSettings();
-    await chrome.storage.local.remove(['peppool_permissions', 'peppool_lockout']);
+    await chrome.storage.local.remove([
+      CHROME_STORAGE_KEYS.PERMISSIONS,
+      CHROME_STORAGE_KEYS.LOCKOUT
+    ]);
 
     lockout.reset();
   }
@@ -248,7 +252,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   function updateVault(encrypted: string) {
     encryptedMnemonic.value = encrypted;
-    localStorage.setItem('peppool_vault', encrypted);
+    localStorage.setItem(LOCAL_STORAGE_KEYS.VAULT, encrypted);
   }
 
   let pollTimer: ReturnType<typeof setInterval> | null = null;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,6 +1,7 @@
 import * as message from 'bitcoinjs-message';
 import { PEPECOIN } from './networks';
 import { API_TIMEOUT_MS, APP_NAME, APP_VERSION } from './constants';
+import { LOCAL_STORAGE_KEYS } from '@/constants/storage';
 
 const API_BASE = import.meta.env.VITE_MAINNET_API || 'https://peppool.space/api';
 
@@ -9,10 +10,6 @@ const AUTH_HEADERS = {
   'X-App-Name': APP_NAME,
   'X-App-Version': APP_VERSION
 };
-
-const STORAGE_KEY_TOKEN = 'peppool_auth_token';
-const STORAGE_KEY_EXPIRES = 'peppool_auth_expires';
-const STORAGE_KEY_ADDRESS = 'peppool_auth_address';
 
 interface ChallengeResponse {
   nonce: string;
@@ -69,29 +66,29 @@ async function requestToken(address: string, signature: string): Promise<TokenRe
 }
 
 function storeToken(token: string, expiresAt: number, address: string) {
-  localStorage.setItem(STORAGE_KEY_TOKEN, token);
-  localStorage.setItem(STORAGE_KEY_EXPIRES, expiresAt.toString());
-  localStorage.setItem(STORAGE_KEY_ADDRESS, address);
+  localStorage.setItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN, token);
+  localStorage.setItem(LOCAL_STORAGE_KEYS.AUTH_EXPIRES, expiresAt.toString());
+  localStorage.setItem(LOCAL_STORAGE_KEYS.AUTH_ADDRESS, address);
 }
 
 function clearStoredToken() {
-  localStorage.removeItem(STORAGE_KEY_TOKEN);
-  localStorage.removeItem(STORAGE_KEY_EXPIRES);
-  localStorage.removeItem(STORAGE_KEY_ADDRESS);
+  localStorage.removeItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN);
+  localStorage.removeItem(LOCAL_STORAGE_KEYS.AUTH_EXPIRES);
+  localStorage.removeItem(LOCAL_STORAGE_KEYS.AUTH_ADDRESS);
 }
 
 export function getStoredToken(): string | null {
-  return localStorage.getItem(STORAGE_KEY_TOKEN);
+  return localStorage.getItem(LOCAL_STORAGE_KEYS.AUTH_TOKEN);
 }
 
 function getStoredExpiry(): number {
-  const expiresAt = localStorage.getItem(STORAGE_KEY_EXPIRES);
+  const expiresAt = localStorage.getItem(LOCAL_STORAGE_KEYS.AUTH_EXPIRES);
   if (!expiresAt) return 0;
   return parseInt(expiresAt, 10) * 1000;
 }
 
 function getStoredAddress(): string | null {
-  return localStorage.getItem(STORAGE_KEY_ADDRESS);
+  return localStorage.getItem(LOCAL_STORAGE_KEYS.AUTH_ADDRESS);
 }
 
 function isTokenExpired(): boolean {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,16 +1,11 @@
 import { APP_VERSION } from './constants';
-
-const VERSION_KEY = 'peppool_app_version';
+import { LOCAL_STORAGE_KEYS, STORAGE_PREFIX } from '@/constants/storage';
 
 /**
  * Keys to preserve on version change. Settings and wallet state live in
  * chrome.storage.local — only the vault and version marker remain in localStorage.
  */
-const KEEP_KEYS = ['peppool_vault', 'peppool_app_version'];
-
-function shouldKeep(key: string): boolean {
-  return KEEP_KEYS.includes(key);
-}
+const KEEP_KEYS: string[] = [LOCAL_STORAGE_KEYS.VAULT, LOCAL_STORAGE_KEYS.APP_VERSION];
 
 /**
  * Compare stored app version against current. If different, wipe all
@@ -19,17 +14,17 @@ function shouldKeep(key: string): boolean {
  * initialize, since they read from localStorage in their setup functions.
  */
 export function wipeCacheOnVersionChange(): boolean {
-  const storedVersion = localStorage.getItem(VERSION_KEY);
+  const storedVersion = localStorage.getItem(LOCAL_STORAGE_KEYS.APP_VERSION);
 
   if (storedVersion === APP_VERSION) return false;
 
   const keys = Object.keys(localStorage);
   for (const key of keys) {
-    if (key.startsWith('peppool_') && !shouldKeep(key)) {
+    if (key.startsWith(STORAGE_PREFIX) && !KEEP_KEYS.includes(key)) {
       localStorage.removeItem(key);
     }
   }
 
-  localStorage.setItem(VERSION_KEY, APP_VERSION);
+  localStorage.setItem(LOCAL_STORAGE_KEYS.APP_VERSION, APP_VERSION);
   return true;
 }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,3 +1,5 @@
+import { CHROME_STORAGE_KEYS } from '@/constants/storage';
+
 /**
  * Per-origin permission entry.
  * `accounts` lists the addresses the user approved for this origin.
@@ -14,15 +16,13 @@ export interface PermissionsMap {
   [origin: string]: SitePermission;
 }
 
-const STORAGE_KEY = 'peppool_permissions';
-
 export async function loadPermissions(): Promise<PermissionsMap> {
-  const data = await chrome.storage.local.get(STORAGE_KEY);
-  return (data[STORAGE_KEY] || {}) as PermissionsMap;
+  const data = await chrome.storage.local.get(CHROME_STORAGE_KEYS.PERMISSIONS);
+  return (data[CHROME_STORAGE_KEYS.PERMISSIONS] || {}) as PermissionsMap;
 }
 
 export async function savePermissions(permissions: PermissionsMap): Promise<void> {
-  await chrome.storage.local.set({ [STORAGE_KEY]: permissions });
+  await chrome.storage.local.set({ [CHROME_STORAGE_KEYS.PERMISSIONS]: permissions });
 }
 
 export function hasPermission(

--- a/src/utils/price.ts
+++ b/src/utils/price.ts
@@ -2,6 +2,7 @@ import { reactive } from 'vue';
 import { getSettings } from './settings';
 import { fetchPepPrice } from './api';
 import { RIBBITS_PER_PEP } from './constants';
+import { LOCAL_STORAGE_KEYS } from '@/constants/storage';
 
 export interface Prices {
   USD: number;
@@ -9,12 +10,11 @@ export interface Prices {
 }
 
 const CURRENCY_SYMBOLS: Record<string, string> = { USD: '$', EUR: '€' };
-const STORAGE_KEY = 'peppool_prices';
 
 const prices: Prices = reactive({ USD: 0, EUR: 0 });
 
 function loadFromCache(): void {
-  const raw = localStorage.getItem(STORAGE_KEY);
+  const raw = localStorage.getItem(LOCAL_STORAGE_KEYS.PRICES);
   if (raw) {
     try {
       const cached = JSON.parse(raw);
@@ -34,13 +34,13 @@ export function getPrices(): Prices {
 export async function refreshPrices(): Promise<void> {
   const fetched = await fetchPepPrice();
   Object.assign(prices, fetched);
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...prices }));
+  localStorage.setItem(LOCAL_STORAGE_KEYS.PRICES, JSON.stringify({ ...prices }));
 }
 
 export function clearPrices(): void {
   prices.USD = 0;
   prices.EUR = 0;
-  localStorage.removeItem(STORAGE_KEY);
+  localStorage.removeItem(LOCAL_STORAGE_KEYS.PRICES);
 }
 
 /**

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,6 +1,7 @@
 import { reactive } from 'vue';
 import type { ExplorerId } from './explorer';
 import type { Account } from '@/stores/wallet';
+import { CHROME_STORAGE_KEYS } from '@/constants/storage';
 
 export interface Settings {
   currency: 'USD' | 'EUR';
@@ -25,22 +26,23 @@ const walletState: WalletState = reactive({ ...WALLET_STATE_DEFAULTS });
  */
 export async function loadSettings(): Promise<void> {
   const data = await chrome.storage.local.get([
-    'peppool_settings',
-    'peppool_accounts',
-    'peppool_active_account'
+    CHROME_STORAGE_KEYS.SETTINGS,
+    CHROME_STORAGE_KEYS.ACCOUNTS,
+    CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT
   ]);
 
-  if (data.peppool_settings) {
-    Object.assign(settings, SETTINGS_DEFAULTS, data.peppool_settings);
+  if (data[CHROME_STORAGE_KEYS.SETTINGS]) {
+    Object.assign(settings, SETTINGS_DEFAULTS, data[CHROME_STORAGE_KEYS.SETTINGS]);
   }
 
-  if (data.peppool_accounts) {
-    const raw = data.peppool_accounts;
+  if (data[CHROME_STORAGE_KEYS.ACCOUNTS]) {
+    const raw = data[CHROME_STORAGE_KEYS.ACCOUNTS];
     walletState.accounts = typeof raw === 'string' ? JSON.parse(raw) : raw;
   }
 
-  if (data.peppool_active_account != null) {
-    walletState.activeAccountIndex = parseInt(String(data.peppool_active_account)) || 0;
+  if (data[CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT] != null) {
+    walletState.activeAccountIndex =
+      parseInt(String(data[CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT])) || 0;
   }
 }
 
@@ -54,17 +56,17 @@ export function getWalletState(): WalletState {
 
 export async function saveSettings(partial: Partial<Settings>): Promise<void> {
   Object.assign(settings, partial);
-  await chrome.storage.local.set({ peppool_settings: { ...settings } });
+  await chrome.storage.local.set({ [CHROME_STORAGE_KEYS.SETTINGS]: { ...settings } });
 }
 
 export async function saveWalletState(state: Partial<WalletState>): Promise<void> {
   Object.assign(walletState, state);
   const update: Record<string, any> = {};
   if (state.accounts !== undefined) {
-    update.peppool_accounts = JSON.stringify(walletState.accounts);
+    update[CHROME_STORAGE_KEYS.ACCOUNTS] = JSON.stringify(walletState.accounts);
   }
   if (state.activeAccountIndex !== undefined) {
-    update.peppool_active_account = walletState.activeAccountIndex.toString();
+    update[CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT] = walletState.activeAccountIndex.toString();
   }
   await chrome.storage.local.set(update);
 }
@@ -72,9 +74,9 @@ export async function saveWalletState(state: Partial<WalletState>): Promise<void
 export async function clearAllSettings(): Promise<void> {
   resetSettingsState();
   await chrome.storage.local.remove([
-    'peppool_settings',
-    'peppool_accounts',
-    'peppool_active_account'
+    CHROME_STORAGE_KEYS.SETTINGS,
+    CHROME_STORAGE_KEYS.ACCOUNTS,
+    CHROME_STORAGE_KEYS.ACTIVE_ACCOUNT
   ]);
 }
 


### PR DESCRIPTION
## Summary
- Adds `src/constants/storage.ts` exporting `LOCAL_STORAGE_KEYS`, `CHROME_STORAGE_KEYS`, and `STORAGE_PREFIX` as the single source of truth for all persistent storage key strings.
- Updates every consumer (`background.ts`, `stores/{wallet,account,inscriptions,lockout}.ts`, `utils/{auth,cache,permissions,price,settings}.ts`) to reference the constants directly.
- Removes the cross-file drift risk where `wallet.ts` hardcoded `'peppool_lockout'` in the wipe path while `lockout.ts` defined its own copy of the same string.

## Test plan
- [x] `npm run build` clean
- [x] `npx vitest run` — 525 tests pass