### PR TITLE
Remove unreachable password prompt from approval views

### DIFF
--- a/src/composables/useApprovalRequest.spec.ts
+++ b/src/composables/useApprovalRequest.spec.ts
@@ -154,43 +154,8 @@ describe('useApprovalRequest', () => {
   });
 
   describe('runWithMnemonic', () => {
-    it('prompts for password when wallet is locked and password field is empty', async () => {
+    it('invokes withMnemonic and runs the action — wallet is already unlocked by the route guard', async () => {
       const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(false);
-      const action = vi.fn();
-
-      const host = mountHost();
-      await flushPromises();
-
-      await host.api.runWithMnemonic(action);
-
-      expect(host.api.error.value).toBe('Please enter your password');
-      expect(action).not.toHaveBeenCalled();
-      expect(host.api.isProcessing.value).toBe(false);
-    });
-
-    it('shows "Invalid password" when unlock fails, and does not run the action', async () => {
-      const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(false);
-      const unlockSpy = vi.spyOn(store, 'unlock').mockResolvedValue(false);
-      const action = vi.fn();
-
-      const host = mountHost();
-      await flushPromises();
-      host.api.password.value = 'wrong';
-
-      await host.api.runWithMnemonic(action);
-
-      expect(unlockSpy).toHaveBeenCalledWith('wrong');
-      expect(host.api.error.value).toBe('Invalid password');
-      expect(host.api.isProcessing.value).toBe(false);
-      expect(action).not.toHaveBeenCalled();
-    });
-
-    it('unlocks then invokes withMnemonic with the action when password is correct', async () => {
-      const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(false);
-      vi.spyOn(store, 'unlock').mockResolvedValue(true);
       const withMnemonicSpy = vi
         .spyOn(store, 'withMnemonic')
         .mockImplementation((fn: any) => fn('test mnemonic'));
@@ -198,7 +163,6 @@ describe('useApprovalRequest', () => {
 
       const host = mountHost();
       await flushPromises();
-      host.api.password.value = 'correct';
 
       await host.api.runWithMnemonic(action);
 
@@ -206,25 +170,8 @@ describe('useApprovalRequest', () => {
       expect(action).toHaveBeenCalledWith('test mnemonic');
     });
 
-    it('skips password gating when mnemonic is already loaded', async () => {
-      const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
-      const unlockSpy = vi.spyOn(store, 'unlock');
-      vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) => fn('mnemonic'));
-      const action = vi.fn().mockResolvedValue(undefined);
-
-      const host = mountHost();
-      await flushPromises();
-
-      await host.api.runWithMnemonic(action);
-
-      expect(unlockSpy).not.toHaveBeenCalled();
-      expect(action).toHaveBeenCalledWith('mnemonic');
-    });
-
     it('captures errors thrown inside the action into error and resets isProcessing', async () => {
       const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
       vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) => fn('mnemonic'));
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -242,7 +189,6 @@ describe('useApprovalRequest', () => {
 
     it('falls back to "Action failed" when thrown error has no message', async () => {
       const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
       vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) => fn('mnemonic'));
       vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -271,7 +217,6 @@ describe('useApprovalRequest', () => {
 
     it('clears any previous error message at the start of a new run', async () => {
       const store = useWalletStore();
-      vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
       vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) => fn('mnemonic'));
 
       const host = mountHost();

--- a/src/composables/useApprovalRequest.ts
+++ b/src/composables/useApprovalRequest.ts
@@ -1,4 +1,4 @@
-import { ref, computed, onMounted } from 'vue';
+import { ref, onMounted } from 'vue';
 import { useWalletStore } from '@/stores/wallet';
 
 interface ApprovalRequest<TParams = any> {
@@ -23,12 +23,9 @@ export function useApprovalRequest<TParams = any>(opts: UseApprovalRequestOption
   const origin = ref('');
   const method = ref('');
   const requestData = ref<ApprovalRequest<TParams> | null>(null);
-  const password = ref('');
   const error = ref('');
   const invalidRequest = ref('');
   const isProcessing = ref(false);
-
-  const isMnemonicLoaded = computed(() => walletStore.isMnemonicLoaded);
 
   onMounted(async () => {
     const params = new URLSearchParams(window.location.search);
@@ -52,29 +49,16 @@ export function useApprovalRequest<TParams = any>(opts: UseApprovalRequestOption
   });
 
   /**
-   * Ensures the wallet is unlocked, then runs the action with the decrypted mnemonic.
-   * Handles password prompting, error display, and isProcessing state.
+   * Runs the action with the decrypted mnemonic. The router guard already
+   * ensures the wallet is unlocked before any /approve/* route mounts, so no
+   * password prompting is needed here.
    */
   async function runWithMnemonic(action: (mnemonic: string) => Promise<void>) {
     if (!requestId.value || !requestData.value) return;
     error.value = '';
+    isProcessing.value = true;
 
     try {
-      if (!walletStore.isMnemonicLoaded) {
-        if (!password.value) {
-          error.value = 'Please enter your password';
-          return;
-        }
-        isProcessing.value = true;
-        const success = await walletStore.unlock(password.value);
-        if (!success) {
-          error.value = 'Invalid password';
-          isProcessing.value = false;
-          return;
-        }
-      }
-
-      isProcessing.value = true;
       await walletStore.withMnemonic(action);
     } catch (err: any) {
       console.error('Approval action failed', err);
@@ -116,11 +100,9 @@ export function useApprovalRequest<TParams = any>(opts: UseApprovalRequestOption
     origin,
     method,
     requestData,
-    password,
     error,
     invalidRequest,
     isProcessing,
-    isMnemonicLoaded,
     runWithMnemonic,
     approve,
     reject

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -21,7 +21,6 @@ import { SendTransaction } from '@/models/SendTransaction';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
-import PepPasswordInput from '@/components/ui/form/PepPasswordInput.vue';
 
 interface Recipient {
   address: string;
@@ -43,14 +42,11 @@ const walletStore = useWalletStore();
 const inscriptionStore = useInscriptionStore();
 
 const {
-  requestId,
   origin,
   requestData,
-  password,
   error,
   invalidRequest,
   isProcessing,
-  isMnemonicLoaded,
   runWithMnemonic,
   approve,
   reject
@@ -125,9 +121,6 @@ async function handleApprove() {
 function handleReject() {
   reject('User rejected the transaction');
 }
-
-// Expose for template clarity (parity with previous SignTxView ids)
-void requestId;
 </script>
 
 <template>
@@ -167,17 +160,7 @@ void requestId;
         </div>
       </div>
 
-      <div v-if="!isMnemonicLoaded" class="space-y-2">
-        <PepPasswordInput
-          id="sign-tx-password"
-          v-model="password"
-          label="Enter Password to Confirm"
-          placeholder="Your password"
-          :error="error"
-          @keyup.enter="handleApprove"
-        />
-      </div>
-      <div v-else-if="error" class="px-1 text-sm text-red-400">
+      <div v-if="error" class="px-1 text-sm text-red-400">
         {{ error }}
       </div>
     </div>

--- a/src/views/approval/SignMessageView.spec.ts
+++ b/src/views/approval/SignMessageView.spec.ts
@@ -79,21 +79,6 @@ describe('SignMessageView', () => {
     expect(wrapper.text()).toContain('Hello Pepecoin');
   });
 
-  it('should request password if mnemonic is not cached', async () => {
-    const store = useWalletStore();
-    store.isUnlocked = true;
-    // ensure no mnemonic loaded
-    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(false);
-
-    const wrapper = mount(SignMessageView, {
-      global: globalConfig
-    });
-
-    await flushPromises();
-
-    expect(wrapper.find('input[type="password"]').exists()).toBe(true);
-  });
-
   it('should sign and send response on approve', async () => {
     const store = useWalletStore();
     store.isUnlocked = true;

--- a/src/views/approval/SignMessageView.vue
+++ b/src/views/approval/SignMessageView.vue
@@ -5,7 +5,6 @@ import { signMessage } from '@/utils/crypto';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
-import PepPasswordInput from '@/components/ui/form/PepPasswordInput.vue';
 
 interface SignMessageParams {
   message: string;
@@ -13,17 +12,8 @@ interface SignMessageParams {
 
 const walletStore = useWalletStore();
 
-const {
-  origin,
-  requestData,
-  password,
-  error,
-  isProcessing,
-  isMnemonicLoaded,
-  runWithMnemonic,
-  approve,
-  reject
-} = useApprovalRequest<SignMessageParams>();
+const { origin, requestData, error, isProcessing, runWithMnemonic, approve, reject } =
+  useApprovalRequest<SignMessageParams>();
 
 const messageToSign = computed(() => requestData.value?.params.message ?? '');
 
@@ -60,17 +50,7 @@ function handleReject() {
         </div>
       </div>
 
-      <div v-if="!isMnemonicLoaded" class="space-y-2">
-        <PepPasswordInput
-          id="sign-message-password"
-          v-model="password"
-          label="Enter Password to Confirm"
-          placeholder="Your password"
-          :error="error"
-          @keyup.enter="handleApprove"
-        />
-      </div>
-      <div v-else-if="error" class="px-1 text-sm text-red-400">
+      <div v-if="error" class="px-1 text-sm text-red-400">
         {{ error }}
       </div>
     </div>

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -7,7 +7,6 @@ import { RIBBITS_PER_PEP } from '@/utils/constants';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
-import PepPasswordInput from '@/components/ui/form/PepPasswordInput.vue';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
 
@@ -24,17 +23,8 @@ interface PsbtIO {
 
 const walletStore = useWalletStore();
 
-const {
-  origin,
-  requestData,
-  password,
-  error,
-  isProcessing,
-  isMnemonicLoaded,
-  runWithMnemonic,
-  approve,
-  reject
-} = useApprovalRequest<SignPsbtParams>();
+const { origin, requestData, error, isProcessing, runWithMnemonic, approve, reject } =
+  useApprovalRequest<SignPsbtParams>();
 
 const psbtDetails = computed(() => {
   if (!requestData.value) return null;
@@ -244,17 +234,7 @@ function handleReject() {
         </div>
       </div>
 
-      <div v-if="!isMnemonicLoaded" class="space-y-2">
-        <PepPasswordInput
-          id="sign-tx-password"
-          v-model="password"
-          label="Enter Password to Confirm"
-          placeholder="Your password"
-          :error="error"
-          @keyup.enter="handleApprove"
-        />
-      </div>
-      <div v-else-if="error" class="px-1 text-sm text-red-400">
+      <div v-if="error" class="px-1 text-sm text-red-400">
         {{ error }}
       </div>
     </div>


### PR DESCRIPTION
## Summary
The router guard in \`src/router/index.ts\` blocks any non-public route — including \`/approve/*\` — when the wallet is locked. The intended approval route is stashed in \`pendingRedirect\` and the user is bounced to \`/\` to unlock; only after unlocking are they redirected back. By the time any approval view mounts, \`walletStore.isUnlocked === true\`, and since \`isMnemonicLoaded\` is just \`session.hasSessionKey\` (set the moment the session unlocks), the \`v-if=\"!isMnemonicLoaded\"\` branch in approval views was unreachable in production.

This PR strips the dead branches:

- \`useApprovalRequest\` drops \`password\`, \`isMnemonicLoaded\`, and the \`unlock()\` / \"Please enter your password\" / \"Invalid password\" paths inside \`runWithMnemonic\`. The composable now wraps \`walletStore.withMnemonic(action)\` directly with try/catch and \`isProcessing\` handling.
- \`SendTransferApproval.vue\`, \`SignPsbtApproval.vue\`, \`SignMessageView.vue\` lose their \`PepPasswordInput\` blocks.

Pure dead-code removal — no behaviour change.

## Test plan
- [x] \`npm run build\` (vue-tsc + vite)
- [x] \`npx vitest run\` — 575 pass (4 dead-code tests removed: locked-wallet password prompt, invalid-password, unlock-then-run, SignMessage password input)
- [x] Manual smoke test: lock the wallet, trigger sendTransfer / signPsbt / signMessage from a dApp, confirm the unlock screen appears first and the approval view follows after unlock