### PR TITLE
Add broadcast option to signPsbt

### DIFF
--- a/DAPP_INTEGRATION.md
+++ b/DAPP_INTEGRATION.md
@@ -115,12 +115,38 @@ console.log('Transaction Broadcasted:', txid);
 Sign a Partially Signed Pepecoin Transaction (PSBT). The dApp provides a base64-encoded PSBT, and the wallet signs only the inputs that match the user's public key.
 
 ```javascript
-const { psbt, signedIndexes } = await provider.request('signPsbt', {
+const { psbt } = await provider.request('signPsbt', {
   psbt: 'base64_encoded_psbt_string...'
 });
 
 // psbt: base64-encoded PSBT with signatures added
-// signedIndexes: array of input indexes that were signed (e.g. [0, 2])
+```
+
+**Parameters**
+
+| Property | Type | Description |
+|---|---|---|
+| `psbt` | `string` | The base64-encoded PSBT to sign. |
+| `broadcast` | `boolean` (optional) | If `true`, the wallet finalizes the PSBT after signing and broadcasts the resulting transaction. Defaults to `false`. |
+
+**Result (`SignPsbtResult`)**
+
+| Property | Description |
+|---|---|
+| `psbt` | The base64-encoded signed PSBT. |
+| `txid` | The transaction id as a hex-encoded string. Only returned when the transaction was broadcast (`broadcast: true`). |
+
+**Broadcasting after signing**
+
+Set `broadcast: true` to have the wallet finalize and broadcast the PSBT once the user approves. Otherwise the signed PSBT is returned without broadcasting, so the dApp (or another party) can finalize and broadcast it later.
+
+```javascript
+const { psbt, txid } = await provider.request('signPsbt', {
+  psbt: 'base64_encoded_psbt_string...',
+  broadcast: true
+});
+
+console.log('Transaction Broadcasted:', txid);
 ```
 
 ---

--- a/dev/connect.html
+++ b/dev/connect.html
@@ -289,9 +289,37 @@
         <div id="send-status" class="status" style="margin-top: 0.5rem;">—</div>
     </div>
 
+    <!-- Sign PSBT -->
+    <div class="card">
+        <h2>6. Sign PSBT</h2>
+        <p class="status" style="margin-bottom: 0.5rem;">
+            Builds a simple 1-in / 1-out PSBT spending a confirmed UTXO from the connected address,
+            or paste a base64 PSBT below.
+        </p>
+        <div class="field">
+            <label>Recipient Address</label>
+            <input id="psbt-recipient" type="text" placeholder="Paddr...">
+        </div>
+        <div class="field">
+            <label>Amount (ribbits)</label>
+            <input id="psbt-amount" type="number" placeholder="100000000" value="100000000">
+        </div>
+        <div class="field">
+            <label>Or paste base64 PSBT (optional — overrides builder)</label>
+            <input id="psbt-raw" type="text" placeholder="cHNidP8BAH...">
+        </div>
+        <div class="row">
+            <label style="display: inline-flex; align-items: center; gap: 0.4rem; margin-bottom: 0;">
+                <input id="psbt-broadcast" type="checkbox"> broadcast
+            </label>
+            <button id="btn-sign-psbt" disabled>Sign PSBT</button>
+        </div>
+        <div id="psbt-status" class="status" style="margin-top: 0.5rem;">—</div>
+    </div>
+
     <!-- Disconnect -->
     <div class="card">
-        <h2>6. Disconnect</h2>
+        <h2>7. Disconnect</h2>
         <div class="row">
             <button id="btn-disconnect" class="danger" disabled>Disconnect</button>
             <span id="disconnect-status" class="status">—</span>
@@ -308,6 +336,14 @@
         </div>
     </div>
 
+    <script type="module">
+        // Load bitcoinjs-lib + buffer for the PSBT builder. Exposed on window
+        // for the non-module script below.
+        import * as bitcoin from 'https://esm.sh/bitcoinjs-lib@6.1.5';
+        import { Buffer } from 'https://esm.sh/buffer@6.0.3';
+        window._bitcoin = bitcoin;
+        window._buffer = Buffer;
+    </script>
     <script>
         let provider = null;
 
