### PR TITLE
Move API response shapes into src/models with valibot validation

### DIFF
--- a/src/models/AddressInfo.ts
+++ b/src/models/AddressInfo.ts
@@ -1,0 +1,19 @@
+import * as v from 'valibot';
+
+export const RawAddressStatsSchema = v.object({
+  funded_txo_count: v.number(),
+  funded_txo_sum: v.number(),
+  spent_txo_count: v.number(),
+  spent_txo_sum: v.number(),
+  tx_count: v.number()
+});
+
+export type RawAddressStats = v.InferOutput<typeof RawAddressStatsSchema>;
+
+export const RawAddressInfoSchema = v.object({
+  address: v.string(),
+  chain_stats: RawAddressStatsSchema,
+  mempool_stats: RawAddressStatsSchema
+});
+
+export type RawAddressInfo = v.InferOutput<typeof RawAddressInfoSchema>;

--- a/src/models/Fees.ts
+++ b/src/models/Fees.ts
@@ -1,0 +1,11 @@
+import * as v from 'valibot';
+
+export const RecommendedFeesSchema = v.object({
+  fastestFee: v.number(),
+  halfHourFee: v.number(),
+  hourFee: v.number(),
+  economyFee: v.number(),
+  minimumFee: v.number()
+});
+
+export type RecommendedFees = v.InferOutput<typeof RecommendedFeesSchema>;

