### PR TITLE
Exclude unconfirmed balance from spendable on send page

### DIFF
--- a/src/models/AddressInfo.ts
+++ b/src/models/AddressInfo.ts
@@ -17,3 +17,8 @@ export const RawAddressInfoSchema = v.object({
 });
 
 export type RawAddressInfo = v.InferOutput<typeof RawAddressInfoSchema>;
+
+export interface AddressBalance {
+  confirmed: number;
+  pending: number;
+}

--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -10,7 +10,7 @@ vi.mock('@/utils/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/api')>();
   return {
     ...actual,
-    fetchAddressInfo: vi.fn(() => Promise.resolve(100000000)),
+    fetchAddressInfo: vi.fn(() => Promise.resolve({ confirmed: 100000000, pending: 0 })),
     fetchTransactions: vi.fn(() => Promise.resolve([])),
     fetchTipHeight: vi.fn(() => Promise.resolve(100)),
     fetchUtxos: vi.fn(() =>
@@ -42,21 +42,26 @@ describe('Account Store', () => {
   });
 
   it('should restore cached balance from localStorage', () => {
-    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 4_200_000_000 }));
+    localStorage.setItem(
+      'peppool_balance',
+      JSON.stringify({ [addr]: { confirmed: 4_000_000_000, pending: 200_000_000 } })
+    );
     const account = useAccountStore();
     account.loadCachedData(addr);
     expect(account.balanceRibbits).toBe(4_200_000_000);
+    expect(account.confirmedBalanceRibbits).toBe(4_000_000_000);
+    expect(account.pendingBalanceRibbits).toBe(200_000_000);
   });
 
   it('should sync balance from API', async () => {
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(500000000);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 500000000, pending: 0 });
     const account = useAccountStore();
 
     await account.sync(addr, true);
 
     expect(account.balanceRibbits).toBe(500_000_000);
     const balanceCache = JSON.parse(localStorage.getItem('peppool_balance')!);
-    expect(balanceCache[addr]).toBe(500_000_000);
+    expect(balanceCache[addr]).toEqual({ confirmed: 500_000_000, pending: 0 });
   });
 
   it('should skip sync when tip height unchanged', async () => {
@@ -77,7 +82,7 @@ describe('Account Store', () => {
     await account.sync(addr, true);
     vi.clearAllMocks();
     vi.mocked(api.fetchTipHeight).mockResolvedValue(100);
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(200000000);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 200000000, pending: 0 });
 
     await account.sync(addr, true);
     expect(api.fetchAddressInfo).toHaveBeenCalled();
@@ -85,7 +90,7 @@ describe('Account Store', () => {
   });
 
   it('should compute spendable balance excluding inscription UTXOs', async () => {
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(300000000);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 300000000, pending: 0 });
     vi.mocked(api.fetchUtxos).mockResolvedValue([
       { txid: 'spendable1', vout: 0, value: 200000000, status: { confirmed: true } },
       { txid: 'inscribed1', vout: 1, value: 10000, status: { confirmed: true } },
@@ -104,14 +109,64 @@ describe('Account Store', () => {
     expect(account.spendableBalanceRibbits).toBe(299_990_000);
   });
 
-  it('should fall back to total balance when UTXO fetch fails', async () => {
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(100000000);
+  it('should fall back to confirmed balance when UTXO fetch fails', async () => {
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 100000000, pending: 0 });
     vi.mocked(api.fetchUtxos).mockRejectedValue(new Error('Network error'));
 
     const account = useAccountStore();
     await account.sync(addr, true);
 
     expect(account.balanceRibbits).toBe(100_000_000);
+    expect(account.spendableBalanceRibbits).toBe(100_000_000);
+  });
+
+  it('should exclude pending balance from spendableBalanceRibbits (issue #35)', async () => {
+    // Address has 5 PEP confirmed plus 0.5 PEP unconfirmed in mempool. Coin selection
+    // only spends confirmed UTXOs, so spendable must reflect confirmed only — otherwise
+    // the send page promises funds that filterSpendableUtxos() will refuse to use.
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({
+      confirmed: 500_000_000,
+      pending: 50_000_000
+    });
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'confirmed', vout: 0, value: 500_000_000, status: { confirmed: true } },
+      { txid: 'pending', vout: 0, value: 50_000_000, status: { confirmed: false } }
+    ]);
+    vi.mocked(api.fetchAddressInscriptions).mockResolvedValue({
+      inscriptions: [],
+      outputs: [],
+      total: 0
+    });
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
+    expect(account.balanceRibbits).toBe(550_000_000);
+    expect(account.confirmedBalanceRibbits).toBe(500_000_000);
+    expect(account.pendingBalanceRibbits).toBe(50_000_000);
+    expect(account.spendableBalanceRibbits).toBe(500_000_000);
+  });
+
+  it('should ignore unconfirmed inscription UTXOs when computing spendable', async () => {
+    // A pending inscription UTXO must not be subtracted from confirmed balance —
+    // otherwise spendable drops below what filterSpendableUtxos() will actually find (issue #35).
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({
+      confirmed: 100_000_000,
+      pending: 10_000
+    });
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'confirmed', vout: 0, value: 100_000_000, status: { confirmed: true } },
+      { txid: 'pending-inscribed', vout: 0, value: 10_000, status: { confirmed: false } }
+    ]);
+    vi.mocked(api.fetchAddressInscriptions).mockResolvedValue({
+      inscriptions: [],
+      outputs: ['pending-inscribed:0'],
+      total: 0
+    });
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
     expect(account.spendableBalanceRibbits).toBe(100_000_000);
   });
 