@@ -346,8 +382,12 @@
             document.getElementById('btn-sign').disabled = false;
             document.getElementById('btn-send').disabled = false;
             document.getElementById('btn-add-recipient').disabled = false;
+            document.getElementById('btn-sign-psbt').disabled = false;
             document.getElementById('btn-disconnect').disabled = false;
         }
+
+        // Track connected address for PSBT builder
+        let connectedAddress = null;
 
         function showProviderInfo(p) {
             const info = document.getElementById('provider-info');
@@ -395,6 +435,7 @@
             try {
                 const result = await provider.request('wallet_connect');
                 const addr = Array.isArray(result) ? result[0] : result;
+                connectedAddress = addr;
                 setStatus('connect-status', addr, 'ok');
                 log('wallet_connect', 'ok', addr);
             } catch (err) {
@@ -409,6 +450,7 @@
             try {
                 const accounts = await provider.request('getAccounts');
                 const text = Array.isArray(accounts) ? accounts.join(', ') : JSON.stringify(accounts);
+                if (Array.isArray(accounts) && accounts[0]) connectedAddress = accounts[0];
                 setStatus('accounts-status', text, 'ok');
                 log('getAccounts', 'ok', text);
             } catch (err) {
@@ -476,6 +518,84 @@
             } catch (err) {
                 setStatus('send-status', err.message, 'err');
                 log('sendTransfer', 'err', err.message);
+            }
+        });
+
+        // --- signPsbt ---
+        const PEPECOIN_NETWORK = {
+            messagePrefix: '\x19Pepecoin Signed Message:\n',
+            bech32: 'pep',
+            bip32: { public: 0x0488b21e, private: 0x0488ade4 },
+            pubKeyHash: 0x38,
+            scriptHash: 0x16,
+            wif: 0x9e
+        };
+        const API_BASE = 'https://peppool.space/api';
+        const FEE_RIBBITS = 50000; // generous flat fee for the dev builder
+
+        async function buildSamplePsbt(recipient, amount) {
+            const { Psbt, Transaction, address: bAddress } = window._bitcoin;
+            const Buffer = window._buffer;
+
+            const utxosResp = await fetch(`${API_BASE}/address/${connectedAddress}/utxo`);
+            if (!utxosResp.ok) throw new Error('Failed to fetch UTXOs');
+            const utxos = await utxosResp.json();
+            const confirmed = utxos.filter(u => u.status?.confirmed);
+            const need = amount + FEE_RIBBITS;
+            const utxo = confirmed.find(u => u.value >= need);
+            if (!utxo) throw new Error(`No single confirmed UTXO with value >= ${need} ribbits`);
+
+            const hexResp = await fetch(`${API_BASE}/tx/${utxo.txid}/hex`);
+            if (!hexResp.ok) throw new Error('Failed to fetch tx hex');
+            const rawHex = (await hexResp.text()).trim();
+
+            const psbt = new Psbt({ network: PEPECOIN_NETWORK });
+            psbt.setVersion(1);
+            psbt.addInput({
+                hash: utxo.txid,
+                index: utxo.vout,
+                nonWitnessUtxo: Buffer.from(rawHex, 'hex')
+            });
+            psbt.addOutput({
+                address: recipient,
+                value: amount
+            });
+            const change = utxo.value - amount - FEE_RIBBITS;
+            if (change > 0) {
+                psbt.addOutput({ address: connectedAddress, value: change });
+            }
+            return psbt.toBase64();
+        }
+
+        document.getElementById('btn-sign-psbt').addEventListener('click', async () => {
+            const recipient = document.getElementById('psbt-recipient').value.trim();
+            const amount = parseInt(document.getElementById('psbt-amount').value, 10);
+            const raw = document.getElementById('psbt-raw').value.trim();
+            const broadcast = document.getElementById('psbt-broadcast').checked;
+
+            try {
+                let base64Psbt;
+                if (raw) {
+                    base64Psbt = raw;
+                } else {
+                    if (!connectedAddress) throw new Error('Connect the wallet first');
+                    if (!recipient) throw new Error('Enter a recipient address');
+                    if (!amount || amount <= 0) throw new Error('Enter a valid amount');
+                    if (!window._bitcoin) throw new Error('bitcoinjs-lib still loading — try again in a moment');
+                    setStatus('psbt-status', 'Building PSBT…', '');
+                    base64Psbt = await buildSamplePsbt(recipient, amount);
+                }
+
+                setStatus('psbt-status', `Requesting signature${broadcast ? ' + broadcast' : ''}…`, '');
+                const result = await provider.request('signPsbt', { psbt: base64Psbt, broadcast });
+                const text = result.txid
+                    ? `txid: ${result.txid}\npsbt: ${result.psbt}`
+                    : `psbt: ${result.psbt}`;
+                setStatus('psbt-status', text, 'ok');
+                log('signPsbt', 'ok', result.txid ? `broadcast ${result.txid}` : 'signed (not broadcast)');
+            } catch (err) {
+                setStatus('psbt-status', err.message, 'err');
+                log('signPsbt', 'err', err.message);
             }
         });
 

