### PR TITLE
Add inscription send flow

### DIFF
--- a/src/composables/useSendInscription.spec.ts
+++ b/src/composables/useSendInscription.spec.ts
@@ -65,22 +65,29 @@ describe('parseSatpoint', () => {
 describe('selectFeeUtxos', () => {
   const rawHex = 'deadbeef';
 
-  it('selects one UTXO when it covers the fee', () => {
-    const utxos = [{ txid: 't1', vout: 0, value: 1_000_000, rawHex }];
+  it('selects one UTXO when it covers the fee plus the soft-dust surcharge', () => {
+    const utxos = [{ txid: 't1', vout: 0, value: 10_000_000, rawHex }];
     const { feeUtxos, feeRibbits } = selectFeeUtxos(utxos, 1000);
     expect(feeUtxos).toHaveLength(1);
-    expect(feeRibbits).toBeGreaterThan(0);
-    expect(feeRibbits).toBeLessThanOrEqual(1_000_000);
+    // Size-based fee for (2 inputs, 2 outputs) at 1000 ribbits/byte = 374,000.
+    // Plus 4,000,000 ribbits soft-dust surcharge for the postage output.
+    expect(feeRibbits).toBe(4_374_000);
   });
 
   it('accumulates UTXOs when the first does not cover the fee', () => {
     const utxos = [
-      { txid: 't1', vout: 0, value: 1_000, rawHex },
-      { txid: 't2', vout: 0, value: 5_000, rawHex },
-      { txid: 't3', vout: 0, value: 1_000_000, rawHex }
+      { txid: 't1', vout: 0, value: 100_000, rawHex },
+      { txid: 't2', vout: 0, value: 200_000, rawHex },
+      { txid: 't3', vout: 0, value: 10_000_000, rawHex }
     ];
     const { feeUtxos } = selectFeeUtxos(utxos, 1000);
     expect(feeUtxos.length).toBeGreaterThan(1);
+  });
+
+  it('includes the soft-dust surcharge in the calculated fee', () => {
+    const utxos = [{ txid: 't1', vout: 0, value: 10_000_000, rawHex }];
+    const { feeRibbits } = selectFeeUtxos(utxos, 1000);
+    expect(feeRibbits).toBeGreaterThanOrEqual(4_000_000);
   });
 
   it('throws when total spendable cannot cover any fee', () => {

--- a/src/composables/useSendInscription.spec.ts
+++ b/src/composables/useSendInscription.spec.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSendInscription, parseSatpoint, selectFeeUtxos } from './useSendInscription';
+import { useApp } from '@/composables/useApp';
+import * as api from '@/utils/api';
+import * as crypto from '@/utils/crypto';
+import type { Inscription } from '@/models/Inscription';
+
+const { mockGetOutputsSet } = vi.hoisted(() => ({
+  mockGetOutputsSet: vi.fn(() => Promise.resolve(new Set<string>()))
+}));
+
+vi.mock('@/composables/useApp');
+vi.mock('@/stores/inscriptions', () => ({
+  useInscriptionStore: vi.fn(() => ({ getOutputsSet: mockGetOutputsSet }))
+}));
+vi.mock('@/utils/api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/api')>();
+  return {
+    ...actual,
+    fetchRecommendedFees: vi.fn(),
+    fetchUtxos: vi.fn(),
+    fetchTxHex: vi.fn(),
+    validateAddress: vi.fn(),
+    broadcastTx: vi.fn()
+  };
+});
+vi.mock('@/utils/crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/crypto')>();
+  return {
+    ...actual,
+    deriveSigner: vi.fn(),
+    createSignedInscriptionTx: vi.fn(),
+    isValidAddress: vi.fn()
+  };
+});
+
+const SENDER = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
+const RECIPIENT = 'PrEcEpienTaDdReSsXxXxXxXxXxXxXxXxX';
+
+function makeInscription(satpoint: string): Inscription {
+  return {
+    id: 'insc1',
+    number: 0,
+    contentType: 'image/png',
+    contentLength: 100,
+    height: 1,
+    value: 10000,
+    parents: [],
+    properties: null,
+    satpoint,
+    timestamp: 0
+  };
+}
+
+describe('parseSatpoint', () => {
+  it('extracts txid and vout from satpoint', () => {
+    expect(parseSatpoint('abc:3:0')).toEqual({ txid: 'abc', vout: 3 });
+  });
+
+  it('throws on malformed satpoint', () => {
+    expect(() => parseSatpoint('garbage')).toThrow('Invalid satpoint');
+  });
+});
+
+describe('selectFeeUtxos', () => {
+  const rawHex = 'deadbeef';
+
+  it('selects one UTXO when it covers the fee', () => {
+    const utxos = [{ txid: 't1', vout: 0, value: 1_000_000, rawHex }];
+    const { feeUtxos, feeRibbits } = selectFeeUtxos(utxos, 1000);
+    expect(feeUtxos).toHaveLength(1);
+    expect(feeRibbits).toBeGreaterThan(0);
+    expect(feeRibbits).toBeLessThanOrEqual(1_000_000);
+  });
+
+  it('accumulates UTXOs when the first does not cover the fee', () => {
+    const utxos = [
+      { txid: 't1', vout: 0, value: 1_000, rawHex },
+      { txid: 't2', vout: 0, value: 5_000, rawHex },
+      { txid: 't3', vout: 0, value: 1_000_000, rawHex }
+    ];
+    const { feeUtxos } = selectFeeUtxos(utxos, 1000);
+    expect(feeUtxos.length).toBeGreaterThan(1);
+  });
+
+  it('throws when total spendable cannot cover any fee', () => {
+    const utxos = [{ txid: 't1', vout: 0, value: 1, rawHex }];
+    expect(() => selectFeeUtxos(utxos, 1000)).toThrow('Insufficient balance');
+  });
+});
+
+describe('useSendInscription', () => {
+  let mockWallet: any;
+  let mockAccount: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccount = { spendableBalanceRibbits: 1_000_000_000 };
+    mockWallet = {
+      address: SENDER,
+      refreshBalance: vi.fn(),
+      isMnemonicLoaded: true,
+      withMnemonic: vi.fn((fn: any) => Promise.resolve(fn('test mnemonic'))),
+      activeAccount: { address: SENDER, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }
+    };
+    vi.mocked(useApp).mockReturnValue({
+      wallet: mockWallet,
+      account: mockAccount,
+      settings: { settings: { explorer: 'peppool' } }
+    } as any);
+  });
+
+  it('loads recommended fees', async () => {
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1500 } as any);
+    const { loadFees, fees, isLoadingFees } = useSendInscription();
+    expect(isLoadingFees.value).toBe(true);
+    await loadFees();
+    expect(isLoadingFees.value).toBe(false);
+    expect(fees.value?.fastestFee).toBe(1500);
+  });
+
+  it('rejects sending to own address', async () => {
+    vi.mocked(crypto.isValidAddress).mockReturnValue(true);
+    const { validateRecipient } = useSendInscription();
+    await expect(validateRecipient(SENDER)).rejects.toThrow('Cannot send to your own address');
+  });
+
+  it('rejects empty / invalid addresses', async () => {
+    const { validateRecipient } = useSendInscription();
+    await expect(validateRecipient('')).rejects.toThrow('enter a recipient address');
+
+    vi.mocked(crypto.isValidAddress).mockReturnValue(false);
+    await expect(validateRecipient('garbage')).rejects.toThrow('Invalid address format');
+  });
+
+  it('builds and broadcasts an inscription transfer with fresh UTXOs', async () => {
+    const utxos = [
+      { txid: 'inscriptionTx', vout: 0, value: 10000, status: { confirmed: true } },
+      { txid: 'fee1', vout: 0, value: 500_000_000, status: { confirmed: true } }
+    ];
+    vi.mocked(api.fetchUtxos).mockResolvedValue(utxos as any);
+    mockGetOutputsSet.mockResolvedValue(new Set(['inscriptionTx:0']));
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchTxHex).mockResolvedValue('rawhex');
+    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
+    vi.mocked(crypto.createSignedInscriptionTx).mockResolvedValue('signed-hex');
+    vi.mocked(api.broadcastTx).mockResolvedValue('broadcast-txid');
+
+    const { send, loadFees } = useSendInscription();
+    await loadFees();
+
+    const inscription = makeInscription('inscriptionTx:0:0');
+    const txid = await send(inscription, RECIPIENT, 'password');
+
+    expect(txid).toBe('broadcast-txid');
+    // Ensure inscription UTXO went in as input 0 and fee UTXOs followed
+    const call = vi.mocked(crypto.createSignedInscriptionTx).mock.calls[0];
+    const [, recipientArg, inscriptionUtxoArg, feeUtxosArg] = call;
+    expect(recipientArg).toBe(RECIPIENT);
+    expect(inscriptionUtxoArg.txid).toBe('inscriptionTx');
+    expect(inscriptionUtxoArg.vout).toBe(0);
+    expect(inscriptionUtxoArg.value).toBe(10000);
+    expect(feeUtxosArg.map((u: any) => u.txid)).toEqual(['fee1']);
+    expect(mockWallet.refreshBalance).toHaveBeenCalledWith(true);
+  });
+
+  it('throws when the inscription UTXO is no longer present on chain', async () => {
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'fee1', vout: 0, value: 500_000_000, status: { confirmed: true } }
+    ] as any);
+    mockGetOutputsSet.mockResolvedValue(new Set());
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+
+    const { send, loadFees } = useSendInscription();
+    await loadFees();
+
+    const inscription = makeInscription('missingTx:0:0');
+    await expect(send(inscription, RECIPIENT, 'password')).rejects.toThrow(
+      'Inscription UTXO not found'
+    );
+  });
+
+  it('uses the active account derivation indices when signing', async () => {
+    mockWallet.activeAccount = {
+      address: SENDER,
+      path: "m/44'/3434'/4'/0/2",
+      label: 'Account 5'
+    };
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'inscriptionTx', vout: 0, value: 10000, status: { confirmed: true } },
+      { txid: 'fee1', vout: 0, value: 500_000_000, status: { confirmed: true } }
+    ] as any);
+    mockGetOutputsSet.mockResolvedValue(new Set(['inscriptionTx:0']));
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchTxHex).mockResolvedValue('rawhex');
+    vi.mocked(crypto.deriveSigner).mockReturnValue({} as any);
+    vi.mocked(crypto.createSignedInscriptionTx).mockResolvedValue('signed-hex');
+    vi.mocked(api.broadcastTx).mockResolvedValue('broadcast-txid');
+
+    const { send, loadFees } = useSendInscription();
+    await loadFees();
+
+    await send(makeInscription('inscriptionTx:0:0'), RECIPIENT, 'password');
+    expect(crypto.deriveSigner).toHaveBeenCalledWith('test mnemonic', 4, 2);
+  });
+
+  it('requires a password when the mnemonic is not loaded in session', async () => {
+    mockWallet.isMnemonicLoaded = false;
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+
+    const { send, loadFees } = useSendInscription();
+    await loadFees();
+
+    await expect(send(makeInscription('a:0:0'), RECIPIENT, '')).rejects.toThrow(
+      'Password required'
+    );
+  });
+});

