### PR TITLE
Allow Vite dev server in CSP during dev

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,7 +33,21 @@ export default defineConfig(({ command }) => ({
         }
     },
     plugins: [
-        crx({ manifest }),
+        // In dev (`vite`), allow scripts/HMR from the Vite dev server. The
+        // production build keeps the strict CSP from manifest.json.
+        crx({
+            manifest:
+                command === 'serve'
+                    ? {
+                          ...manifest,
+                          content_security_policy: {
+                              ...manifest.content_security_policy,
+                              extension_pages:
+                                  "script-src 'self' 'wasm-unsafe-eval' http://localhost:5173; object-src 'self'; connect-src 'self' https://peppool.space http://localhost:5173 ws://localhost:5173"
+                          }
+                      }
+                    : manifest
+        }),
         vue({
             template: {
                 compilerOptions: {


### PR DESCRIPTION
Fixes #48.

## Summary
- Loading the unpacked `dist/` from `npm run dev` failed with `ERR_FAILED` because `manifest.json`'s strict MV3 `content_security_policy.extension_pages` blocked scripts/HMR from `http://localhost:5173`.
- Patch the manifest CSP only when `command === 'serve'` to add `http://localhost:5173` to `script-src` and `connect-src` (plus `ws://localhost:5173` for HMR). Production CSP is untouched.

## Test plan
- [x] `npm run dev` writes `dist/manifest.json` with the relaxed CSP
- [x] `npm run build` writes `dist/manifest.json` with the original strict CSP
- [x] `vitest` 561/561 pass
- [x] `npm run format` clean
- [ ] Manual: load unpacked `dist/` from `npm run dev` → popup opens, HMR works