--- a/src/views/approval/SignTxView.spec.ts
+++ b/src/views/approval/SignTxView.spec.ts
@@ -54,6 +54,9 @@ const { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt }
     const mockExtractTransaction = vi.fn().mockReturnValue({ toHex: () => 'finalized-tx-hex' });
     const mockPsbt = {
       inputCount: 2,
+      txInputs: [],
+      txOutputs: [],
+      data: { inputs: [] },
       signInput: mockSignInput,
       finalizeAllInputs: mockFinalizeAllInputs,
       extractTransaction: mockExtractTransaction,

--- a/src/views/approval/SignTxView.spec.ts
+++ b/src/views/approval/SignTxView.spec.ts
@@ -47,15 +47,21 @@ vi.mock('@/utils/crypto', () => ({
 
 // Mock bitcoinjs-lib for signPsbt tests
 // vi.mock is hoisted — cannot reference local variables, so use vi.hoisted
-const { mockSignInput, mockPsbt } = vi.hoisted(() => {
-  const mockSignInput = vi.fn();
-  const mockPsbt = {
-    inputCount: 2,
-    signInput: mockSignInput,
-    toBase64: vi.fn().mockReturnValue('signed-psbt-base64')
-  };
-  return { mockSignInput, mockPsbt };
-});
+const { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt } = vi.hoisted(
+  () => {
+    const mockSignInput = vi.fn();
+    const mockFinalizeAllInputs = vi.fn();
+    const mockExtractTransaction = vi.fn().mockReturnValue({ toHex: () => 'finalized-tx-hex' });
+    const mockPsbt = {
+      inputCount: 2,
+      signInput: mockSignInput,
+      finalizeAllInputs: mockFinalizeAllInputs,
+      extractTransaction: mockExtractTransaction,
+      toBase64: vi.fn().mockReturnValue('signed-psbt-base64')
+    };
+    return { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt };
+  }
+);
 vi.mock('bitcoinjs-lib', () => ({
   Psbt: {
     fromBase64: vi.fn().mockReturnValue(mockPsbt)
@@ -299,10 +305,60 @@ describe('SignTxView', () => {
     expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith({
       target: 'peppool-background-response',
       requestId: 'req123',
-      result: { psbt: 'signed-psbt-base64', signedIndexes: [0] }
+      result: { psbt: 'signed-psbt-base64' }
     });
+    expect(mockFinalizeAllInputs).not.toHaveBeenCalled();
+    const apiNoBroadcast = await import('@/utils/api');
+    expect(apiNoBroadcast.broadcastTx).not.toHaveBeenCalled();
 
     // Restore for other tests
+    (window as any).location.search = '?id=req123&origin=https://test-dapp.com&method=sendTransfer';
+  });
+
+  it('signPsbt finalizes and broadcasts when broadcast flag is true', async () => {
+    (window as any).location.search = '?id=req123&origin=https://test-dapp.com&method=signPsbt';
+
+    (global.chrome.storage.local.get as any).mockImplementation((key: string) => {
+      if (key === 'request_req123') {
+        return Promise.resolve({
+          request_req123: {
+            requestId: 'req123',
+            method: 'signPsbt',
+            params: { psbt: 'base64-psbt-data', broadcast: true },
+            origin: 'https://test-dapp.com'
+          }
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    mockSignInput.mockImplementation(() => {});
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+    vi.spyOn(store, 'refreshBalance').mockResolvedValue(undefined as any);
+
+    const wrapper = mount(SignTxView, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockFinalizeAllInputs).toHaveBeenCalled();
+    const api = await import('@/utils/api');
+    expect(api.broadcastTx).toHaveBeenCalledWith('finalized-tx-hex');
+    expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      target: 'peppool-background-response',
+      requestId: 'req123',
+      result: { psbt: 'signed-psbt-base64', txid: 'mock-txid' }
+    });
+
     (window as any).location.search = '?id=req123&origin=https://test-dapp.com&method=sendTransfer';
   });
 

--- a/src/views/approval/SignTxView.vue
+++ b/src/views/approval/SignTxView.vue
@@ -48,7 +48,6 @@ const txDetails = computed(() => {
       : [{ address: params.recipient, amount: params.amount }];
 
     return {
-      type: 'Transfer',
       recipients: recipients.map((r: any) => ({
         address: r.address,
         amountPep: r.amount / RIBBITS_PER_PEP
@@ -60,7 +59,6 @@ const txDetails = computed(() => {
 
   if (method.value === 'signPsbt') {
     return {
-      type: 'Sign PSBT',
       psbt: requestData.value.params.psbt,
       broadcast: requestData.value.params.broadcast === true
     };
@@ -267,7 +265,7 @@ async function handleReject() {
     <div v-else-if="txDetails" class="space-y-6">
       <div class="space-y-2 text-center">
         <h2 class="truncate text-sm font-medium text-slate-400">{{ origin }}</h2>
-        <p class="text-lg font-bold text-white">Requests {{ txDetails.type }}</p>
+        <p class="text-lg font-bold text-white">Review Transaction</p>
       </div>
 
       <div v-if="method === 'sendTransfer'" class="space-y-4">

--- a/src/views/approval/SignTxView.vue
+++ b/src/views/approval/SignTxView.vue
@@ -61,7 +61,8 @@ const txDetails = computed(() => {
   if (method.value === 'signPsbt') {
     return {
       type: 'Sign PSBT',
-      psbt: requestData.value.params.psbt
+      psbt: requestData.value.params.psbt,
+      broadcast: requestData.value.params.broadcast === true
     };
   }
 
@@ -192,34 +193,46 @@ async function handleSendTransfer(mnemonic: string) {
 }
 
 async function handleSignPsbt(mnemonic: string) {
-  const { psbt: base64Psbt } = requestData.value.params;
+  const { psbt: base64Psbt, broadcast } = requestData.value.params;
   const psbt = bitcoin.Psbt.fromBase64(base64Psbt, { network: PEPECOIN });
 
   const { accountIndex, addressIndex } = parseDerivationPath(walletStore.activeAccount!.path);
   const signer = deriveSigner(mnemonic, accountIndex, addressIndex);
 
   // Only sign inputs that belong to this signer's key
-  const signedIndexes: number[] = [];
+  let signedCount = 0;
   for (let i = 0; i < psbt.inputCount; i++) {
     try {
       psbt.signInput(i, signer);
-      signedIndexes.push(i);
+      signedCount++;
     } catch {
       // Input does not belong to this signer — skip
     }
   }
 
-  if (signedIndexes.length === 0) {
+  if (signedCount === 0) {
     throw new Error('No inputs in this PSBT belong to your wallet');
+  }
+
+  const result: { psbt: string; txid?: string } = { psbt: psbt.toBase64() };
+
+  if (broadcast === true) {
+    psbt.finalizeAllInputs();
+    const txHex = psbt.extractTransaction().toHex();
+    result.txid = await broadcastTx(txHex);
+    result.psbt = psbt.toBase64();
   }
 
   chrome.runtime.sendMessage({
     target: 'peppool-background-response',
     requestId: requestId.value,
-    result: { psbt: psbt.toBase64(), signedIndexes }
+    result
   });
 
   await chrome.storage.local.remove(`request_${requestId.value}`);
+  if (broadcast === true) {
+    await walletStore.refreshBalance(true);
+  }
   window.close();
 }
 
@@ -281,6 +294,13 @@ async function handleReject() {
           <p class="text-xs leading-relaxed text-slate-400">
             This dApp wants to sign a Partially Signed Transaction (PSBT). Review the details
             carefully.
+          </p>
+          <p
+            v-if="!txDetails.broadcast"
+            class="mt-3 text-xs leading-relaxed font-medium text-amber-400"
+          >
+            This transaction will not be broadcast from your wallet. It may be broadcast later by a
+            third party.
           </p>
           <div
             class="mt-4 h-24 overflow-hidden rounded border border-slate-800 bg-slate-950 p-2 font-mono text-[10px] break-all text-slate-500"

--- a/src/views/approval/SignTxView.vue
+++ b/src/views/approval/SignTxView.vue
@@ -38,34 +38,101 @@ const isProcessing = ref(false);
 
 const isMnemonicLoaded = computed(() => walletStore.isMnemonicLoaded);
 
-const txDetails = computed(() => {
-  if (!requestData.value) return null;
+const transferDetails = computed(() => {
+  if (!requestData.value || method.value !== 'sendTransfer') return null;
+  const params = requestData.value.params;
+  const recipients = Array.isArray(params.recipients)
+    ? params.recipients
+    : [{ address: params.recipient, amount: params.amount }];
 
-  if (method.value === 'sendTransfer') {
-    const params = requestData.value.params;
-    const recipients = Array.isArray(params.recipients)
-      ? params.recipients
-      : [{ address: params.recipient, amount: params.amount }];
-
-    return {
-      recipients: recipients.map((r: any) => ({
-        address: r.address,
-        amountPep: r.amount / RIBBITS_PER_PEP
-      })),
-      totalAmountPep:
-        recipients.reduce((sum: number, r: any) => sum + r.amount, 0) / RIBBITS_PER_PEP
-    };
-  }
-
-  if (method.value === 'signPsbt') {
-    return {
-      psbt: requestData.value.params.psbt,
-      broadcast: requestData.value.params.broadcast === true
-    };
-  }
-
-  return null;
+  return {
+    recipients: recipients.map((r: any) => ({
+      address: r.address,
+      amountPep: r.amount / RIBBITS_PER_PEP
+    })),
+    totalAmountPep: recipients.reduce((sum: number, r: any) => sum + r.amount, 0) / RIBBITS_PER_PEP
+  };
 });
+
+const psbtDetails = computed(() => {
+  if (!requestData.value || method.value !== 'signPsbt') return null;
+  return {
+    psbt: requestData.value.params.psbt,
+    broadcast: requestData.value.params.broadcast === true,
+    ...decodePsbtSummary(requestData.value.params.psbt, walletStore.address)
+  };
+});
+
+const hasDetails = computed(() => !!transferDetails.value || !!psbtDetails.value);
+
+interface PsbtIO {
+  address: string | null;
+  amountPep: number | null;
+  mine: boolean;
+}
+
+function decodePsbtSummary(
+  base64: string,
+  myAddress: string | null
+): { inputs: PsbtIO[]; outputs: PsbtIO[]; netChangePep: number | null; decodeError: boolean } {
+  try {
+    const psbt = bitcoin.Psbt.fromBase64(base64, { network: PEPECOIN });
+
+    const inputs: PsbtIO[] = psbt.txInputs.map((txIn: any, i: number) => {
+      const data = psbt.data.inputs[i];
+      let address: string | null = null;
+      let value: number | null = null;
+      if (data?.nonWitnessUtxo) {
+        const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
+        const out = prevTx.outs[txIn.index];
+        if (out) {
+          value = Number(out.value);
+          try {
+            address = bitcoin.address.fromOutputScript(out.script, PEPECOIN);
+          } catch {
+            /* non-standard script */
+          }
+        }
+      }
+      return {
+        address,
+        amountPep: value === null ? null : value / RIBBITS_PER_PEP,
+        mine: !!myAddress && address === myAddress
+      };
+    });
+
+    const outputs: PsbtIO[] = psbt.txOutputs.map((o: any) => {
+      let address: string | null = null;
+      try {
+        address = bitcoin.address.fromOutputScript(o.script, PEPECOIN);
+      } catch {
+        /* non-standard script */
+      }
+      return {
+        address,
+        amountPep: Number(o.value) / RIBBITS_PER_PEP,
+        mine: !!myAddress && address === myAddress
+      };
+    });
+
+    const allInputAmountsKnown = inputs.every((i) => i.amountPep !== null);
+    let netChangePep: number | null = null;
+    if (allInputAmountsKnown) {
+      const myIn = inputs.filter((i) => i.mine).reduce((s, i) => s + (i.amountPep ?? 0), 0);
+      const myOut = outputs.filter((o) => o.mine).reduce((s, o) => s + (o.amountPep ?? 0), 0);
+      netChangePep = myOut - myIn;
+    }
+
+    return { inputs, outputs, netChangePep, decodeError: false };
+  } catch {
+    return { inputs: [], outputs: [], netChangePep: null, decodeError: true };
+  }
+}
+
+function formatPep(amount: number | null): string {
+  if (amount === null) return '—';
+  return `${amount.toLocaleString('en-US', { maximumFractionDigits: 8 })} PEP`;
+}
 
 onMounted(async () => {
   const params = new URLSearchParams(window.location.search);
@@ -262,15 +329,15 @@ async function handleReject() {
       </div>
     </div>
 
-    <div v-else-if="txDetails" class="space-y-6">
+    <div v-else-if="hasDetails" class="space-y-6">
       <div class="space-y-2 text-center">
         <h2 class="truncate text-sm font-medium text-slate-400">{{ origin }}</h2>
         <p class="text-lg font-bold text-white">Review Transaction</p>
       </div>
 
-      <div v-if="method === 'sendTransfer'" class="space-y-4">
+      <div v-if="transferDetails" class="space-y-4">
         <div
-          v-for="(r, i) in txDetails.recipients"
+          v-for="(r, i) in transferDetails.recipients"
           :key="i"
           class="space-y-3 rounded-xl border border-slate-800 bg-slate-900 p-4"
         >
@@ -287,24 +354,93 @@ async function handleReject() {
         </div>
       </div>
 
-      <div v-if="method === 'signPsbt'" class="space-y-4">
-        <div class="rounded-xl border border-slate-800 bg-slate-900 p-4">
-          <p class="text-xs leading-relaxed text-slate-400">
-            This dApp wants to sign a Partially Signed Transaction (PSBT). Review the details
-            carefully.
+      <div v-if="psbtDetails" class="space-y-3">
+        <!-- Net effect -->
+        <div
+          v-if="psbtDetails.netChangePep !== null"
+          class="rounded-xl border border-slate-800 bg-slate-900 p-4"
+        >
+          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">
+            {{ psbtDetails.netChangePep < 0 ? 'You will send' : 'You will receive' }}
+          </span>
+          <p class="text-pepe-green mt-1 text-lg font-bold">
+            {{ formatPep(Math.abs(psbtDetails.netChangePep)) }}
           </p>
-          <p
-            v-if="!txDetails.broadcast"
-            class="mt-3 text-xs leading-relaxed font-medium text-amber-400"
+        </div>
+
+        <!-- Inputs -->
+        <div
+          v-if="psbtDetails.inputs.length"
+          class="space-y-2 rounded-xl border border-slate-800 bg-slate-900 p-4"
+        >
+          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">From</span>
+          <div
+            v-for="(io, i) in psbtDetails.inputs"
+            :key="`in-${i}`"
+            class="flex items-start justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
           >
+            <div class="min-w-0 space-y-0.5">
+              <p class="font-mono text-xs break-all text-slate-300">
+                {{ io.address ?? 'Non-standard script' }}
+              </p>
+              <span
+                v-if="io.mine"
+                class="text-pepe-green inline-block text-[10px] font-bold tracking-wider uppercase"
+                >Your wallet</span
+              >
+            </div>
+            <span class="shrink-0 text-xs font-bold text-slate-200">{{
+              formatPep(io.amountPep)
+            }}</span>
+          </div>
+        </div>
+
+        <!-- Outputs -->
+        <div
+          v-if="psbtDetails.outputs.length"
+          class="space-y-2 rounded-xl border border-slate-800 bg-slate-900 p-4"
+        >
+          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">To</span>
+          <div
+            v-for="(io, i) in psbtDetails.outputs"
+            :key="`out-${i}`"
+            class="flex items-start justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+          >
+            <div class="min-w-0 space-y-0.5">
+              <p class="font-mono text-xs break-all text-slate-300">
+                {{ io.address ?? 'Non-standard script' }}
+              </p>
+              <span
+                v-if="io.mine"
+                class="text-pepe-green inline-block text-[10px] font-bold tracking-wider uppercase"
+                >Your wallet</span
+              >
+            </div>
+            <span class="shrink-0 text-xs font-bold text-slate-200">{{
+              formatPep(io.amountPep)
+            }}</span>
+          </div>
+        </div>
+
+        <!-- Decode failure fallback -->
+        <div
+          v-if="psbtDetails.decodeError"
+          class="rounded-xl border border-slate-800 bg-slate-900 p-4"
+        >
+          <p class="text-xs leading-relaxed text-slate-400">
+            Unable to decode this PSBT. Only proceed if you trust this dApp.
+          </p>
+        </div>
+
+        <!-- Broadcast warning -->
+        <div
+          v-if="!psbtDetails.broadcast"
+          class="rounded-xl border border-amber-900/50 bg-amber-950/20 p-3"
+        >
+          <p class="text-xs leading-relaxed text-amber-400">
             This transaction will not be broadcast from your wallet. It may be broadcast later by a
             third party.
           </p>
-          <div
-            class="mt-4 h-24 overflow-hidden rounded border border-slate-800 bg-slate-950 p-2 font-mono text-[10px] break-all text-slate-500"
-          >
-            {{ txDetails.psbt }}
-          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- `signPsbt` now accepts an optional `broadcast` flag. When `true`, the wallet finalizes the PSBT after signing, broadcasts the transaction, and returns `{ psbt, txid }`. When omitted/false, the signed PSBT is returned as `{ psbt }` without broadcasting — matching the Xverse `SignPsbtResult` shape.
- Approval popup decodes the PSBT and shows inputs, outputs, and net effect (added in 2c75192), with an Xverse-style warning when `broadcast` is false: *"This transaction will not be broadcast from your wallet. It may be broadcast later by a third party."*
- Removed the non-spec `signedIndexes` field from the response.
- `dev/connect.html` gains a signPsbt section for manual testing (base64 PSBT input + broadcast toggle).
- `DAPP_INTEGRATION.md` updated with the new parameter, result shape, and a broadcast example.

## Test plan
- [x] Unit test: `signPsbt` returns `{ psbt }` and does not broadcast when flag is omitted
- [x] Unit test: `signPsbt` finalizes, broadcasts, and returns `{ psbt, txid }` when `broadcast: true`
- [x] `vue-tsc -b` clean
- [x] `vitest` 561/561 pass
- [x] Manual: dev/connect.html → signPsbt with `broadcast: false` → returns signed PSBT, no tx on chain
- [x] Manual: dev/connect.html → signPsbt with `broadcast: true` → tx appears on peppool.space, balance refreshes