--- a/src/composables/useSendInscription.ts
+++ b/src/composables/useSendInscription.ts
@@ -1,0 +1,195 @@
+import { ref, computed } from 'vue';
+import { useApp } from '@/composables/useApp';
+import {
+  fetchUtxos,
+  fetchTxHex,
+  validateAddress,
+  fetchRecommendedFees,
+  broadcastTx,
+  filterSpendableUtxos
+} from '@/utils/api';
+import { useInscriptionStore } from '@/stores/inscriptions';
+import {
+  createSignedInscriptionTx,
+  isValidAddress,
+  deriveSigner,
+  parseDerivationPath,
+  estimateTxSize,
+  type UTXO
+} from '@/utils/crypto';
+import { decrypt as decryptMnemonic } from '@/utils/encryption';
+import type { RecommendedFees } from '@/models/Fees';
+import type { Inscription } from '@/models/Inscription';
+import { RECOMMENDED_FEE_RATE } from '@/utils/constants';
+
+interface FeeSelection {
+  feeUtxos: UTXO[];
+  feeRibbits: number;
+}
+
+/**
+ * Parses an ord satpoint ("txid:vout:offset") into the txid:vout that holds it.
+ */
+export function parseSatpoint(satpoint: string): { txid: string; vout: number } {
+  const parts = satpoint.split(':');
+  if (parts.length < 2 || !parts[0] || parts[1] === undefined) {
+    throw new Error(`Invalid satpoint: ${satpoint}`);
+  }
+  return { txid: parts[0], vout: parseInt(parts[1], 10) };
+}
+
+/**
+ * Greedy fee selection: walk spendable UTXOs in order, accumulating until the
+ * fee for (1 inscription input + N fee inputs + 2 outputs) is covered. Returns
+ * the chosen UTXOs and the exact fee for the resulting tx shape.
+ */
+export function selectFeeUtxos(spendable: UTXO[], feeRate: number): FeeSelection {
+  const feeUtxos: UTXO[] = [];
+  let total = 0;
+
+  for (const utxo of spendable) {
+    feeUtxos.push(utxo);
+    total += utxo.value;
+    // 1 inscription input + N fee inputs, 2 outputs (recipient + change)
+    const size = estimateTxSize(1 + feeUtxos.length, 2);
+    const fee = Math.ceil(size * feeRate);
+    if (total >= fee) {
+      return { feeUtxos, feeRibbits: fee };
+    }
+  }
+
+  throw new Error('Insufficient balance to cover network fee');
+}
+
+export function useSendInscription() {
+  const { wallet: walletStore, account } = useApp();
+  const inscriptionStore = useInscriptionStore();
+
+  const fees = ref<RecommendedFees | null>(null);
+  const isLoadingFees = ref(true);
+
+  const feeRate = computed(() => {
+    if (!fees.value) return RECOMMENDED_FEE_RATE;
+    return Math.max(RECOMMENDED_FEE_RATE, fees.value.fastestFee);
+  });
+
+  /**
+   * Estimated fee for display on the review screen. Assumes 2 inputs (1
+   * inscription + 1 funding) and 2 outputs (recipient + change). The actual
+   * fee at send time may differ by one input's worth if more funding UTXOs
+   * are needed, but this matches typical transfers.
+   */
+  const estimatedFeeRibbits = computed(() => {
+    const size = estimateTxSize(2, 2);
+    return Math.ceil(size * feeRate.value);
+  });
+
+  const isInsufficientFunds = computed(() => {
+    if (isLoadingFees.value) return false;
+    return account.spendableBalanceRibbits < estimatedFeeRibbits.value;
+  });
+
+  async function loadFees() {
+    isLoadingFees.value = true;
+    try {
+      fees.value = await fetchRecommendedFees();
+    } catch (e) {
+      console.error('Failed to load fees', e);
+      throw e;
+    } finally {
+      isLoadingFees.value = false;
+    }
+  }
+
+  async function validateRecipient(recipient: string) {
+    if (!recipient) {
+      throw new Error('Please enter a recipient address');
+    }
+    if (!isValidAddress(recipient)) {
+      throw new Error('Invalid address format');
+    }
+    if (recipient === walletStore.address) {
+      throw new Error('Cannot send to your own address');
+    }
+    const validation = await validateAddress(recipient);
+    if (!validation.isvalid) {
+      throw new Error('Invalid Pepecoin address');
+    }
+    return true;
+  }
+
+  let isSending = false;
+
+  async function send(
+    inscription: Inscription,
+    recipient: string,
+    password: string
+  ): Promise<string> {
+    if (isSending) throw new Error('Transaction already in progress');
+    isSending = true;
+
+    try {
+      let mnemonic: string;
+      if (walletStore.isMnemonicLoaded) {
+        mnemonic = await walletStore.withMnemonic((m) => m);
+      } else {
+        if (!password) throw new Error('Password required');
+        mnemonic = await decryptMnemonic(walletStore.encryptedMnemonic!, password);
+      }
+
+      const address = walletStore.address!;
+      const [allUtxos, inscriptionSet] = await Promise.all([
+        fetchUtxos(address),
+        inscriptionStore.getOutputsSet(address)
+      ]);
+
+      const { txid: satTxid, vout: satVout } = parseSatpoint(inscription.satpoint);
+      const inscriptionUtxo = allUtxos.find((u) => u.txid === satTxid && u.vout === satVout);
+      if (!inscriptionUtxo) {
+        throw new Error('Inscription UTXO not found — it may have already been moved');
+      }
+
+      const spendable = filterSpendableUtxos(allUtxos, inscriptionSet);
+      const { feeUtxos, feeRibbits } = selectFeeUtxos(spendable, feeRate.value);
+
+      const inputs: UTXO[] = [inscriptionUtxo, ...feeUtxos];
+      const inputsWithHex: UTXO[] = [];
+      for (const utxo of inputs) {
+        const rawHex = await fetchTxHex(utxo.txid);
+        inputsWithHex.push({ ...utxo, rawHex });
+      }
+
+      const activePath = walletStore.activeAccount?.path;
+      const { accountIndex, addressIndex } = activePath
+        ? parseDerivationPath(activePath)
+        : { accountIndex: 0, addressIndex: 0 };
+      const signer = deriveSigner(mnemonic, accountIndex, addressIndex);
+
+      const signedInscriptionUtxo = inputsWithHex[0]!;
+      const signedFeeUtxos = inputsWithHex.slice(1);
+      const signedHex = await createSignedInscriptionTx(
+        signer,
+        recipient,
+        signedInscriptionUtxo,
+        signedFeeUtxos,
+        feeRibbits
+      );
+
+      const txid = await broadcastTx(signedHex);
+      await walletStore.refreshBalance(true);
+      return txid;
+    } finally {
+      isSending = false;
+    }
+  }
+
+  return {
+    fees,
+    isLoadingFees,
+    estimatedFeeRibbits,
+    isInsufficientFunds,
+    loadFees,
+    validateRecipient,
+    send
+  };
+}