@@ -214,7 +269,8 @@ describe('Account Store', () => {
 
   it('should reset all state', () => {
     const account = useAccountStore();
-    account.balanceRibbits = 500_000_000;
+    account.confirmedBalanceRibbits = 500_000_000;
+    account.pendingBalanceRibbits = 25_000_000;
     account.transactions = [{ txid: 'x' } as any];
     account.canLoadMoreTransactions = true;
 
@@ -228,7 +284,10 @@ describe('Account Store', () => {
 
   it('should derive spendableBalanceRibbits from cached balance and inscription value on reload', () => {
     // Simulates popup close/reopen: balance and inscription cache hit before sync runs.
-    localStorage.setItem('peppool_balance', JSON.stringify({ [addr]: 300_000_000 }));
+    localStorage.setItem(
+      'peppool_balance',
+      JSON.stringify({ [addr]: { confirmed: 300_000_000, pending: 0 } })
+    );
     localStorage.setItem(
       'peppool_inscriptions',
       JSON.stringify({
@@ -248,7 +307,7 @@ describe('Account Store', () => {
   it('should keep balanceRibbits as integer math without float drift', async () => {
     // 0.1 + 0.2 PEP = 0.3 PEP in float math, but ribbits stay exact.
     // 30_000_000 ribbits = 0.3 PEP. Inscriptions hold 10_000_000 ribbits = 0.1 PEP.
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(30_000_000);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 30_000_000, pending: 0 });
     vi.mocked(api.fetchUtxos).mockResolvedValue([
       { txid: 'a', vout: 0, value: 20_000_000, status: { confirmed: true } },
       { txid: 'inscribed', vout: 0, value: 10_000_000, status: { confirmed: true } }

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -18,15 +18,22 @@ export const useAccountStore = defineStore('account', () => {
 
   // ── State ──
   // Ribbits is the canonical unit (integer). Conversion to PEP/fiat happens at display time.
-  const balanceRibbits = ref<number>(0);
+  const confirmedBalanceRibbits = ref<number>(0);
+  const pendingBalanceRibbits = ref<number>(0);
   const transactions = ref<Transaction[]>([]);
   const canLoadMoreTransactions = ref(false);
   let lastTipHeight = 0;
 
-  // Spendable = total balance minus value locked in inscription UTXOs.
-  // Derived so it survives popup close/reopen: both inputs come from cache.
+  // Total balance (confirmed + mempool) — what users see on the dashboard.
+  const balanceRibbits = computed(
+    () => confirmedBalanceRibbits.value + pendingBalanceRibbits.value
+  );
+
+  // Spendable = confirmed balance minus value locked in confirmed inscription UTXOs.
+  // Mempool balance is excluded because coin selection only spends confirmed UTXOs;
+  // including pending here would let the send page promise funds it can't actually spend (issue #35).
   const spendableBalanceRibbits = computed(() =>
-    Math.max(0, balanceRibbits.value - inscriptionStore.utxoValueRibbits)
+    Math.max(0, confirmedBalanceRibbits.value - inscriptionStore.utxoValueRibbits)
   );
 
   // ── Cache (keyed by address) ──
@@ -40,9 +47,13 @@ export const useAccountStore = defineStore('account', () => {
 
   function loadCachedData(address: string) {
     try {
-      const balanceCache = getCache<number>(LOCAL_STORAGE_KEYS.BALANCE);
-      if (balanceCache[address] != null) {
-        balanceRibbits.value = balanceCache[address];
+      const balanceCache = getCache<{ confirmed: number; pending: number } | number>(
+        LOCAL_STORAGE_KEYS.BALANCE
+      );
+      const cached = balanceCache[address];
+      if (typeof cached === 'object' && cached !== null) {
+        confirmedBalanceRibbits.value = cached.confirmed;
+        pendingBalanceRibbits.value = cached.pending;
       }
 
       const txCache = getCache<unknown[]>(LOCAL_STORAGE_KEYS.TRANSACTIONS);
@@ -97,9 +108,13 @@ export const useAccountStore = defineStore('account', () => {
       if (!force && tipHeight === lastTipHeight && lastTipHeight > 0) return;
       lastTipHeight = tipHeight;
 
-      balanceRibbits.value = await fetchAddressInfo(address);
-      const balanceCache = getCache<number>(LOCAL_STORAGE_KEYS.BALANCE);
-      balanceCache[address] = balanceRibbits.value;
+      const { confirmed, pending } = await fetchAddressInfo(address);
+      confirmedBalanceRibbits.value = confirmed;
+      pendingBalanceRibbits.value = pending;
+      const balanceCache = getCache<{ confirmed: number; pending: number }>(
+        LOCAL_STORAGE_KEYS.BALANCE
+      );
+      balanceCache[address] = { confirmed, pending };
       localStorage.setItem(LOCAL_STORAGE_KEYS.BALANCE, JSON.stringify(balanceCache));
 
       await refreshTransactions(address);
@@ -110,8 +125,10 @@ export const useAccountStore = defineStore('account', () => {
           fetchUtxos(address),
           inscriptionStore.getOutputsSet(address)
         ]);
+        // Only confirmed inscription UTXOs are subtracted, matching filterSpendableUtxos()
+        // which spends only confirmed outputs (issue #35).
         const inscriptionRibbits = utxos
-          .filter((u) => isInscriptionUtxo(u, inscriptionSet))
+          .filter((u) => u.status.confirmed && isInscriptionUtxo(u, inscriptionSet))
           .reduce((sum, u) => sum + u.value, 0);
         inscriptionStore.setUtxoValueRibbits(inscriptionRibbits);
       } catch {
@@ -123,7 +140,8 @@ export const useAccountStore = defineStore('account', () => {
   }
 
   function reset() {
-    balanceRibbits.value = 0;
+    confirmedBalanceRibbits.value = 0;
+    pendingBalanceRibbits.value = 0;
     transactions.value = [];
     canLoadMoreTransactions.value = false;
     lastTipHeight = 0;
@@ -131,6 +149,8 @@ export const useAccountStore = defineStore('account', () => {
 
   return {
     balanceRibbits,
+    confirmedBalanceRibbits,
+    pendingBalanceRibbits,
     spendableBalanceRibbits,
     transactions,
     canLoadMoreTransactions,

--- a/src/stores/lockout.spec.ts
+++ b/src/stores/lockout.spec.ts
@@ -28,7 +28,7 @@ vi.mock('../utils/encryption', () => ({
 
 // Mock API
 vi.mock('../utils/api', () => ({
-  fetchAddressInfo: vi.fn(() => Promise.resolve(0)),
+  fetchAddressInfo: vi.fn(() => Promise.resolve({ confirmed: 0, pending: 0 })),
   fetchTransactions: vi.fn(() => Promise.resolve([])),
   hasAddressActivity: vi.fn(() => Promise.resolve(false)),
   fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0, EUR: 0 })),

--- a/src/stores/wallet.spec.ts
+++ b/src/stores/wallet.spec.ts
@@ -15,7 +15,7 @@ vi.mock('@/utils/api', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/utils/api')>();
   return {
     ...actual,
-    fetchAddressInfo: vi.fn(() => Promise.resolve(100000000)),
+    fetchAddressInfo: vi.fn(() => Promise.resolve({ confirmed: 100000000, pending: 0 })),
     fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0.5, EUR: 0.4 })),
     fetchTransactions: vi.fn(() => Promise.resolve([])),
     hasAddressActivity: vi.fn(() => Promise.resolve(false)),
@@ -305,7 +305,7 @@ describe('Wallet Store', () => {
     ];
     store.activeAccountIndex = 0;
 
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(300000000); // 3 PEP total
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 300000000, pending: 0 }); // 3 PEP total
     vi.mocked(api.fetchUtxos).mockResolvedValue([
       { txid: 'spendable1', vout: 0, value: 200000000, status: { confirmed: true } },
       { txid: 'inscribed1', vout: 1, value: 10000, status: { confirmed: true } },
@@ -335,7 +335,7 @@ describe('Wallet Store', () => {
     ];
     store.activeAccountIndex = 0;
 
-    vi.mocked(api.fetchAddressInfo).mockResolvedValue(100000000);
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({ confirmed: 100000000, pending: 0 });
     vi.mocked(api.fetchUtxos).mockRejectedValue(new Error('Network error'));
 
     await store.refreshBalance(true);

--- a/src/stores/wallet_lock.spec.ts
+++ b/src/stores/wallet_lock.spec.ts
@@ -25,7 +25,7 @@ vi.mock('../utils/encryption', () => ({
 
 // Mock API
 vi.mock('../utils/api', () => ({
-  fetchAddressInfo: vi.fn(() => Promise.resolve(0)),
+  fetchAddressInfo: vi.fn(() => Promise.resolve({ confirmed: 0, pending: 0 })),
   fetchTransactions: vi.fn(() => Promise.resolve([])),
   hasAddressActivity: vi.fn(() => Promise.resolve(false)),
   fetchPepPrice: vi.fn(() => Promise.resolve({ USD: 0, EUR: 0 })),

--- a/src/utils/api.spec.ts
+++ b/src/utils/api.spec.ts
@@ -127,8 +127,9 @@ describe('API Utils', () => {
 
     (vi.mocked(fetch) as any).mockResolvedValue(mockResponse(data));
 
-    const balanceRibbits = await fetchAddressInfo('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
-    expect(balanceRibbits).toBe(RIBBITS_PER_PEP * 1.3);
+    const balance = await fetchAddressInfo('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
+    expect(balance.confirmed).toBe(RIBBITS_PER_PEP * 0.8);
+    expect(balance.pending).toBe(RIBBITS_PER_PEP * 0.5);
   });
 
   it('should detect address activity based on tx_count', async () => {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -7,7 +7,7 @@ import {
   type Inscription,
   type RawAddressInscriptionsResponse
 } from '@/models/Inscription';
-import { RawAddressInfoSchema } from '@/models/AddressInfo';
+import { RawAddressInfoSchema, type AddressBalance } from '@/models/AddressInfo';
 import { RecommendedFeesSchema, type RecommendedFees } from '@/models/Fees';
 import { UtxoSchema, type Utxo } from '@/models/Utxo';
 import { PriceSchema, type Price } from '@/models/Price';
@@ -107,12 +107,12 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   }
 }
 
-export async function fetchAddressInfo(address: string): Promise<number> {
+export async function fetchAddressInfo(address: string): Promise<AddressBalance> {
   const raw = await request<unknown>(`/address/${encodeURIComponent(address)}`);
   const data = v.parse(RawAddressInfoSchema, raw);
-  const confirmedBalance = data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum;
-  const mempoolBalance = data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum;
-  return confirmedBalance + mempoolBalance;
+  const confirmed = data.chain_stats.funded_txo_sum - data.chain_stats.spent_txo_sum;
+  const pending = data.mempool_stats.funded_txo_sum - data.mempool_stats.spent_txo_sum;
+  return { confirmed, pending };
 }
 
 export async function hasAddressActivity(address: string): Promise<boolean> {


### PR DESCRIPTION
Closes #35.

## Summary
- `fetchAddressInfo()` now returns `{ confirmed, pending }` (in ribbits) instead of a combined sum.
- Account store tracks `confirmedBalanceRibbits` and `pendingBalanceRibbits` separately. `balanceRibbits` is a computed total so the dashboard still shows incoming deposits immediately.
- `spendableBalanceRibbits` is derived from confirmed balance only, matching what `filterSpendableUtxos()` will actually return at sign time.
- Inscription UTXO value is summed from confirmed UTXOs only — a pending inscription UTXO is no longer subtracted from the confirmed pool.
- Balance cache shape changed from `Record<address, number>` to `Record<address, { confirmed, pending }>`. Stale entries fall through and get repopulated on next sync.

## Test plan
- [x] Existing 528 tests pass
- [x] New regression test: spendable excludes pending balance
- [x] New regression test: spendable ignores unconfirmed inscription UTXOs
- [x] `npm run build` clean