--- a/src/models/Inscription.ts
+++ b/src/models/Inscription.ts
@@ -33,6 +33,16 @@ export const RawInscriptionResponseSchema = v.object({
 
 export type RawInscriptionResponse = v.InferOutput<typeof RawInscriptionResponseSchema>;
 
+export const RawAddressInscriptionsResponseSchema = v.object({
+  inscriptions: v.array(v.string()),
+  outputs: v.array(v.string()),
+  total: v.number()
+});
+
+export type RawAddressInscriptionsResponse = v.InferOutput<
+  typeof RawAddressInscriptionsResponseSchema
+>;
+
 export function toInscription(raw: RawInscriptionResponse): Inscription {
   return {
     id: raw.id,

--- a/src/models/Price.ts
+++ b/src/models/Price.ts
@@ -1,0 +1,8 @@
+import * as v from 'valibot';
+
+export const PriceSchema = v.object({
+  USD: v.number(),
+  EUR: v.number()
+});
+
+export type Price = v.InferOutput<typeof PriceSchema>;

--- a/src/models/SendTransaction.spec.ts
+++ b/src/models/SendTransaction.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { SendTransaction } from './SendTransaction';
-import type { RecommendedFees } from '@/utils/api';
+import type { RecommendedFees } from '@/models/Fees';
 import { RIBBITS_PER_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 import { estimateTxSize } from '@/utils/crypto';
 

--- a/src/models/SendTransaction.ts
+++ b/src/models/SendTransaction.ts
@@ -1,5 +1,5 @@
 import { estimateTxSize, type UTXO } from '@/utils/crypto';
-import type { RecommendedFees } from '@/utils/api';
+import type { RecommendedFees } from '@/models/Fees';
 import { RIBBITS_PER_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
 export class SendTransaction {

--- a/src/models/Utxo.ts
+++ b/src/models/Utxo.ts
@@ -1,0 +1,14 @@
+import * as v from 'valibot';
+
+export const UtxoSchema = v.object({
+  txid: v.string(),
+  vout: v.number(),
+  value: v.number(),
+  status: v.object({
+    confirmed: v.boolean(),
+    block_height: v.optional(v.number()),
+    block_time: v.optional(v.number())
+  })
+});
+
+export type Utxo = v.InferOutput<typeof UtxoSchema>;

--- a/src/utils/api.spec.ts
+++ b/src/utils/api.spec.ts
@@ -14,9 +14,9 @@ import {
   fetchInscriptionOutputs,
   fetchAddressInscriptions,
   fetchInscription,
-  isInscriptionUtxo,
-  type ApiUtxo
+  isInscriptionUtxo
 } from './api';
+import type { Utxo } from '@/models/Utxo';
 import { RIBBITS_PER_PEP } from './constants';
 import { clearAuth } from './auth';
 
@@ -110,12 +110,18 @@ describe('API Utils', () => {
     const data = {
       address: 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU',
       chain_stats: {
+        funded_txo_count: 1,
         funded_txo_sum: RIBBITS_PER_PEP,
-        spent_txo_sum: RIBBITS_PER_PEP * 0.2
+        spent_txo_count: 0,
+        spent_txo_sum: RIBBITS_PER_PEP * 0.2,
+        tx_count: 1
       },
       mempool_stats: {
+        funded_txo_count: 0,
         funded_txo_sum: RIBBITS_PER_PEP * 0.5,
-        spent_txo_sum: 0
+        spent_txo_count: 0,
+        spent_txo_sum: 0,
+        tx_count: 0
       }
     };
 
@@ -126,23 +132,33 @@ describe('API Utils', () => {
   });
 
   it('should detect address activity based on tx_count', async () => {
+    const emptyStats = {
+      funded_txo_count: 0,
+      funded_txo_sum: 0,
+      spent_txo_count: 0,
+      spent_txo_sum: 0,
+      tx_count: 0
+    };
     const dataActive = {
-      chain_stats: { tx_count: 1 },
-      mempool_stats: { tx_count: 0 }
+      address: 'addr',
+      chain_stats: { ...emptyStats, tx_count: 1 },
+      mempool_stats: emptyStats
     };
     (vi.mocked(fetch) as any).mockResolvedValue(mockResponse(dataActive));
     expect(await hasAddressActivity('addr')).toBe(true);
 
     const dataMempoolOnly = {
-      chain_stats: { tx_count: 0 },
-      mempool_stats: { tx_count: 1 }
+      address: 'addr',
+      chain_stats: emptyStats,
+      mempool_stats: { ...emptyStats, tx_count: 1 }
     };
     (vi.mocked(fetch) as any).mockResolvedValue(mockResponse(dataMempoolOnly));
     expect(await hasAddressActivity('addr')).toBe(true);
 
     const dataInactive = {
-      chain_stats: { tx_count: 0 },
-      mempool_stats: { tx_count: 0 }
+      address: 'addr',
+      chain_stats: emptyStats,
+      mempool_stats: emptyStats
     };
     (vi.mocked(fetch) as any).mockResolvedValue(mockResponse(dataInactive));
     expect(await hasAddressActivity('addr')).toBe(false);
@@ -308,13 +324,13 @@ describe('API Utils', () => {
 
   it('isInscriptionUtxo matches against inscription output set', () => {
     const inscriptionSet = new Set(['abc123:0', 'def456:2']);
-    const inscriptionUtxo: ApiUtxo = {
+    const inscriptionUtxo: Utxo = {
       txid: 'abc123',
       vout: 0,
       value: 100_000,
       status: { confirmed: true }
     };
-    const safeUtxo: ApiUtxo = {
+    const safeUtxo: Utxo = {
       txid: 'abc123',
       vout: 1,
       value: 500_000_000,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -2,9 +2,15 @@ import { API_TIMEOUT_MS, APP_NAME, APP_VERSION } from './constants';
 import { RawTransactionSchema, type RawTransaction } from '@/models/Transaction';
 import {
   RawInscriptionResponseSchema,
+  RawAddressInscriptionsResponseSchema,
   toInscription,
-  type Inscription
+  type Inscription,
+  type RawAddressInscriptionsResponse
 } from '@/models/Inscription';
+import { RawAddressInfoSchema } from '@/models/AddressInfo';
+import { RecommendedFeesSchema, type RecommendedFees } from '@/models/Fees';
+import { UtxoSchema, type Utxo } from '@/models/Utxo';
+import { PriceSchema, type Price } from '@/models/Price';
 import { getStoredToken, clearAuth } from './auth';
 import * as v from 'valibot';
 
@@ -101,61 +107,32 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   }
 }
 
-export interface AddressStats {
-  funded_txo_count: number;
-  funded_txo_sum: number;
-  spent_txo_count: number;
-  spent_txo_sum: number;
-  tx_count: number;
-}
-
-export interface AddressInfo {
-  address: string;
-  chain_stats: AddressStats;
-  mempool_stats: AddressStats;
-}
-
 export async function fetchAddressInfo(address: string): Promise<number> {
-  const data = await request<AddressInfo>(`/address/${encodeURIComponent(address)}`);
+  const raw = await request<unknown>(`/address/${encodeURIComponent(address)}`);
+  const data = v.parse(RawAddressInfoSchema, raw);
   const confirmedBalance = data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum;
   const mempoolBalance = data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum;
   return confirmedBalance + mempoolBalance;
 }
 
 export async function hasAddressActivity(address: string): Promise<boolean> {
-  const data = await request<AddressInfo>(`/address/${encodeURIComponent(address)}`);
+  const raw = await request<unknown>(`/address/${encodeURIComponent(address)}`);
+  const data = v.parse(RawAddressInfoSchema, raw);
   return data.chain_stats.tx_count + data.mempool_stats.tx_count > 0;
 }
 
-export async function fetchPepPrice(): Promise<{ USD: number; EUR: number }> {
-  return await request<{ USD: number; EUR: number }>('/prices');
-}
-
-export interface RecommendedFees {
-  fastestFee: number;
-  halfHourFee: number;
-  hourFee: number;
-  economyFee: number;
-  minimumFee: number;
+export async function fetchPepPrice(): Promise<Price> {
+  const raw = await request<unknown>('/prices');
+  return v.parse(PriceSchema, raw);
 }
 
 export async function fetchRecommendedFees(): Promise<RecommendedFees> {
-  return await request<RecommendedFees>('/fees/recommended');
+  const raw = await request<unknown>('/fees/recommended');
+  return v.parse(RecommendedFeesSchema, raw);
 }
 
 export async function validateAddress(address: string): Promise<{ isvalid: boolean }> {
   return await request<{ isvalid: boolean }>(`/validate-address/${encodeURIComponent(address)}`);
-}
-
-export interface ApiUtxo {
-  txid: string;
-  vout: number;
-  value: number;
-  status: {
-    confirmed: boolean;
-    block_height?: number;
-    block_time?: number;
-  };
 }
 
 export async function fetchTransactions(
@@ -167,8 +144,9 @@ export async function fetchTransactions(
   return data.map((tx) => v.parse(RawTransactionSchema, tx));
 }
 
-export async function fetchUtxos(address: string): Promise<ApiUtxo[]> {
-  return await request<ApiUtxo[]>(`/address/${encodeURIComponent(address)}/utxo`);
+export async function fetchUtxos(address: string): Promise<Utxo[]> {
+  const data = await request<unknown[]>(`/address/${encodeURIComponent(address)}/utxo`);
+  return data.map((u) => v.parse(UtxoSchema, u));
 }
 
 /**
@@ -182,21 +160,14 @@ export async function fetchInscriptionOutputs(address: string): Promise<string[]
   return data.outputs;
 }
 
-export interface AddressInscriptionsResponse {
-  inscriptions: string[];
-  outputs: string[];
-  total: number;
-}
-
 /**
  * Fetches both inscription IDs and output identifiers for an address.
  */
 export async function fetchAddressInscriptions(
   address: string
-): Promise<AddressInscriptionsResponse> {
-  return await request<AddressInscriptionsResponse>(
-    `/address/${encodeURIComponent(address)}/inscriptions`
-  );
+): Promise<RawAddressInscriptionsResponse> {
+  const raw = await request<unknown>(`/address/${encodeURIComponent(address)}/inscriptions`);
+  return v.parse(RawAddressInscriptionsResponseSchema, raw);
 }
 
 /**
@@ -212,14 +183,14 @@ export async function fetchInscription(id: string): Promise<Inscription> {
  * Returns true if the given UTXO holds an inscription and should be excluded from coin selection.
  * Matches against a Set of "txid:vout" output identifiers.
  */
-export function isInscriptionUtxo(utxo: ApiUtxo, inscriptionOutputs: Set<string>): boolean {
+export function isInscriptionUtxo(utxo: Utxo, inscriptionOutputs: Set<string>): boolean {
   return inscriptionOutputs.has(`${utxo.txid}:${utxo.vout}`);
 }
 
 /**
  * Filters UTXOs to only confirmed, non-inscription outputs safe for spending.
  */
-export function filterSpendableUtxos(utxos: ApiUtxo[], inscriptionOutputs: Set<string>): ApiUtxo[] {
+export function filterSpendableUtxos(utxos: Utxo[], inscriptionOutputs: Set<string>): Utxo[] {
   return utxos.filter((u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionOutputs));
 }
 


### PR DESCRIPTION
Closes #36.

## Summary
- New model files: `AddressInfo`, `Fees`, `Utxo`, `Price` — each with a valibot schema and inferred type.
- `Inscription.ts` gains `RawAddressInscriptionsResponseSchema`.
- `api.ts` no longer inlines wire-shape interfaces; every JSON response is validated via `v.parse(...)`.
- `ApiUtxo` renamed to `Utxo`.

## Test plan
- [x] `npx vitest run --reporter=dot --silent` (526 passed)
- [x] `vue-tsc -b` clean
- [x] `vite build` succeeds