--- a/src/composables/useSendInscription.ts
+++ b/src/composables/useSendInscription.ts
@@ -20,7 +20,7 @@ import {
 import { decrypt as decryptMnemonic } from '@/utils/encryption';
 import type { RecommendedFees } from '@/models/Fees';
 import type { Inscription } from '@/models/Inscription';
-import { RECOMMENDED_FEE_RATE } from '@/utils/constants';
+import { RECOMMENDED_FEE_RATE, SOFT_DUST_FEE_RIBBITS } from '@/utils/constants';
 
 interface FeeSelection {
   feeUtxos: UTXO[];
@@ -40,8 +40,10 @@ export function parseSatpoint(satpoint: string): { txid: string; vout: number } 
 
 /**
  * Greedy fee selection: walk spendable UTXOs in order, accumulating until the
- * fee for (1 inscription input + N fee inputs + 2 outputs) is covered. Returns
- * the chosen UTXOs and the exact fee for the resulting tx shape.
+ * fee for (1 inscription input + N fee inputs + 2 outputs) is covered. The
+ * inscription postage output is always sub-dust, so the soft-dust surcharge
+ * is added on top of the size-based fee — without it, miners ignore the tx
+ * (observed empirically: confirmed inscription transfers all paid this).
  */
 export function selectFeeUtxos(spendable: UTXO[], feeRate: number): FeeSelection {
   const feeUtxos: UTXO[] = [];
@@ -50,9 +52,8 @@ export function selectFeeUtxos(spendable: UTXO[], feeRate: number): FeeSelection
   for (const utxo of spendable) {
     feeUtxos.push(utxo);
     total += utxo.value;
-    // 1 inscription input + N fee inputs, 2 outputs (recipient + change)
     const size = estimateTxSize(1 + feeUtxos.length, 2);
-    const fee = Math.ceil(size * feeRate);
+    const fee = Math.ceil(size * feeRate) + SOFT_DUST_FEE_RIBBITS;
     if (total >= fee) {
       return { feeUtxos, feeRibbits: fee };
     }
@@ -75,13 +76,14 @@ export function useSendInscription() {
 
   /**
    * Estimated fee for display on the review screen. Assumes 2 inputs (1
-   * inscription + 1 funding) and 2 outputs (recipient + change). The actual
-   * fee at send time may differ by one input's worth if more funding UTXOs
-   * are needed, but this matches typical transfers.
+   * inscription + 1 funding) and 2 outputs (recipient + change), plus the
+   * soft-dust surcharge for the sub-dust postage output. The actual fee at
+   * send time may differ by one input's worth if more funding UTXOs are
+   * needed, but this matches typical transfers.
    */
   const estimatedFeeRibbits = computed(() => {
     const size = estimateTxSize(2, 2);
-    return Math.ceil(size * feeRate.value);
+    return Math.ceil(size * feeRate.value) + SOFT_DUST_FEE_RIBBITS;
   });
 
   const isInsufficientFunds = computed(() => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -14,6 +14,7 @@ import ResetWalletView from '@/views/settings/ResetWalletView.vue';
 import TransactionDetailView from '@/views/wallet/TransactionDetailView.vue';
 import InscriptionsView from '@/views/inscriptions/InscriptionsView.vue';
 import InscriptionDetailView from '@/views/inscriptions/InscriptionDetailView.vue';
+import SendInscriptionView from '@/views/inscriptions/send/SendInscriptionView.vue';
 import CurrencyView from '@/views/settings/CurrencyView.vue';
 import PreferredExplorerView from '@/views/settings/PreferredExplorerView.vue';
 import AutoLockView from '@/views/settings/AutoLockView.vue';
@@ -42,6 +43,7 @@ const routes = [
   { path: '/tx/:txid', component: TransactionDetailView, meta: { persist: true } },
   { path: '/inscriptions', component: InscriptionsView },
   { path: '/inscription/:id', component: InscriptionDetailView, meta: { persist: true } },
+  { path: '/inscription/:id/send', component: SendInscriptionView },
   { path: '/settings/preferences', component: PreferencesView },
   { path: '/settings/security', component: SecurityView },
   { path: '/settings/about', component: AboutView },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -43,7 +43,7 @@ const routes = [
   { path: '/tx/:txid', component: TransactionDetailView, meta: { persist: true } },
   { path: '/inscriptions', component: InscriptionsView },
   { path: '/inscription/:id', component: InscriptionDetailView, meta: { persist: true } },
-  { path: '/inscription/:id/send', component: SendInscriptionView },
+  { path: '/inscription/:id/send', component: SendInscriptionView, meta: { persist: true } },
   { path: '/settings/preferences', component: PreferencesView },
   { path: '/settings/security', component: SecurityView },
   { path: '/settings/about', component: AboutView },

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,6 +9,13 @@ export const APP_VERSION = pkg.version;
 // 1,000 ribbits/byte = 0.01 PEP per KB (Network recommendation)
 export const RECOMMENDED_FEE_RATE = 1000;
 export const MIN_SEND_PEP = 0.01;
+
+// Pepecoin (Dogecoin-derived) soft dust rule: outputs below 1 PEP add a flat
+// surcharge to the effective minimum fee miners enforce. Inscription postage
+// outputs are always sub-dust, which is why inscription transfers stall at
+// the size-only floor unless the surcharge is paid up front.
+export const SOFT_DUST_LIMIT_RIBBITS = 100_000_000;
+export const SOFT_DUST_FEE_RIBBITS = 4_000_000;
 export const MIN_PASSWORD_LENGTH = 8;
 export const TXS_PER_PAGE = 25;
 

--- a/src/utils/crypto.spec.ts
+++ b/src/utils/crypto.spec.ts
@@ -8,6 +8,7 @@ import {
   deriveSigner,
   parseDerivationPath,
   createSignedTx,
+  createSignedInscriptionTx,
   signMessage,
   type UTXO,
   estimateTxSize,
@@ -228,6 +229,95 @@ describe('Crypto Utils', () => {
       );
 
       expect(signedHex).toBe('signed-hex-output');
+    });
+  });
+
+  describe('Inscription Transaction Signing', () => {
+    const recipient = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
+    const validDummyHex =
+      '0100000001bc9606ba9ed606fa66006000000000000000000000000000000000000000000000000000ffffffff0100e1f505000000001976a91476a91476a91476a91476a91476a91476a91476a91488ac00000000';
+    const inscriptionTxid = 'a'.repeat(64);
+    const feeTxid = 'b'.repeat(64);
+    const signer = deriveSigner(mnemonic);
+
+    const inscriptionUtxo: UTXO = {
+      txid: inscriptionTxid,
+      vout: 0,
+      value: 10000, // postage in ribbits
+      rawHex: validDummyHex
+    };
+
+    it('should add the inscription UTXO as input 0 and recipient as output 0', async () => {
+      const psbtSpy = vi.spyOn(bitcoin, 'Psbt');
+      const feeUtxos: UTXO[] = [
+        { txid: feeTxid, vout: 0, value: RIBBITS_PER_PEP, rawHex: validDummyHex }
+      ];
+
+      await createSignedInscriptionTx(signer, recipient, inscriptionUtxo, feeUtxos, 100_000);
+
+      const psbtInstance = psbtSpy.mock.results[psbtSpy.mock.results.length - 1].value;
+      const firstInput = psbtInstance.addInput.mock.calls[0][0];
+      const firstOutput = psbtInstance.addOutput.mock.calls[0][0];
+
+      expect(firstInput.hash).toBe(inscriptionTxid);
+      expect(firstInput.index).toBe(0);
+      expect(firstOutput.address).toBe(recipient);
+      expect(firstOutput.value).toBe(BigInt(inscriptionUtxo.value));
+    });
+
+    it('should preserve the original postage on the recipient output', async () => {
+      const psbtSpy = vi.spyOn(bitcoin, 'Psbt');
+      const feeUtxos: UTXO[] = [
+        { txid: feeTxid, vout: 0, value: RIBBITS_PER_PEP, rawHex: validDummyHex }
+      ];
+
+      await createSignedInscriptionTx(signer, recipient, inscriptionUtxo, feeUtxos, 100_000);
+
+      const psbtInstance = psbtSpy.mock.results[psbtSpy.mock.results.length - 1].value;
+      const recipientOutput = psbtInstance.addOutput.mock.calls[0][0];
+      expect(recipientOutput.value).toBe(BigInt(10000));
+    });
+
+    it('should add a change output back to the sender when leftover > 0', async () => {
+      const psbtSpy = vi.spyOn(bitcoin, 'Psbt');
+      const feeUtxos: UTXO[] = [
+        { txid: feeTxid, vout: 0, value: RIBBITS_PER_PEP, rawHex: validDummyHex }
+      ];
+
+      await createSignedInscriptionTx(signer, recipient, inscriptionUtxo, feeUtxos, 100_000);
+
+      const psbtInstance = psbtSpy.mock.results[psbtSpy.mock.results.length - 1].value;
+      // outputs: [recipient, change]
+      expect(psbtInstance.addOutput.mock.calls.length).toBe(2);
+      const change = psbtInstance.addOutput.mock.calls[1][0];
+      expect(change.value).toBe(BigInt(RIBBITS_PER_PEP - 100_000));
+    });
+
+    it('should omit change output when fee inputs exactly cover the fee', async () => {
+      const psbtSpy = vi.spyOn(bitcoin, 'Psbt');
+      const feeUtxos: UTXO[] = [{ txid: feeTxid, vout: 0, value: 100_000, rawHex: validDummyHex }];
+
+      await createSignedInscriptionTx(signer, recipient, inscriptionUtxo, feeUtxos, 100_000);
+
+      const psbtInstance = psbtSpy.mock.results[psbtSpy.mock.results.length - 1].value;
+      expect(psbtInstance.addOutput.mock.calls.length).toBe(1);
+    });
+
+    it('should throw when fee inputs do not cover the fee', async () => {
+      const feeUtxos: UTXO[] = [{ txid: feeTxid, vout: 0, value: 50_000, rawHex: validDummyHex }];
+      await expect(
+        createSignedInscriptionTx(signer, recipient, inscriptionUtxo, feeUtxos, 100_000)
+      ).rejects.toThrow('Insufficient funds to cover fee');
+    });
+
+    it('should throw when inscription UTXO is missing rawHex', async () => {
+      const bare: UTXO = { txid: inscriptionTxid, vout: 0, value: 10000 };
+      const feeUtxos: UTXO[] = [
+        { txid: feeTxid, vout: 0, value: RIBBITS_PER_PEP, rawHex: validDummyHex }
+      ];
+      await expect(
+        createSignedInscriptionTx(signer, recipient, bare, feeUtxos, 100_000)
+      ).rejects.toThrow('Missing raw hex');
     });
   });
 });

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -184,6 +184,72 @@ export async function createSignedTx(
 }
 
 /**
+ * Build, sign, and finalize an inscription transfer.
+ *
+ * Ord follows the first-input/first-output rule: the sat range from the first
+ * input falls into the first output. So we lock the inscription UTXO into
+ * input 0 and the recipient (preserving postage) into output 0. Fee inputs
+ * and change come after.
+ */
+export async function createSignedInscriptionTx(
+  signer: Signer,
+  recipient: string,
+  inscriptionUtxo: UTXO,
+  feeUtxos: UTXO[],
+  feeRibbits: number
+): Promise<string> {
+  if (!inscriptionUtxo.rawHex) {
+    throw new Error(`Missing raw hex for UTXO ${inscriptionUtxo.txid}`);
+  }
+
+  const feeInputSum = feeUtxos.reduce((sum, u) => sum + u.value, 0);
+  const change = feeInputSum - feeRibbits;
+
+  if (change < 0) {
+    throw new Error('Insufficient funds to cover fee');
+  }
+
+  const psbt = new bitcoin.Psbt({ network: PEPECOIN });
+  psbt.version = 1;
+
+  psbt.addInput({
+    hash: inscriptionUtxo.txid,
+    index: inscriptionUtxo.vout,
+    nonWitnessUtxo: new Uint8Array(Buffer.from(inscriptionUtxo.rawHex, 'hex'))
+  });
+
+  for (const utxo of feeUtxos) {
+    if (!utxo.rawHex) throw new Error(`Missing raw hex for UTXO ${utxo.txid}`);
+    psbt.addInput({
+      hash: utxo.txid,
+      index: utxo.vout,
+      nonWitnessUtxo: new Uint8Array(Buffer.from(utxo.rawHex, 'hex'))
+    });
+  }
+
+  psbt.addOutput({
+    address: recipient,
+    value: BigInt(inscriptionUtxo.value)
+  });
+
+  if (change > 0) {
+    const { address: myAddress } = bitcoin.payments.p2pkh({
+      pubkey: signer.publicKey,
+      network: PEPECOIN
+    });
+    psbt.addOutput({
+      address: myAddress!,
+      value: BigInt(change)
+    });
+  }
+
+  psbt.signAllInputs(signer);
+  psbt.finalizeAllInputs();
+
+  return psbt.extractTransaction().toHex();
+}
+
+/**
  * Sign an arbitrary message with a P2PKH private key.
  * This uses the standard Bitcoin (Pepecoin) signed message format.
  */

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -246,7 +246,10 @@ export async function createSignedInscriptionTx(
   psbt.signAllInputs(signer);
   psbt.finalizeAllInputs();
 
-  return psbt.extractTransaction().toHex();
+  // Bypass bitcoinjs-lib's 5000 sat/byte safety check: the soft-dust surcharge
+  // (~4M ribbits) is concentrated in a small ~374-byte tx, which trips the
+  // guard even though the absolute fee is correct for Pepecoin's miner policy.
+  return psbt.extractTransaction(true).toHex();
 }
 
 /**

--- a/src/views/inscriptions/InscriptionDetailView.vue
+++ b/src/views/inscriptions/InscriptionDetailView.vue
@@ -57,6 +57,10 @@ onMounted(async () => {
 function openExplorer() {
   pepeExplorer.openInscription(settingsStore.settings.explorer, id);
 }
+
+function goToSend() {
+  router.push(`/inscription/${id}/send`);
+}
 </script>
 
 <template>
@@ -137,9 +141,12 @@ function openExplorer() {
     </div>
 
     <template #actions>
-      <PepButton v-if="inscription" id="view-on-explorer" @click="openExplorer" class="w-full">
-        View on Explorer
-      </PepButton>
+      <div v-if="inscription" class="w-full space-y-3">
+        <PepButton id="send-inscription" @click="goToSend" class="w-full"> Send </PepButton>
+        <PepButton id="view-on-explorer" @click="openExplorer" variant="secondary" class="w-full">
+          View on Explorer
+        </PepButton>
+      </div>
     </template>
   </PepMainLayout>
 </template>

--- a/src/views/inscriptions/send/SendInscriptionStepForm.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepForm.vue
@@ -31,7 +31,7 @@ onMounted(() => {
           <span class="text-[10px] font-bold tracking-widest text-slate-500 uppercase"
             >Sending Inscription</span
           >
-          <span class="text-offwhite truncate text-sm font-bold">#{{ inscription.number }}</span>
+          <span class="text-offwhite truncate text-sm font-bold">{{ inscription.number }}</span>
         </div>
       </div>
 

--- a/src/views/inscriptions/send/SendInscriptionStepForm.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepForm.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import type { Inscription } from '@/models/Inscription';
+
+const props = defineProps<{
+  form: any;
+  inscription: Inscription;
+  isInsufficientFunds: boolean;
+  displayFee: string;
+}>();
+
+defineEmits(['address-blur', 'next']);
+
+const recipientInput = ref<any>(null);
+
+onMounted(() => {
+  if (!props.form.recipient) {
+    setTimeout(() => recipientInput.value?.focus(), 50);
+  }
+});
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col">
+    <PepForm id="send-inscription-form" class="flex flex-1 flex-col" @submit="$emit('next')">
+      <div class="flex items-center gap-3 rounded-2xl border border-slate-700 bg-slate-800 p-3">
+        <div class="h-16 w-16 shrink-0 overflow-hidden rounded-xl border border-slate-700">
+          <PepInscription :id="inscription.id" :content-type="inscription.contentType" />
+        </div>
+        <div class="flex min-w-0 flex-col">
+          <span class="text-[10px] font-bold tracking-widest text-slate-500 uppercase"
+            >Sending Inscription</span
+          >
+          <span class="text-offwhite truncate text-sm font-bold">#{{ inscription.number }}</span>
+        </div>
+      </div>
+
+      <PepInput
+        ref="recipientInput"
+        v-model="form.recipient"
+        id="recipient"
+        label="Recipient Address"
+        placeholder="Enter address"
+        :error="form.errors.recipient"
+        :disabled="form.isProcessing"
+        clearable
+        autofocus
+        @blur="$emit('address-blur')"
+      />
+
+      <div class="px-1">
+        <div class="flex flex-col">
+          <span class="text-[10px] font-bold tracking-wider text-slate-500 uppercase"
+            >Estimated Fee</span
+          >
+          <span class="text-xs font-bold text-slate-300">{{ displayFee }}</span>
+        </div>
+      </div>
+
+      <div class="mt-2 flex h-6 items-center justify-center">
+        <p
+          class="text-center text-sm font-medium text-red-400 transition-opacity duration-200"
+          :class="form.errors.general ? 'opacity-100' : 'pointer-events-none opacity-0 select-none'"
+        >
+          {{ form.errors.general }}
+        </p>
+      </div>
+    </PepForm>
+  </div>
+</template>

--- a/src/views/inscriptions/send/SendInscriptionStepReview.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepReview.vue
@@ -31,7 +31,7 @@ const { wallet: walletStore } = useApp();
               >Sending</span
             >
             <span class="text-offwhite truncate text-base font-bold"
-              >Inscription #{{ inscription.number }}</span
+              >Inscription {{ inscription.number }}</span
             >
           </div>
         </div>

--- a/src/views/inscriptions/send/SendInscriptionStepReview.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepReview.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useApp } from '@/composables/useApp';
+import type { Inscription } from '@/models/Inscription';
+
+defineProps<{
+  form: any;
+  inscription: Inscription;
+  displayFee: string;
+}>();
+
+defineEmits(['send']);
+
+const { wallet: walletStore } = useApp();
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col">
+    <PepForm
+      id="send-inscription-review-form"
+      :loading="form.isProcessing"
+      class="flex flex-1 flex-col"
+      @submit="$emit('send')"
+    >
+      <div class="space-y-4 rounded-2xl border border-slate-700 bg-slate-800 p-4 text-left">
+        <div class="flex items-center gap-3">
+          <div class="h-16 w-16 shrink-0 overflow-hidden rounded-xl border border-slate-700">
+            <PepInscription :id="inscription.id" :content-type="inscription.contentType" />
+          </div>
+          <div class="flex min-w-0 flex-col">
+            <span class="text-[10px] font-bold tracking-widest text-slate-500 uppercase"
+              >Sending</span
+            >
+            <span class="text-offwhite truncate text-base font-bold"
+              >Inscription #{{ inscription.number }}</span
+            >
+          </div>
+        </div>
+
+        <div class="flex flex-col space-y-0.5">
+          <span class="text-[10px] font-bold tracking-widest text-slate-500 uppercase">To</span>
+          <span class="font-mono text-xs leading-relaxed break-all text-slate-300">{{
+            form.recipient
+          }}</span>
+        </div>
+
+        <div class="flex flex-col space-y-0.5">
+          <span class="text-[10px] font-bold tracking-widest text-slate-500 uppercase"
+            >Network Fee</span
+          >
+          <span class="text-sm font-bold text-slate-400">{{ displayFee }}</span>
+        </div>
+      </div>
+
+      <div v-if="!walletStore.isMnemonicLoaded" class="mt-0">
+        <PepPasswordInput
+          v-model="form.password"
+          id="confirm-password"
+          label="Enter Password to Confirm"
+          placeholder="Enter your password"
+          :error="form.errors.general"
+        />
+      </div>
+
+      <div v-if="walletStore.isMnemonicLoaded" class="mt-2 flex h-6 items-center justify-center">
+        <p
+          class="text-center text-sm font-medium text-red-400 transition-opacity duration-200"
+          :class="form.hasError() ? 'opacity-100' : 'pointer-events-none opacity-0 select-none'"
+        >
+          {{ form.errors.general }}
+        </p>
+      </div>
+    </PepForm>
+  </div>
+</template>

--- a/src/views/inscriptions/send/SendInscriptionStepSuccess.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepSuccess.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{
+  txid: string;
+}>();
+</script>
+
+<template>
+  <div class="flex flex-1 flex-col">
+    <PepSuccessState title="Inscription sent!" description="Your inscription is on its way.">
+      <PepCopyableId label="Transaction ID" :id="txid" />
+    </PepSuccessState>
+  </div>
+</template>

--- a/src/views/inscriptions/send/SendInscriptionView.vue
+++ b/src/views/inscriptions/send/SendInscriptionView.vue
@@ -1,0 +1,255 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useApp } from '@/composables/useApp';
+import { useSendInscription } from '@/composables/useSendInscription';
+import { useInscriptionStore } from '@/stores/inscriptions';
+import { fetchInscription } from '@/utils/api';
+import { isValidAddress } from '@/utils/crypto';
+import { useForm } from '@/utils/form';
+import { UX_DELAY_FAST, UX_DELAY_SLOW } from '@/utils/constants';
+import { pepeExplorer } from '@/utils/explorer';
+import * as price from '@/utils/price';
+import type { Inscription } from '@/models/Inscription';
+
+import SendInscriptionStepForm from './SendInscriptionStepForm.vue';
+import SendInscriptionStepReview from './SendInscriptionStepReview.vue';
+import SendInscriptionStepSuccess from './SendInscriptionStepSuccess.vue';
+
+const { router, route, settings: settingsStore } = useApp();
+const inscriptionStore = useInscriptionStore();
+const {
+  isLoadingFees,
+  estimatedFeeRibbits,
+  isInsufficientFunds,
+  loadFees,
+  validateRecipient,
+  send
+} = useSendInscription();
+
+const id = route.params.id as string;
+
+const fetched = ref<Inscription | null>(null);
+const inscription = computed<Inscription | null>(() => {
+  const stored = inscriptionStore.inscriptions[id];
+  if (stored) return stored as Inscription;
+  return fetched.value;
+});
+
+const isLoadingInscription = ref(false);
+const inscriptionError = ref('');
+
+const form = useForm({
+  recipient: '',
+  password: '',
+  step: 1,
+  txid: ''
+});
+
+const displayFee = computed(() => price.formatPep(estimatedFeeRibbits.value));
+
+const canReview = computed(() => {
+  return (
+    !isLoadingFees.value &&
+    !!form.recipient &&
+    !form.hasError() &&
+    !isInsufficientFunds.value &&
+    !!inscription.value
+  );
+});
+
+const nextButtonLabel = computed(() => {
+  if (isLoadingFees.value) return 'Loading...';
+  if (isInsufficientFunds.value) return 'Insufficient funds';
+  return 'Next';
+});
+
+watch(
+  () => form.recipient,
+  (val) => {
+    const stripped = val.replace(/\s/g, '');
+    if (stripped !== val) form.recipient = stripped;
+  }
+);
+
+function handleAddressBlur() {
+  if (!form.recipient) {
+    form.clearError('recipient');
+    return;
+  }
+  if (!isValidAddress(form.recipient)) {
+    form.setError('recipient', 'Invalid address format');
+    return;
+  }
+  form.clearError('recipient');
+}
+
+async function handleReview() {
+  form.isProcessing = true;
+  form.clearError('general');
+  const startTime = Date.now();
+
+  try {
+    await validateRecipient(form.recipient);
+    const elapsed = Date.now() - startTime;
+    if (elapsed < 500) await new Promise((r) => setTimeout(r, 500 - elapsed));
+    form.step = 2;
+  } catch (e: any) {
+    form.setError('general', e.message || 'Validation failed');
+  } finally {
+    form.isProcessing = false;
+  }
+}
+
+async function handleSend() {
+  if (!inscription.value) return;
+  form.isProcessing = true;
+  form.clearError('general');
+  const startTime = Date.now();
+
+  try {
+    const txid = await send(inscription.value, form.recipient, form.password);
+    form.txid = txid;
+    const elapsed = Date.now() - startTime;
+    if (elapsed < 500) await new Promise((r) => setTimeout(r, 500 - elapsed));
+
+    form.recipient = '';
+    form.password = '';
+    form.step = 3;
+  } catch (e: any) {
+    form.setError('general', e.message || 'Failed to send');
+  } finally {
+    form.isProcessing = false;
+  }
+}
+
+function handleCancel() {
+  form.reset();
+  router.push(`/inscription/${id}`);
+}
+
+function handleClose() {
+  form.reset();
+  router.push('/inscriptions');
+}
+
+function openExplorer() {
+  pepeExplorer.openTx(settingsStore.settings.explorer, form.txid);
+}
+
+onMounted(async () => {
+  if (!inscription.value) {
+    isLoadingInscription.value = true;
+    try {
+      fetched.value = await fetchInscription(id);
+    } catch (e: any) {
+      inscriptionError.value = e?.message || 'Failed to load inscription';
+    } finally {
+      isLoadingInscription.value = false;
+    }
+  }
+
+  try {
+    await loadFees();
+  } catch (e) {
+    // surfaced via isInsufficientFunds / loading state
+  }
+});
+</script>
+
+<template>
+  <PepMainLayout>
+    <template #header>
+      <PepPageHeader
+        :title="form.step === 3 ? 'Success' : 'Send Inscription'"
+        :onBack="
+          form.step === 3
+            ? handleClose
+            : form.step === 2
+              ? () => {
+                  form.step = 1;
+                  form.clearError();
+                  form.password = '';
+                }
+              : form.step === 1
+                ? handleCancel
+                : undefined
+        "
+      />
+    </template>
+
+    <div
+      v-if="isLoadingInscription"
+      class="flex flex-1 flex-col items-center justify-center space-y-4"
+    >
+      <PepSpinner size="32" class="text-pep-green" />
+      <p class="text-sm font-bold tracking-widest text-slate-500 uppercase">Loading...</p>
+    </div>
+
+    <div
+      v-else-if="inscriptionError"
+      class="flex flex-1 flex-col items-center justify-center space-y-4 text-center"
+    >
+      <p class="font-bold text-red-400">{{ inscriptionError }}</p>
+    </div>
+
+    <SendInscriptionStepForm
+      v-else-if="inscription && form.step === 1"
+      :form="form"
+      :inscription="inscription"
+      :isInsufficientFunds="isInsufficientFunds"
+      :displayFee="displayFee"
+      @address-blur="handleAddressBlur"
+      @next="handleReview"
+    />
+
+    <SendInscriptionStepReview
+      v-else-if="inscription && form.step === 2"
+      :form="form"
+      :inscription="inscription"
+      :displayFee="displayFee"
+      @send="handleSend"
+    />
+
+    <SendInscriptionStepSuccess v-if="form.step === 3" :txid="form.txid" />
+
+    <template #actions>
+      <PepLoadingButton
+        v-if="inscription && form.step === 1"
+        @click="handleReview"
+        :loading="form.isProcessing"
+        :minLoadingMs="UX_DELAY_FAST"
+        :disabled="!canReview"
+        :variant="isInsufficientFunds ? 'danger' : 'primary'"
+        class="w-full"
+      >
+        {{ nextButtonLabel }}
+      </PepLoadingButton>
+
+      <div v-if="inscription && form.step === 2" class="space-y-3">
+        <PepLoadingButton
+          @click="handleSend"
+          :loading="form.isProcessing"
+          :minLoadingMs="UX_DELAY_SLOW"
+          :disabled="form.hasError()"
+          class="w-full"
+        >
+          Send
+        </PepLoadingButton>
+        <PepButton
+          type="button"
+          @click="handleCancel"
+          variant="secondary"
+          :disabled="form.isProcessing"
+          class="w-full"
+        >
+          Cancel
+        </PepButton>
+      </div>
+
+      <div v-if="form.step === 3" class="w-full space-y-3">
+        <PepButton @click="openExplorer" class="w-full">View on Explorer</PepButton>
+        <PepButton @click="handleClose" variant="secondary" class="w-full">Close</PepButton>
+      </div>
+    </template>
+  </PepMainLayout>
+</template>


### PR DESCRIPTION
## Summary
- Adds a 3-step send flow (form → review → success) for transferring an inscription to another address.
- Builds the transfer per ord's first-input/first-output rule: inscription UTXO is locked to input 0, recipient gets output 0 with the original postage, fee inputs and change follow.
- Adds a primary **Send** button to the inscription detail view; "View on Explorer" is now secondary.

Stacked on top of #40.

## Test plan
- [x] Open an inscription and tap **Send** — flow opens at `/inscription/:id/send`.
- [x] Enter an invalid address → inline error.
- [x] Enter own address → "Cannot send to your own address".
- [x] Insufficient PEP balance for fee → button shows "Insufficient funds".
- [x] Happy path → review screen shows inscription preview, recipient, network fee.
- [x] Confirm → broadcast succeeds, success screen shows txid + explorer link.
- [x] Verify on-chain that the inscription moved (sat on output 0 of the new tx, postage preserved).
- [x] Inscription disappears from sender's inscriptions list after the next sync.