### PR TITLE
Add signInputs and per-input sighash support to signPsbt

### DIFF
--- a/DAPP_INTEGRATION.md
+++ b/DAPP_INTEGRATION.md
@@ -117,11 +117,14 @@ console.log('Transaction Broadcasted:', txid);
 ```
 
 ### `signPsbt` (Advanced)
-Sign a Partially Signed Pepecoin Transaction (PSBT). The dApp provides a base64-encoded PSBT, and the wallet signs only the inputs that match the user's public key.
+Sign a Partially Signed Bitcoin Transaction (PSBT — BIP-174; the same format applies to Pepecoin). The dApp provides a base64-encoded PSBT and an explicit `signInputs` map listing which input indices to sign with which address. The wallet only signs the indices listed under the active account address.
 
 ```javascript
 const { psbt } = await provider.request('signPsbt', {
-  psbt: 'base64_encoded_psbt_string...'
+  psbt: 'base64_encoded_psbt_string...',
+  signInputs: {
+    'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU': [0, 1]
+  }
 });
 
 // psbt: base64-encoded PSBT with signatures added
@@ -132,7 +135,12 @@ const { psbt } = await provider.request('signPsbt', {
 | Property | Type | Description |
 |---|---|---|
 | `psbt` | `string` | The base64-encoded PSBT to sign. |
+| `signInputs` | `Record<string, number[]>` | Map of address → input indices to sign with that address. The wallet signs only the indices listed under the active account. |
 | `broadcast` | `boolean` (optional) | If `true`, the wallet finalizes the PSBT after signing and broadcasts the resulting transaction. Defaults to `false`. |
+
+**Sighash types**
+
+By default each input is signed with `SIGHASH_ALL`. To request `SIGHASH_SINGLE | ANYONECANPAY` (used for inscription listings and other half-signed offers), set the `sighashType` field on the relevant PSBT input *before* base64-encoding — the wallet honors what the PSBT itself declares. Supported flags: `SIGHASH_ALL` (`0x01`) and `SIGHASH_SINGLE | ANYONECANPAY` (`0x83`). Other flags are rejected. PSBTs containing any non-default sighash cannot be broadcast by the wallet (`broadcast: true` is rejected); the dApp must finalize and broadcast the completed transaction itself.
 
 **Result (`SignPsbtResult`)**
 
@@ -148,6 +156,9 @@ Set `broadcast: true` to have the wallet finalize and broadcast the PSBT once th
 ```javascript
 const { psbt, txid } = await provider.request('signPsbt', {
   psbt: 'base64_encoded_psbt_string...',
+  signInputs: {
+    'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU': [0]
+  },
   broadcast: true
 });
 

--- a/dev/connect.html
+++ b/dev/connect.html
@@ -307,6 +307,10 @@
         <div class="field">
             <label>Or paste base64 PSBT (optional — overrides builder)</label>
             <input id="psbt-raw" type="text" placeholder="cHNidP8BAH...">
+            <p class="status" style="margin-top: 0.25rem; font-size: 0.75rem;">
+                Note: signs input 0 with the connected address. For multi-input PSBTs edit the
+                <code>signInputs</code> map in the source.
+            </p>
         </div>
         <div class="row">
             <label style="display: inline-flex; align-items: center; gap: 0.4rem; margin-bottom: 0;">
@@ -590,7 +594,11 @@
                 }
 
                 setStatus('psbt-status', `Requesting signature${broadcast ? ' + broadcast' : ''}…`, '');
-                const result = await provider.request('signPsbt', { psbt: base64Psbt, broadcast });
+                const result = await provider.request('signPsbt', {
+                    psbt: base64Psbt,
+                    signInputs: { [connectedAddress]: [0] },
+                    broadcast
+                });
                 const text = result.txid
                     ? `txid: ${result.txid}\npsbt: ${result.psbt}`
                     : `psbt: ${result.psbt}`;

--- a/scripts/build-sighash-psbt.ts
+++ b/scripts/build-sighash-psbt.ts
@@ -1,0 +1,40 @@
+// Builds a 1-in / 1-out PSBT with sighashType 0x83 (SIGHASH_SINGLE | ANYONECANPAY)
+// on input 0, spending a confirmed UTXO from the given address back to itself.
+// Usage: npx tsx scripts/build-sighash-psbt.ts <Paddr...>
+import { Psbt } from 'bitcoinjs-lib';
+import { PEPECOIN } from '../src/utils/networks';
+
+const API_BASE = 'https://peppool.space/api';
+const FEE_RIBBITS = 50_000;
+const SIGHASH_SINGLE_ANYONECANPAY = 0x83;
+
+async function main() {
+  const address = process.argv[2];
+  if (!address) {
+    console.error('Usage: npx tsx scripts/build-sighash-psbt.ts <address>');
+    process.exit(1);
+  }
+
+  const utxos = await (await fetch(`${API_BASE}/address/${address}/utxo`)).json();
+  const utxo = utxos.find((u: any) => u.status?.confirmed && u.value > FEE_RIBBITS + 1000);
+  if (!utxo) throw new Error('No confirmed UTXO with sufficient value');
+
+  const rawHex = (await (await fetch(`${API_BASE}/tx/${utxo.txid}/hex`)).text()).trim();
+
+  const psbt = new Psbt({ network: PEPECOIN });
+  psbt.setVersion(1);
+  psbt.addInput({
+    hash: utxo.txid,
+    index: utxo.vout,
+    nonWitnessUtxo: Buffer.from(rawHex, 'hex'),
+    sighashType: SIGHASH_SINGLE_ANYONECANPAY
+  });
+  psbt.addOutput({ address, value: BigInt(utxo.value - FEE_RIBBITS) });
+
+  console.log(psbt.toBase64());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/background.spec.ts
+++ b/src/background.spec.ts
@@ -315,3 +315,64 @@ describe('background sendTransfer param validation', () => {
     await vi.waitFor(() => expect(windowsCreateMock).toHaveBeenCalled());
   });
 });
+
+describe('background signPsbt param validation', () => {
+  const storageData: Record<string, any> = {
+    peppool_permissions: {
+      'https://dapp.com': { accounts: ['Ptest123'], permissions: ['connect'] }
+    },
+    peppool_accounts: JSON.stringify([
+      { address: 'Ptest123', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }
+    ]),
+    peppool_active_account: '0'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (chrome.storage.local.get as any).mockImplementation(async (keys: string | string[]) => {
+      const keyList = Array.isArray(keys) ? keys : [keys];
+      const result: Record<string, any> = {};
+      for (const k of keyList) {
+        if (k in storageData) result[k] = storageData[k];
+      }
+      return result;
+    });
+  });
+
+  it('rejects signPsbt without signInputs', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', { psbt: 'base64' });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({ error: 'signInputs is required.' });
+    expect(windowsCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects signPsbt with invalid address key', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: 'base64',
+      signInputs: { bc1qxyz: [0] }
+    });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: 'Invalid address in signInputs: bc1qxyz'
+    });
+  });
+
+  it('rejects signPsbt with negative input index', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: 'base64',
+      signInputs: { PJGSjPmY3PzGyE54M3VGiRaEQFBhxuokV1: [-1] }
+    });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: expect.stringContaining('invalid index')
+    });
+  });
+
+  it('opens approval popup for valid signPsbt request', async () => {
+    sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: 'base64',
+      signInputs: { PJGSjPmY3PzGyE54M3VGiRaEQFBhxuokV1: [0] }
+    });
+    await vi.waitFor(() => expect(windowsCreateMock).toHaveBeenCalled());
+  });
+});

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,6 +10,7 @@
  */
 
 import { loadPermissions, savePermissions, hasPermission, revokeOrigin } from '@/utils/permissions';
+import { validateSignPsbtParams } from '@/utils/psbt';
 import { CHROME_STORAGE_KEYS } from '@/constants/storage';
 
 const ALARM_NAME_AUTOLOCK = 'peppool-inactivity-lock';
@@ -163,6 +164,15 @@ async function handleDappRequest(
       // Validate sendTransfer params before opening popup
       if (method === 'sendTransfer') {
         const validationError = validateTransferParams(request.params);
+        if (validationError) {
+          sendResponse({ error: validationError });
+          requestQueue.delete(requestId);
+          return;
+        }
+      }
+
+      if (method === 'signPsbt') {
+        const validationError = validateSignPsbtParams(request.params);
         if (validationError) {
           sendResponse({ error: validationError });
           requestQueue.delete(requestId);

--- a/src/utils/psbt.spec.ts
+++ b/src/utils/psbt.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ALLOWED_SIGHASHES,
+  SIGHASH,
+  getInputSighash,
+  sighashLabel,
+  validateSignPsbtParams
+} from './psbt';
+
+const VALID_ADDR = 'PJGSjPmY3PzGyE54M3VGiRaEQFBhxuokV1';
+const VALID_ADDR_2 = 'PWnYJiJtFWcksb6Ex4WaPEoa5y3CnXzVmh';
+
+describe('sighashLabel', () => {
+  it('labels common flags', () => {
+    expect(sighashLabel(SIGHASH.ALL)).toBe('SIGHASH_ALL');
+    expect(sighashLabel(SIGHASH.SINGLE_ANYONECANPAY)).toBe('SIGHASH_SINGLE | ANYONECANPAY');
+  });
+
+  it('falls back to hex for unknown flags', () => {
+    expect(sighashLabel(0x05)).toBe('0x05');
+  });
+});
+
+describe('ALLOWED_SIGHASHES', () => {
+  it('includes SIGHASH_ALL and SIGHASH_SINGLE | ANYONECANPAY', () => {
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.ALL)).toBe(true);
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.SINGLE_ANYONECANPAY)).toBe(true);
+  });
+
+  it('excludes plain SINGLE/NONE and ANYONECANPAY variants of ALL/NONE', () => {
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.NONE)).toBe(false);
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.SINGLE)).toBe(false);
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.ALL_ANYONECANPAY)).toBe(false);
+    expect(ALLOWED_SIGHASHES.has(SIGHASH.NONE_ANYONECANPAY)).toBe(false);
+  });
+});
+
+describe('getInputSighash', () => {
+  it('returns SIGHASH_ALL when input has no sighashType', () => {
+    const psbt = { data: { inputs: [{}] } } as any;
+    expect(getInputSighash(psbt, 0)).toBe(SIGHASH.ALL);
+  });
+
+  it('returns the explicit sighashType when set', () => {
+    const psbt = { data: { inputs: [{ sighashType: SIGHASH.SINGLE_ANYONECANPAY }] } } as any;
+    expect(getInputSighash(psbt, 0)).toBe(SIGHASH.SINGLE_ANYONECANPAY);
+  });
+});
+
+describe('validateSignPsbtParams', () => {
+  it('accepts a minimal valid request', () => {
+    expect(
+      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0] } })
+    ).toBeNull();
+  });
+
+  it('accepts multiple addresses with multiple indices', () => {
+    expect(
+      validateSignPsbtParams({
+        psbt: 'base64',
+        signInputs: { [VALID_ADDR]: [0], [VALID_ADDR_2]: [1, 2] },
+        broadcast: true
+      })
+    ).toBeNull();
+  });
+
+  it('rejects missing psbt', () => {
+    expect(validateSignPsbtParams({ signInputs: { [VALID_ADDR]: [0] } })).toContain('psbt');
+  });
+
+  it('rejects missing signInputs', () => {
+    expect(validateSignPsbtParams({ psbt: 'base64' })).toContain('signInputs is required');
+  });
+
+  it('rejects empty signInputs', () => {
+    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: {} })).toContain('at least one');
+  });
+
+  it('rejects invalid address keys', () => {
+    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: { bc1qxyz: [0] } })).toContain(
+      'Invalid address'
+    );
+  });
+
+  it('rejects empty index arrays', () => {
+    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [] } })).toContain(
+      'non-empty array'
+    );
+  });
+
+  it('rejects negative or non-integer indices', () => {
+    expect(
+      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [-1] } })
+    ).toContain('invalid index');
+    expect(
+      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [1.5] } })
+    ).toContain('invalid index');
+  });
+
+  it('rejects duplicate indices for the same address', () => {
+    expect(
+      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0, 0] } })
+    ).toContain('duplicate');
+  });
+
+  it('rejects non-boolean broadcast', () => {
+    expect(
+      validateSignPsbtParams({
+        psbt: 'base64',
+        signInputs: { [VALID_ADDR]: [0] },
+        broadcast: 'yes'
+      })
+    ).toContain('broadcast');
+  });
+});

--- a/src/utils/psbt.ts
+++ b/src/utils/psbt.ts
@@ -1,0 +1,89 @@
+import * as bitcoin from 'bitcoinjs-lib';
+
+export const SIGHASH = {
+  ALL: 0x01,
+  NONE: 0x02,
+  SINGLE: 0x03,
+  ANYONECANPAY: 0x80,
+  ALL_ANYONECANPAY: 0x81,
+  NONE_ANYONECANPAY: 0x82,
+  SINGLE_ANYONECANPAY: 0x83
+} as const;
+
+// Sighash flags the wallet will sign with. ANYONECANPAY variants enable
+// half-signed PSBTs (e.g. inscription listings) where a counterparty can
+// later add inputs/outputs without invalidating our signature.
+export const ALLOWED_SIGHASHES: ReadonlySet<number> = new Set([
+  SIGHASH.ALL,
+  SIGHASH.SINGLE_ANYONECANPAY
+]);
+
+export function sighashLabel(flag: number): string {
+  switch (flag) {
+    case SIGHASH.ALL:
+      return 'SIGHASH_ALL';
+    case SIGHASH.NONE:
+      return 'SIGHASH_NONE';
+    case SIGHASH.SINGLE:
+      return 'SIGHASH_SINGLE';
+    case SIGHASH.ALL_ANYONECANPAY:
+      return 'SIGHASH_ALL | ANYONECANPAY';
+    case SIGHASH.NONE_ANYONECANPAY:
+      return 'SIGHASH_NONE | ANYONECANPAY';
+    case SIGHASH.SINGLE_ANYONECANPAY:
+      return 'SIGHASH_SINGLE | ANYONECANPAY';
+    default:
+      return `0x${flag.toString(16).padStart(2, '0')}`;
+  }
+}
+
+export function getInputSighash(psbt: bitcoin.Psbt, index: number): number {
+  return psbt.data.inputs[index]?.sighashType ?? SIGHASH.ALL;
+}
+
+const PEP_ADDRESS_RE = /^P[1-9A-HJ-NP-Za-km-z]{25,33}$/;
+
+/**
+ * Validates the shape of signPsbt request params before opening the approval
+ * popup. Deeper checks (PSBT decoding, index range, sighash allowlist) happen
+ * in the approval view which already parses the PSBT.
+ */
+export function validateSignPsbtParams(params: any): string | null {
+  if (!params || typeof params !== 'object') return 'Missing PSBT parameters.';
+
+  if (typeof params.psbt !== 'string' || params.psbt.length === 0) {
+    return 'Missing or invalid psbt.';
+  }
+
+  if (params.signInputs == null || typeof params.signInputs !== 'object') {
+    return 'signInputs is required.';
+  }
+
+  const entries = Object.entries(params.signInputs as Record<string, unknown>);
+  if (entries.length === 0) return 'signInputs must include at least one address.';
+
+  for (const [address, indices] of entries) {
+    if (!PEP_ADDRESS_RE.test(address)) {
+      return `Invalid address in signInputs: ${address}`;
+    }
+    if (!Array.isArray(indices) || indices.length === 0) {
+      return `signInputs[${address}] must be a non-empty array of input indices.`;
+    }
+    const seen = new Set<number>();
+    for (const idx of indices) {
+      if (typeof idx !== 'number' || !Number.isInteger(idx) || idx < 0) {
+        return `signInputs[${address}] contains invalid index: ${idx}`;
+      }
+      if (seen.has(idx)) {
+        return `signInputs[${address}] contains duplicate index: ${idx}`;
+      }
+      seen.add(idx);
+    }
+  }
+
+  if (params.broadcast != null && typeof params.broadcast !== 'boolean') {
+    return 'broadcast must be a boolean.';
+  }
+
+  return null;
+}

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -76,17 +76,18 @@ describe('SignPsbtApproval', () => {
     const store = useWalletStore();
     vi.spyOn(store, 'checkSession').mockResolvedValue(true);
 
-    makeRequest({ psbt: 'base64-psbt-data' });
+    mockPsbt.inputCount = 2;
+    mockPsbt.data.inputs = [{}, {}] as any;
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
   });
 
   const globalConfig = {
     components: { PepButton, PepMainLayout, PepPageHeader, PepPasswordInput }
   };
 
-  it('only signs inputs that belong to the signer and does not broadcast by default', async () => {
-    mockSignInput.mockImplementation((index: number) => {
-      if (index === 1) throw new Error('Can not sign for this input');
-    });
+  it('signs only the inputs listed for the active account and does not broadcast by default', async () => {
+    mockSignInput.mockImplementation(() => {});
 
     const store = useWalletStore();
     store.isUnlocked = true;
@@ -103,6 +104,8 @@ describe('SignPsbtApproval', () => {
     await wrapper.find('#approve-transaction-button').trigger('click');
     await flushPromises();
 
+    expect(mockSignInput).toHaveBeenCalledTimes(1);
+    expect(mockSignInput).toHaveBeenCalledWith(0, expect.anything(), [0x01]);
     expect(global.chrome.runtime.sendMessage).toHaveBeenCalledWith({
       target: 'peppool-background-response',
       requestId: 'req123',
@@ -114,7 +117,11 @@ describe('SignPsbtApproval', () => {
   });
 
   it('finalizes and broadcasts when broadcast flag is true', async () => {
-    makeRequest({ psbt: 'base64-psbt-data', broadcast: true });
+    makeRequest({
+      psbt: 'base64-psbt-data',
+      signInputs: { Psender: [0, 1] },
+      broadcast: true
+    });
     mockSignInput.mockImplementation(() => {});
 
     const store = useWalletStore();
@@ -143,9 +150,106 @@ describe('SignPsbtApproval', () => {
     });
   });
 
-  it('rejects when no inputs belong to the signer', async () => {
-    mockSignInput.mockImplementation(() => {
-      throw new Error('Can not sign for this input');
+  it('rejects when signInputs has no entry for the active account', async () => {
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { Pother: [0] } });
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockSignInput).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('This PSBT is not for the active account');
+  });
+
+  it('rejects when a signInputs index is out of range', async () => {
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [5] } });
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockSignInput).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('out of range');
+  });
+
+  it('honors SIGHASH_SINGLE | ANYONECANPAY from PSBT input data', async () => {
+    mockPsbt.inputCount = 1;
+    mockPsbt.data.inputs = [{ sighashType: 0x83 }] as any;
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
+    mockSignInput.mockImplementation(() => {});
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockSignInput).toHaveBeenCalledWith(0, expect.anything(), [0x83]);
+    expect(mockFinalizeAllInputs).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported sighash types', async () => {
+    mockPsbt.inputCount = 1;
+    mockPsbt.data.inputs = [{ sighashType: 0x02 }] as any;
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockSignInput).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Unsupported sighash');
+  });
+
+  it('rejects broadcast when any signed input has non-default sighash', async () => {
+    mockPsbt.inputCount = 1;
+    mockPsbt.data.inputs = [{ sighashType: 0x83 }] as any;
+    makeRequest({
+      psbt: 'base64-psbt-data',
+      signInputs: { Psender: [0] },
+      broadcast: true
     });
 
     const store = useWalletStore();
@@ -163,7 +267,9 @@ describe('SignPsbtApproval', () => {
     await wrapper.find('#approve-transaction-button').trigger('click');
     await flushPromises();
 
-    expect(wrapper.text()).toContain('No inputs in this PSBT belong to your wallet');
+    expect(mockSignInput).not.toHaveBeenCalled();
+    expect(mockFinalizeAllInputs).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('Cannot broadcast');
   });
 
   it('sends rejection on cancel', async () => {

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -9,9 +9,11 @@ import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
+import { ALLOWED_SIGHASHES, SIGHASH, getInputSighash, sighashLabel } from '@/utils/psbt';
 
 interface SignPsbtParams {
   psbt: string;
+  signInputs: Record<string, number[]>;
   broadcast?: boolean;
 }
 
@@ -95,25 +97,39 @@ function decodePsbtSummary(
 
 async function handleApprove() {
   await runWithMnemonic(async (mnemonic) => {
-    const { psbt: base64Psbt, broadcast } = requestData.value!.params;
+    const { psbt: base64Psbt, signInputs, broadcast } = requestData.value!.params;
     const psbt = bitcoin.Psbt.fromBase64(base64Psbt, { network: PEPECOIN });
+
+    const myAddress = walletStore.address;
+    if (!myAddress) throw new Error('No active account.');
+
+    const indices = signInputs[myAddress] ?? [];
+    if (indices.length === 0) {
+      throw new Error('This PSBT is not for the active account.');
+    }
+    for (const i of indices) {
+      if (i < 0 || i >= psbt.inputCount) {
+        throw new Error(`signInputs index ${i} is out of range.`);
+      }
+    }
+
+    const sighashes = indices.map((i) => getInputSighash(psbt, i));
+    for (const flag of sighashes) {
+      if (!ALLOWED_SIGHASHES.has(flag)) {
+        throw new Error(`Unsupported sighash: ${sighashLabel(flag)}`);
+      }
+    }
+    const hasNonDefault = sighashes.some((s) => s !== SIGHASH.ALL);
+    if (broadcast === true && hasNonDefault) {
+      throw new Error('Cannot broadcast a PSBT with non-default sighash.');
+    }
 
     const { accountIndex, addressIndex } = parseDerivationPath(walletStore.activeAccount!.path);
     const signer = deriveSigner(mnemonic, accountIndex, addressIndex);
 
-    let signedCount = 0;
-    for (let i = 0; i < psbt.inputCount; i++) {
-      try {
-        psbt.signInput(i, signer);
-        signedCount++;
-      } catch {
-        // Input does not belong to this signer — skip
-      }
-    }
-
-    if (signedCount === 0) {
-      throw new Error('No inputs in this PSBT belong to your wallet');
-    }
+    indices.forEach((inputIndex, k) => {
+      psbt.signInput(inputIndex, signer, [sighashes[k]!]);
+    });
 
     const result: { psbt: string; txid?: string } = { psbt: psbt.toBase64() };
 


### PR DESCRIPTION
## Summary
- Aligns the `signPsbt` request shape with sats-connect: now requires `signInputs: Record<string, number[]>` so the dApp explicitly chooses which input indices to sign with which address. The wallet only signs indices listed under the active account.
- Honors per-input `sighashType` declared on the PSBT itself. Allowlist is `SIGHASH_ALL` (`0x01`) and `SIGHASH_SINGLE | ANYONECANPAY` (`0x83`) — the latter unlocks half-signed PSBTs for inscription listings.
- Rejects `broadcast: true` when any signed input has non-default sighash (a partial PSBT can't be finalized standalone).
- Validation of `signInputs` shape moved into `background.ts` (mirrors `sendTransfer` pattern); deeper PSBT-aware checks live in the approval view.
- View *template* is unchanged — banners/badges for ANYONECANPAY come with the upcoming UI refactor.

## Files
- `src/utils/psbt.ts` (new) — `SIGHASH` constants, `ALLOWED_SIGHASHES`, `sighashLabel`, `getInputSighash`, `validateSignPsbtParams`
- `src/views/approval/SignPsbtApproval.vue` — script-only: required `signInputs`, fatal out-of-range, sighash read from PSBT, sighash allowlist, broadcast guard
- `src/background.ts` — `validateSignPsbtParams` before opening popup
- `dev/connect.html`, `DAPP_INTEGRATION.md` — updated to the new shape

## Test plan
- [x] `npm run format`
- [x] `npx vitest run --reporter=dot --silent` — 599/599 pass (incl. 12 new util tests, 4 new background tests, 5 new approval view tests)
- [x] `npm run build` — `vue-tsc -b` clean
- [x] Manual: sign a 1-in/1-out PSBT via `dev/connect.html` (default builder)
- [x] Manual: sign a PSBT with `sighashType: 0x83` on input 0 — verify approval succeeds and `broadcast: true` is rejected