### PR TITLE
Move vault from localStorage to chrome.storage.local

### DIFF
--- a/src/composables/useChangePassword.ts
+++ b/src/composables/useChangePassword.ts
@@ -42,7 +42,7 @@ export function useChangePassword() {
     // Re-encrypt with new password
     await walletStore.withMnemonic(async (mnemonic) => {
       const newEncrypted = await encrypt(mnemonic, newPassword);
-      walletStore.updateVault(newEncrypted);
+      await walletStore.updateVault(newEncrypted);
     });
 
     isSuccess.value = true;

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -13,22 +13,23 @@ export const STORAGE_PREFIX = 'peppool_';
 
 // Persisted in browser localStorage (synchronous, survives extension reload).
 export const LOCAL_STORAGE_KEYS = {
-  VAULT: 'peppool_vault',
-  TRANSACTIONS: 'peppool_transactions',
-  BALANCE: 'peppool_balance',
-  PRICES: 'peppool_prices',
-  INSCRIPTIONS: 'peppool_inscriptions',
   APP_VERSION: 'peppool_app_version',
-  AUTH_TOKEN: 'peppool_auth_token',
+  AUTH_ADDRESS: 'peppool_auth_address',
   AUTH_EXPIRES: 'peppool_auth_expires',
-  AUTH_ADDRESS: 'peppool_auth_address'
+  AUTH_TOKEN: 'peppool_auth_token',
+  BALANCE: 'peppool_balance',
+  INSCRIPTIONS: 'peppool_inscriptions',
+  PRICES: 'peppool_prices',
+  TRANSACTIONS: 'peppool_transactions'
 } as const;
 
-// Persisted in chrome.storage.local (async, accessible from background worker).
+// Persisted in chrome.storage.local (async, accessible from background worker,
+// not subject to browser storage eviction).
 export const CHROME_STORAGE_KEYS = {
+  ACCOUNTS: 'peppool_accounts',
+  ACTIVE_ACCOUNT: 'peppool_active_account',
   LOCKOUT: 'peppool_lockout',
   PERMISSIONS: 'peppool_permissions',
   SETTINGS: 'peppool_settings',
-  ACCOUNTS: 'peppool_accounts',
-  ACTIVE_ACCOUNT: 'peppool_active_account'
+  VAULT: 'peppool_vault'
 } as const;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { createPinia } from 'pinia';
 import { router } from '@/router';
 import { wipeCacheOnVersionChange } from '@/utils/cache';
 import { loadSettings } from '@/utils/settings';
+import { loadVault } from '@/utils/vault';
 import '@tailwindplus/elements';
 import './style.css';
 import App from './App.vue';
@@ -10,8 +11,8 @@ import App from './App.vue';
 // Wipe stale cache before Pinia stores read from localStorage
 wipeCacheOnVersionChange();
 
-// Load settings from chrome.storage.local before Pinia stores initialize
-await loadSettings();
+// Load settings and vault from chrome.storage.local before Pinia stores initialize
+await Promise.all([loadSettings(), loadVault()]);
 import PepButton from '@/components/ui/PepButton.vue';
 import PepLoadingButton from '@/components/ui/PepLoadingButton.vue';
 import PepInput from '@/components/ui/form/PepInput.vue';

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -8,6 +8,7 @@ import { Transaction } from '@/models/Transaction';
 import * as api from '@/utils/api';
 import * as settings from '@/utils/settings';
 import { resetSettingsState } from '@/utils/settings';
+import { resetVaultState, getVault } from '@/utils/vault';
 
 // Mock the API and Crypto utils
 vi.mock('@/utils/api', async (importOriginal) => {
@@ -38,6 +39,7 @@ describe('Wallet Store', () => {
     setActivePinia(createPinia());
     localStorage.clear();
     resetSettingsState();
+    resetVaultState();
     vi.clearAllMocks();
   });
 
@@ -59,7 +61,10 @@ describe('Wallet Store', () => {
     expect(store.accounts).toHaveLength(1);
     expect(store.accounts[0].label).toBe('Account 1');
     expect(store.accounts[0].path).toBe("m/44'/3434'/0'/0/0");
-    expect(localStorage.getItem('peppool_vault')).not.toBeNull();
+    expect(getVault()).not.toBeNull();
+    expect(chrome.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({ peppool_vault: expect.any(String) })
+    );
     expect(chrome.storage.local.set).toHaveBeenCalledWith(
       expect.objectContaining({ peppool_accounts: expect.any(String) })
     );
@@ -147,7 +152,8 @@ describe('Wallet Store', () => {
   });
 
   it('should auto-unlock via checkSession if chrome.storage has mnemonic', async () => {
-    localStorage.setItem('peppool_vault', 'any-vault');
+    const { saveVault } = await import('@/utils/vault');
+    await saveVault('any-vault');
     vi.spyOn(settings, 'getWalletState').mockReturnValue({
       accounts: [{ address: 'any-addr', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }],
       activeAccountIndex: 0
@@ -190,8 +196,9 @@ describe('Wallet Store', () => {
     expect(store.address).toBeNull();
     expect(store.accounts).toHaveLength(0);
     expect(store.isCreated).toBe(false);
-    expect(localStorage.getItem('peppool_vault')).toBeNull();
+    expect(getVault()).toBeNull();
     expect(localStorage.getItem('other_app_key')).toBe('keep-me');
+    expect(chrome.storage.local.remove).toHaveBeenCalledWith('peppool_vault');
     expect(chrome.storage.local.remove).toHaveBeenCalledWith([
       'peppool_settings',
       'peppool_accounts',

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -12,6 +12,7 @@ import { hasAddressActivity } from '@/utils/api';
 import { ensureAuth, clearAuth } from '@/utils/auth';
 import { refreshPrices, clearPrices } from '@/utils/price';
 import { getWalletState, saveWalletState, clearAllSettings } from '@/utils/settings';
+import { getVault, saveVault, clearVault } from '@/utils/vault';
 import { useSession } from '@/composables/useSession';
 import { useLockoutStore } from './lockout';
 import { useSettingsStore } from './settings';
@@ -37,7 +38,7 @@ export const useWalletStore = defineStore('wallet', () => {
 
   const accounts = ref<Account[]>(walletStateData.accounts);
   const activeAccountIndex = ref<number>(walletStateData.activeAccountIndex);
-  const encryptedMnemonic = ref<string | null>(localStorage.getItem(LOCAL_STORAGE_KEYS.VAULT));
+  const encryptedMnemonic = ref<string | null>(getVault());
 
   const session = useSession({
     encryptedMnemonic,
@@ -109,7 +110,7 @@ export const useWalletStore = defineStore('wallet', () => {
     activeAccountIndex.value = 0;
     session.markUnlocked();
 
-    localStorage.setItem(LOCAL_STORAGE_KEYS.VAULT, encrypted);
+    await saveVault(encrypted);
     await saveWalletState({ accounts: accounts.value, activeAccountIndex: 0 });
 
     await session.resetLockTimer();
@@ -199,7 +200,7 @@ export const useWalletStore = defineStore('wallet', () => {
     accountStore.reset();
     clearAuth();
 
-    // Wipe all peppool localStorage keys (cache + vault)
+    // Wipe all peppool localStorage cache keys
     const keys = Object.keys(localStorage);
     for (const key of keys) {
       if (key.startsWith(STORAGE_PREFIX)) {
@@ -207,7 +208,8 @@ export const useWalletStore = defineStore('wallet', () => {
       }
     }
 
-    // Wipe chrome.storage (settings, accounts, permissions)
+    // Wipe chrome.storage (vault, settings, accounts, permissions)
+    await clearVault();
     await clearAllSettings();
     await chrome.storage.local.remove([
       CHROME_STORAGE_KEYS.PERMISSIONS,
@@ -250,9 +252,9 @@ export const useWalletStore = defineStore('wallet', () => {
     await saveWalletState({ accounts: accounts.value });
   }
 
-  function updateVault(encrypted: string) {
+  async function updateVault(encrypted: string) {
     encryptedMnemonic.value = encrypted;
-    localStorage.setItem(LOCAL_STORAGE_KEYS.VAULT, encrypted);
+    await saveVault(encrypted);
   }
 
   let pollTimer: ReturnType<typeof setInterval> | null = null;

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -34,7 +34,7 @@ describe('wipeCacheOnVersionChange', () => {
     expect(localStorage.getItem('peppool_auth_address')).toBeNull();
   });
 
-  it('should preserve vault (only persistent localStorage key)', () => {
+  it('should preserve a legacy vault in localStorage so loadVault() can migrate it', () => {
     localStorage.setItem('peppool_app_version', '1.0.0');
     localStorage.setItem('peppool_vault', 'encrypted-mnemonic');
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -2,10 +2,13 @@ import { APP_VERSION } from './constants';
 import { LOCAL_STORAGE_KEYS, STORAGE_PREFIX } from '@/constants/storage';
 
 /**
- * Keys to preserve on version change. Settings and wallet state live in
- * chrome.storage.local — only the vault and version marker remain in localStorage.
+ * Keys to preserve on version change. Settings, wallet state, and the vault
+ * now live in chrome.storage.local; only the version marker stays in
+ * localStorage. The legacy `peppool_vault` key is kept here so users upgrading
+ * from a pre-migration build don't lose their vault before loadVault() can
+ * migrate it into chrome.storage.local.
  */
-const KEEP_KEYS: string[] = [LOCAL_STORAGE_KEYS.VAULT, LOCAL_STORAGE_KEYS.APP_VERSION];
+const KEEP_KEYS: string[] = ['peppool_vault', LOCAL_STORAGE_KEYS.APP_VERSION];
 
 /**
  * Compare stored app version against current. If different, wipe all

--- a/src/utils/vault.ts
+++ b/src/utils/vault.ts
@@ -1,0 +1,53 @@
+import { CHROME_STORAGE_KEYS, STORAGE_PREFIX } from '@/constants/storage';
+
+const LEGACY_VAULT_KEY = `${STORAGE_PREFIX}vault`;
+
+let vault: string | null = null;
+
+/**
+ * Load the encrypted vault from chrome.storage.local into memory.
+ * Must be called before Pinia stores initialize.
+ *
+ * Migrates the vault from localStorage on first run for users upgrading
+ * from versions that stored the vault synchronously.
+ */
+export async function loadVault(): Promise<void> {
+  const data = await chrome.storage.local.get(CHROME_STORAGE_KEYS.VAULT);
+  const stored = data[CHROME_STORAGE_KEYS.VAULT] as string | undefined;
+
+  if (stored) {
+    vault = stored;
+    return;
+  }
+
+  const legacy = localStorage.getItem(LEGACY_VAULT_KEY);
+  if (legacy) {
+    vault = legacy;
+    await chrome.storage.local.set({ [CHROME_STORAGE_KEYS.VAULT]: legacy });
+    localStorage.removeItem(LEGACY_VAULT_KEY);
+    return;
+  }
+
+  vault = null;
+}
+
+export function getVault(): string | null {
+  return vault;
+}
+
+export async function saveVault(encrypted: string): Promise<void> {
+  vault = encrypted;
+  await chrome.storage.local.set({ [CHROME_STORAGE_KEYS.VAULT]: encrypted });
+}
+
+export async function clearVault(): Promise<void> {
+  vault = null;
+  await chrome.storage.local.remove(CHROME_STORAGE_KEYS.VAULT);
+}
+
+/**
+ * Reset in-memory vault. Used in test teardown to prevent state leaking.
+ */
+export function resetVaultState(): void {
+  vault = null;
+}


### PR DESCRIPTION
## Summary
- Vault load/save/clear now lives in `src/utils/vault.ts` (own module, not in settings)
- Vault is persisted in `chrome.storage.local` instead of `localStorage`
- One-time migration on `loadVault()` moves an existing vault out of localStorage

## Test plan
- [ ] Fresh install: create wallet → vault stored in chrome.storage.local
- [ ] Upgrade path: existing user with vault in localStorage → migrated on first launch, legacy key removed
- [ ] Change password still re-encrypts and persists
- [ ] Reset wallet wipes vault from chrome.storage.local