### PR TITLE
Subtract pending outgoing spend from spendable balance

### DIFF
--- a/src/stores/account.spec.ts
+++ b/src/stores/account.spec.ts
@@ -147,6 +147,30 @@ describe('Account Store', () => {
     expect(account.spendableBalanceRibbits).toBe(500_000_000);
   });
 
+  it('should subtract pending outgoing spend from spendable balance', async () => {
+    // After broadcasting an outgoing tx, mempool_stats.spent_txo_sum jumps and pending
+    // goes negative. The input UTXO is gone from /utxo, but chain_stats still counts it,
+    // so confirmed alone overstates spendable funds until the tx confirms.
+    vi.mocked(api.fetchAddressInfo).mockResolvedValue({
+      confirmed: 500_000_000,
+      pending: -100_000_000
+    });
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'remaining', vout: 0, value: 400_000_000, status: { confirmed: true } }
+    ]);
+    vi.mocked(api.fetchAddressInscriptions).mockResolvedValue({
+      inscriptions: [],
+      outputs: [],
+      total: 0
+    });
+
+    const account = useAccountStore();
+    await account.sync(addr, true);
+
+    expect(account.balanceRibbits).toBe(400_000_000);
+    expect(account.spendableBalanceRibbits).toBe(400_000_000);
+  });
+
   it('should ignore unconfirmed inscription UTXOs when computing spendable', async () => {
     // A pending inscription UTXO must not be subtracted from confirmed balance —
     // otherwise spendable drops below what filterSpendableUtxos() will actually find (issue #35).

--- a/src/stores/account.ts
+++ b/src/stores/account.ts
@@ -29,12 +29,17 @@ export const useAccountStore = defineStore('account', () => {
     () => confirmedBalanceRibbits.value + pendingBalanceRibbits.value
   );
 
-  // Spendable = confirmed balance minus value locked in confirmed inscription UTXOs.
-  // Mempool balance is excluded because coin selection only spends confirmed UTXOs;
-  // including pending here would let the send page promise funds it can't actually spend (issue #35).
-  const spendableBalanceRibbits = computed(() =>
-    Math.max(0, confirmedBalanceRibbits.value - inscriptionStore.utxoValueRibbits)
-  );
+  // Spendable matches what filterSpendableUtxos() will actually return at sign time:
+  // - Positive pending (incoming deposit) is excluded — coin selection only spends confirmed UTXOs (issue #35).
+  // - Negative pending (outgoing unconfirmed tx) IS subtracted — the input UTXO is gone from /utxo
+  //   even though chain_stats still counts it, so confirmed alone overstates funds until the tx confirms.
+  const spendableBalanceRibbits = computed(() => {
+    const pendingDebit = Math.min(0, pendingBalanceRibbits.value);
+    return Math.max(
+      0,
+      confirmedBalanceRibbits.value + pendingDebit - inscriptionStore.utxoValueRibbits
+    );
+  });
 
   // ── Cache (keyed by address) ──
   function getCache<T>(key: string): Record<string, T> {


### PR DESCRIPTION
Follow-up to #38.

## Problem
After broadcasting an outgoing tx, `mempool_stats.spent_txo_sum` jumps and `pending` goes negative. The input UTXO is dropped from `/utxo`, but `chain_stats` still counts it — so `confirmedBalanceRibbits` alone overstates spendable funds until the tx confirms. Same class of mismatch as #35, just inverted.

## Fix
\`\`\`
spendable = max(0, confirmed + min(pending, 0) - inscriptions)
\`\`\`
Negative pending (outgoing) is subtracted; positive pending (incoming deposit) is still excluded since coin selection only spends confirmed UTXOs.

## Test plan
- [x] New regression test: pending negative → spendable matches /utxo sum
- [x] Existing 528 tests still pass (529 total)
- [x] `npm run build` clean