### PR TITLE
Refactor amount input around a single source of truth

### DIFF
--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PepAmountInput from './PepAmountInput.vue';
-import { useApp } from '@/composables/useApp';
 
-// Mock useApp
 vi.mock('@/composables/useApp', () => ({
   useApp: vi.fn(() => ({
     wallet: {},
@@ -13,82 +11,159 @@ vi.mock('@/composables/useApp', () => ({
   }))
 }));
 
-// Mock components
 const stubs = {
   PepInput: {
     template:
-      '<div><slot name="prefix" /><input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" /><slot name="suffix" /></div>',
+      '<div><slot name="prefix" /><input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" @blur="$emit(\'blur\', $event)" /><slot name="suffix" /></div>',
     props: ['modelValue']
   },
   PepIcon: { template: '<div />' }
 };
+
+function displayedValue(wrapper: ReturnType<typeof mount>) {
+  return (wrapper.find('input').element as HTMLInputElement).value;
+}
 
 describe('PepAmountInput UI Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should emit update:ribbits when text input changes (PEP mode)', async () => {
+  it('emits update:ribbits when text input changes (PEP mode)', async () => {
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 0, price: 10, isFiatMode: false },
-      global: {
-        stubs
-      }
+      global: { stubs }
     });
 
-    const input = wrapper.find('input');
-    await input.setValue('1'); // 1 PEP
-
+    await wrapper.find('input').setValue('1');
     expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([100_000_000]);
   });
 
-  it('should emit update:ribbits when text input changes (Fiat mode)', async () => {
+  it('emits update:ribbits when text input changes (Fiat mode)', async () => {
     const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 0, price: 10, isFiatMode: true }, // 1 PEP = $10
-      global: {
-        stubs
-      }
+      props: { ribbits: 0, price: 10, isFiatMode: true },
+      global: { stubs }
     });
 
-    const input = wrapper.find('input');
-    await input.setValue('5'); // $5 = 0.5 PEP = 50,000,000 ribbits
-
+    await wrapper.find('input').setValue('5'); // $5 / $10 per PEP = 0.5 PEP
     expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([50_000_000]);
   });
 
-  it('should normalize commas to dots', async () => {
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 0, price: 10, isFiatMode: false },
-      global: {
-        stubs
-      }
-    });
-
-    const input = wrapper.find('input');
-    await input.setValue('1,5');
-
-    // Check internal state
-    // @ts-ignore
-    expect(wrapper.vm.inputAmount).toBe('1.5');
-    expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([150_000_000]);
-  });
-
-  it('should treat fiat input as PEP when price is 0 to avoid division by zero', async () => {
+  it('treats fiat input as PEP when price is 0 to avoid division by zero', async () => {
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 0, price: 0, isFiatMode: true },
       global: { stubs }
     });
 
-    const input = wrapper.find('input');
-    await input.setValue('5');
-
+    await wrapper.find('input').setValue('5');
     expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([500_000_000]);
   });
 
-  it('should reject invalid characters and revert to previous value', async () => {
-    // parseFloat("1x3e") returns 1, which previously caused the visible text
-    // and the underlying ribbits to silently diverge. The input must reject
-    // the keystroke instead of accepting a partial parse.
+  it('normalizes commas to dots in pasted/programmatic input', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.find('input').setValue('1,5');
+    expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([150_000_000]);
+  });
+
+  it('rejects garbage input as a paste fallback (parseFloat would silently truncate)', async () => {
+    // beforeinput blocks typed garbage; setValue bypasses that path so the
+    // handleInput fallback must also reject "1x3e" rather than emitting ribbits=1.
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.find('input').setValue('1');
+    await wrapper.find('input').setValue('1x3e');
+
+    const emits = wrapper.emitted('update:ribbits') as number[][];
+    expect(emits.at(-1)).toEqual([100_000_000]);
+  });
+
+  it('rejects more than 8 decimals in PEP mode', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.find('input').setValue('1.12345678');
+    await wrapper.find('input').setValue('1.123456789');
+
+    const emits = wrapper.emitted('update:ribbits') as number[][];
+    expect(emits.at(-1)).toEqual([112_345_678]);
+  });
+
+  it('rejects more than 2 decimals in fiat mode', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: true },
+      global: { stubs }
+    });
+
+    await wrapper.find('input').setValue('1.23');
+    await wrapper.find('input').setValue('1.234');
+
+    const emits = wrapper.emitted('update:ribbits') as number[][];
+    // 1.23 / $10 = 0.123 PEP = 12_300_000 ribbits.
+    expect(emits.at(-1)).toEqual([12_300_000]);
+  });
+
+  it('does not freeze when toggling to fiat with a tiny amount that exceeds the fiat decimal cap', async () => {
+    // 50_000 ribbits = 0.0005 PEP × $10 = $0.005 → formatFiat emits "0.0050" (4 decimals).
+    // The displayed text is derived from ribbits, not validated as user input,
+    // so it survives even though it exceeds the 2-decimal fiat cap.
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 50_000, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.setProps({ isFiatMode: true });
+    expect(displayedValue(wrapper)).toBe('0.0050');
+  });
+
+  it('does not clear MAX flag when ribbits are set externally', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.setProps({ ribbits: 500_000_000 });
+    expect(wrapper.emitted('change-max')).toBeUndefined();
+  });
+
+  it('emits change-max:false when user types', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 100, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.find('input').setValue('101');
+    expect(wrapper.emitted('change-max')?.[0]).toEqual([false]);
+  });
+
+  it('preserves exact ribbits when MAX is set in fiat mode (no parse round-trip)', async () => {
+    // Regression: in fiat mode, MAX would write the exact ribbits, the
+    // component would format them as e.g. "$1.23", parse that back, divide by
+    // price, and emit a slightly different (often higher) ribbits value than
+    // the wallet balance — causing "insufficient funds" on review.
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: true },
+      global: { stubs }
+    });
+
+    const maxBalance = 123_456_789;
+    await wrapper.setProps({ ribbits: maxBalance });
+
+    // The component must not echo back a different ribbits value.
+    expect(wrapper.emitted('update:ribbits')).toBeUndefined();
+  });
+
+  it('keeps the buffer mid-edit so the cursor does not jump on re-render', async () => {
+    // Typing "1." should leave "1." in the field even though parseFloat("1.") === 1
+    // and props.ribbits won't change between keystrokes.
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 0, price: 10, isFiatMode: false },
       global: { stubs }
@@ -96,81 +171,21 @@ describe('PepAmountInput UI Component', () => {
 
     const input = wrapper.find('input');
     await input.setValue('1');
-    await input.setValue('1x3e');
-
-    // @ts-ignore
-    expect(wrapper.vm.inputAmount).toBe('1');
-    // The final ribbits value must reflect the visible "1", not a partial parse of "1x3e".
-    const emits = wrapper.emitted('update:ribbits') as number[][];
-    expect(emits.at(-1)).toEqual([100_000_000]);
+    await wrapper.setProps({ ribbits: 100_000_000 }); // parent echoes
+    await input.setValue('1.');
+    expect(displayedValue(wrapper)).toBe('1.');
   });
 
-  it('should reject more than 8 decimals in PEP mode', async () => {
+  it('drops the buffer on blur so the canonical display takes over', async () => {
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 0, price: 10, isFiatMode: false },
       global: { stubs }
     });
 
     const input = wrapper.find('input');
-    await input.setValue('1.12345678');
-    await input.setValue('1.123456789');
-
-    // @ts-ignore
-    expect(wrapper.vm.inputAmount).toBe('1.12345678');
-  });
-
-  it('should reject more than 2 decimals in fiat mode', async () => {
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 0, price: 10, isFiatMode: true },
-      global: { stubs }
-    });
-
-    const input = wrapper.find('input');
-    await input.setValue('1.23');
-    await input.setValue('1.234');
-
-    // @ts-ignore
-    expect(wrapper.vm.inputAmount).toBe('1.23');
-  });
-
-  it('should not loop or strip the value when toggling to fiat with a tiny amount', async () => {
-    // formatFiat emits more than 2 decimals for tiny values (e.g. "0.0023").
-    // Validation must not reject external writes — doing so previously caused
-    // an infinite revert loop that froze the popup.
-    // 50_000 ribbits = 0.0005 PEP × $10 = $0.005 → formatFiat emits "0.005" (3 decimals).
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 50_000, price: 10, isFiatMode: false },
-      global: { stubs }
-    });
-
-    await wrapper.setProps({ isFiatMode: true });
-
-    // @ts-ignore
-    expect(wrapper.vm.inputAmount).toBe('0.0050');
-  });
-
-  it('should not clear MAX flag when ribbits are set externally', async () => {
-    // Clicking MAX writes ribbits via prop. The component must not echo back
-    // change-max:false, which would immediately undo the MAX state.
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 0, price: 10, isFiatMode: false },
-      global: { stubs }
-    });
-
-    await wrapper.setProps({ ribbits: 500_000_000 });
-
-    expect(wrapper.emitted('change-max')).toBeUndefined();
-  });
-
-  it('should emit change-max: false when user types', async () => {
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 100, price: 10, isFiatMode: false },
-      global: {
-        stubs
-      }
-    });
-
-    await wrapper.find('input').setValue('101');
-    expect(wrapper.emitted('change-max')?.[0]).toEqual([false]);
+    await input.setValue('1.50');
+    await wrapper.setProps({ ribbits: 150_000_000 });
+    await input.trigger('blur');
+    expect(displayedValue(wrapper)).toBe('1.5');
   });
 });

--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -85,6 +85,54 @@ describe('PepAmountInput UI Component', () => {
     expect(wrapper.emitted('update:ribbits')?.[0]).toEqual([500_000_000]);
   });
 
+  it('should reject invalid characters and revert to previous value', async () => {
+    // parseFloat("1x3e") returns 1, which previously caused the visible text
+    // and the underlying ribbits to silently diverge. The input must reject
+    // the keystroke instead of accepting a partial parse.
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    const input = wrapper.find('input');
+    await input.setValue('1');
+    await input.setValue('1x3e');
+
+    // @ts-ignore
+    expect(wrapper.vm.inputAmount).toBe('1');
+    // The final ribbits value must reflect the visible "1", not a partial parse of "1x3e".
+    const emits = wrapper.emitted('update:ribbits') as number[][];
+    expect(emits.at(-1)).toEqual([100_000_000]);
+  });
+
+  it('should reject more than 8 decimals in PEP mode', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    const input = wrapper.find('input');
+    await input.setValue('1.12345678');
+    await input.setValue('1.123456789');
+
+    // @ts-ignore
+    expect(wrapper.vm.inputAmount).toBe('1.12345678');
+  });
+
+  it('should reject more than 2 decimals in fiat mode', async () => {
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: true },
+      global: { stubs }
+    });
+
+    const input = wrapper.find('input');
+    await input.setValue('1.23');
+    await input.setValue('1.234');
+
+    // @ts-ignore
+    expect(wrapper.vm.inputAmount).toBe('1.23');
+  });
+
   it('should emit change-max: false when user types', async () => {
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 100, price: 10, isFiatMode: false },

--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -97,18 +97,17 @@ describe('PepAmountInput UI Component', () => {
     expect(emits.at(-1)).toEqual([112_345_678]);
   });
 
-  it('rejects more than 2 decimals in fiat mode', async () => {
+  it('allows sub-cent precision in fiat mode (real holdings can be < $0.01)', async () => {
+    // formatFiat itself emits more than 2 decimals for tiny values, and users
+    // hold sub-cent balances at low PEP prices — so the input must accept
+    // up to 8 decimals in fiat mode, same as PEP mode.
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 0, price: 10, isFiatMode: true },
       global: { stubs }
     });
 
-    await wrapper.find('input').setValue('1.23');
-    await wrapper.find('input').setValue('1.234');
-
-    const emits = wrapper.emitted('update:ribbits') as number[][];
-    // 1.23 / $10 = 0.123 PEP = 12_300_000 ribbits.
-    expect(emits.at(-1)).toEqual([12_300_000]);
+    await wrapper.find('input').setValue('0.0049'); // $0.0049 / $10 = 0.00049 PEP
+    expect(wrapper.emitted('update:ribbits')?.at(-1)).toEqual([49_000]);
   });
 
   it('does not freeze when toggling to fiat with a tiny amount that exceeds the fiat decimal cap', async () => {

--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -133,6 +133,35 @@ describe('PepAmountInput UI Component', () => {
     expect(wrapper.vm.inputAmount).toBe('1.23');
   });
 
+  it('should not loop or strip the value when toggling to fiat with a tiny amount', async () => {
+    // formatFiat emits more than 2 decimals for tiny values (e.g. "0.0023").
+    // Validation must not reject external writes — doing so previously caused
+    // an infinite revert loop that froze the popup.
+    // 50_000 ribbits = 0.0005 PEP × $10 = $0.005 → formatFiat emits "0.005" (3 decimals).
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 50_000, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.setProps({ isFiatMode: true });
+
+    // @ts-ignore
+    expect(wrapper.vm.inputAmount).toBe('0.0050');
+  });
+
+  it('should not clear MAX flag when ribbits are set externally', async () => {
+    // Clicking MAX writes ribbits via prop. The component must not echo back
+    // change-max:false, which would immediately undo the MAX state.
+    const wrapper = mount(PepAmountInput, {
+      props: { ribbits: 0, price: 10, isFiatMode: false },
+      global: { stubs }
+    });
+
+    await wrapper.setProps({ ribbits: 500_000_000 });
+
+    expect(wrapper.emitted('change-max')).toBeUndefined();
+  });
+
   it('should emit change-max: false when user types', async () => {
     const wrapper = mount(PepAmountInput, {
       props: { ribbits: 100, price: 10, isFiatMode: false },

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -34,6 +34,30 @@ const { settings: settingsStore } = useApp();
 const inputAmount = ref('');
 let isInternalSync = false;
 
+function decimalPattern() {
+  const maxDecimals = props.isFiatMode ? 2 : 8;
+  return new RegExp(`^\\d*(\\.\\d{0,${maxDecimals}})?$`);
+}
+
+// Block invalid characters at the source so they never enter the field
+// (e.g. typing "x" or "e" into "1" must not produce "1x" or "1e", which
+// parseFloat would silently truncate back to "1").
+function handleBeforeInput(e: Event) {
+  const ev = e as InputEvent;
+  // Allow deletions and other non-insertion edits.
+  if (!ev.data) return;
+
+  const target = ev.target as HTMLInputElement;
+  const start = target.selectionStart ?? target.value.length;
+  const end = target.selectionEnd ?? target.value.length;
+  const inserted = ev.data.replace(',', '.');
+  const next = target.value.slice(0, start) + inserted + target.value.slice(end);
+
+  if (next !== '' && !decimalPattern().test(next)) {
+    ev.preventDefault();
+  }
+}
+
 // Helpers
 const ribbitsToPep = (r: number) => r / RIBBITS_PER_PEP;
 const pepToRibbits = (p: number) => Math.round(p * RIBBITS_PER_PEP);
@@ -68,9 +92,15 @@ watch(
 
 // Sync INTERNAL text input to EXTERNAL ribbits
 watch(inputAmount, (newVal, oldVal) => {
-  // Normalize comma to dot
+  // Normalize comma to dot (covers paste — beforeinput rewrites typed commas).
   if (newVal.includes(',')) {
-    inputAmount.value = newVal.replace(',', '.');
+    inputAmount.value = newVal.replace(/,/g, '.');
+    return;
+  }
+
+  // Pasted text may still contain garbage; strip it back to the last valid value.
+  if (newVal !== '' && !decimalPattern().test(newVal)) {
+    inputAmount.value = oldVal;
     return;
   }
 
@@ -113,6 +143,7 @@ function toggleMode() {
       inputmode="decimal"
       :disabled="disabled"
       inputClass="font-bold"
+      @beforeinput="handleBeforeInput"
     >
       <template #prefix>
         <span class="font-bold text-slate-500">

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -31,37 +31,17 @@ const emit = defineEmits<{
 
 const { settings: settingsStore } = useApp();
 
-const inputAmount = ref('');
-let isInternalSync = false;
-let isExternalWrite = false;
+// SINGLE SOURCE OF TRUTH: props.ribbits.
+//
+// `displayText` is the canonical text rendering of ribbits in the current mode.
+// `editBuffer` is non-null only while the user is mid-edit. It overrides the
+// displayed value so transient/imprecise input ("1.", "0.50000000") survives
+// across the user→ribbits→display round-trip without the cursor jumping.
+//
+// External writes (MAX click, currency toggle, parent prop change) replace the
+// displayed value via `displayText` and never round-trip through parsing.
 
-function decimalPattern() {
-  const maxDecimals = props.isFiatMode ? 2 : 8;
-  return new RegExp(`^\\d*(\\.\\d{0,${maxDecimals}})?$`);
-}
-
-// Block invalid characters at the source so they never enter the field
-// (e.g. typing "x" or "e" into "1" must not produce "1x" or "1e", which
-// parseFloat would silently truncate back to "1").
-function handleBeforeInput(e: Event) {
-  const ev = e as InputEvent;
-  // Allow deletions and other non-insertion edits.
-  if (!ev.data) return;
-
-  const target = ev.target as HTMLInputElement;
-  const start = target.selectionStart ?? target.value.length;
-  const end = target.selectionEnd ?? target.value.length;
-  const inserted = ev.data.replace(',', '.');
-  const next = target.value.slice(0, start) + inserted + target.value.slice(end);
-
-  if (next !== '' && !decimalPattern().test(next)) {
-    ev.preventDefault();
-  }
-}
-
-// Helpers
-const ribbitsToPep = (r: number) => r / RIBBITS_PER_PEP;
-const pepToRibbits = (p: number) => Math.round(p * RIBBITS_PER_PEP);
+const editBuffer = ref<string | null>(null);
 
 const pepString = computed(() => {
   if (props.ribbits === 0) return '';
@@ -71,72 +51,85 @@ const pepString = computed(() => {
   return decimalPart ? `${integerPart || '0'}.${decimalPart}` : integerPart || '0';
 });
 
-// Sync EXTERNAL ribbits to INTERNAL text input
-watch(
-  [() => props.ribbits, () => props.isFiatMode],
-  ([newRibbits, fiatMode]) => {
-    if (isInternalSync) return;
+const displayText = computed(() => {
+  if (props.ribbits === 0) return '';
+  if (props.isFiatMode) {
+    return formatFiat((props.ribbits / RIBBITS_PER_PEP) * props.price);
+  }
+  return pepString.value;
+});
 
-    const next =
-      newRibbits === 0
-        ? ''
-        : fiatMode
-          ? formatFiat(ribbitsToPep(newRibbits) * props.price)
-          : pepString.value;
-    if (next === inputAmount.value) return;
-    isExternalWrite = true;
-    inputAmount.value = next;
-    // The sync internal watcher (set up below) clears the flag on fire, but
-    // on the immediate mount-tick it isn't subscribed yet. Reset defensively.
-    isExternalWrite = false;
-  },
-  { immediate: true }
+const inputValue = computed(() => editBuffer.value ?? displayText.value);
+
+function decimalPattern() {
+  const maxDecimals = props.isFiatMode ? 2 : 8;
+  return new RegExp(`^\\d*(\\.\\d{0,${maxDecimals}})?$`);
+}
+
+function parseToRibbits(text: string): number {
+  const numeric = parseFloat(text);
+  if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+  const pepVal = props.isFiatMode && props.price > 0 ? numeric / props.price : numeric;
+  return Math.round(pepVal * RIBBITS_PER_PEP);
+}
+
+// Block invalid characters at the source so they never enter the field
+// (e.g. "x" or "e" — parseFloat would silently truncate "1x" back to 1).
+function handleBeforeInput(e: Event) {
+  const ev = e as InputEvent;
+  if (!ev.data) return; // deletions, IME composition end, etc.
+
+  const target = ev.target as HTMLInputElement;
+  const start = target.selectionStart ?? target.value.length;
+  const end = target.selectionEnd ?? target.value.length;
+  const inserted = ev.data.replace(/,/g, '.');
+  const next = target.value.slice(0, start) + inserted + target.value.slice(end);
+
+  if (next !== '' && !decimalPattern().test(next)) {
+    ev.preventDefault();
+  }
+}
+
+function handleInput(text: string) {
+  // Programmatic / paste fallback: beforeinput catches typed garbage, but
+  // pasted strings (and tests using setValue) bypass it.
+  const normalized = text.replace(/,/g, '.');
+  if (normalized !== '' && !decimalPattern().test(normalized)) {
+    // Reject by snapping back to whatever the user had before this edit.
+    editBuffer.value = editBuffer.value ?? displayText.value;
+    return;
+  }
+
+  editBuffer.value = normalized;
+  emit('update:ribbits', parseToRibbits(normalized));
+  emit('change-max', false);
+}
+
+function handleBlur() {
+  // Drop the buffer so the canonical display takes over (re-formats e.g.
+  // "1.50" → "1.5", drops trailing dots).
+  editBuffer.value = null;
+}
+
+// External writes invalidate any in-flight edit buffer:
+//   - currency toggle: text representation changes meaning entirely
+//   - prop ribbits change that didn't originate from our last keystroke (MAX,
+//     parent reset). When the parent simply echoes our emit, the buffer's
+//     parsed ribbits matches props.ribbits and we keep it (cursor preserved).
+watch(
+  () => props.isFiatMode,
+  () => {
+    editBuffer.value = null;
+  }
 );
 
-// Sync INTERNAL text input to EXTERNAL ribbits.
-// flush: 'sync' so the isExternalWrite flag set by the external watcher is read
-// in the same tick — without it, multiple synchronous changes batch and the flag
-// leaks onto a subsequent user edit.
 watch(
-  inputAmount,
-  (newVal, oldVal) => {
-    // External writes (MAX, currency toggle, prop sync) trust the formatted value
-    // even if it exceeds the per-mode decimal cap (e.g. formatFiat may emit
-    // "0.0023" for tiny amounts). Validation only applies to user-driven edits.
-    const fromExternal = isExternalWrite;
-    isExternalWrite = false;
-
-    // Normalize comma to dot (covers paste — beforeinput rewrites typed commas).
-    if (!fromExternal && newVal.includes(',')) {
-      inputAmount.value = newVal.replace(/,/g, '.');
-      return;
-    }
-
-    // Pasted text may still contain garbage; strip it back to the last valid value.
-    if (!fromExternal && newVal !== '' && !decimalPattern().test(newVal)) {
-      inputAmount.value = oldVal;
-      return;
-    }
-
-    isInternalSync = true;
-    const numeric = parseFloat(newVal);
-
-    if (isNaN(numeric) || numeric <= 0) {
-      emit('update:ribbits', 0);
-    } else {
-      const pepVal = props.isFiatMode && props.price > 0 ? numeric / props.price : numeric;
-      emit('update:ribbits', pepToRibbits(pepVal));
-    }
-
-    // If user is typing, we are no longer in "MAX" state. External writes
-    // (including the MAX click itself) must not clear the MAX flag.
-    if (!fromExternal && newVal !== oldVal) {
-      emit('change-max', false);
-    }
-
-    isInternalSync = false;
-  },
-  { flush: 'sync' }
+  () => props.ribbits,
+  (newRibbits) => {
+    if (editBuffer.value === null) return;
+    if (parseToRibbits(editBuffer.value) === newRibbits) return;
+    editBuffer.value = null;
+  }
 );
 
 function toggleMode() {
@@ -155,12 +148,14 @@ function toggleMode() {
 
     <PepInput
       :id="id"
-      v-model="inputAmount"
+      :modelValue="inputValue"
       placeholder="0.00"
       inputmode="decimal"
       :disabled="disabled"
       inputClass="font-bold"
+      @update:modelValue="handleInput"
       @beforeinput="handleBeforeInput"
+      @blur="handleBlur"
     >
       <template #prefix>
         <span class="font-bold text-slate-500">

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -61,10 +61,10 @@ const displayText = computed(() => {
 
 const inputValue = computed(() => editBuffer.value ?? displayText.value);
 
-function decimalPattern() {
-  const maxDecimals = props.isFiatMode ? 2 : 8;
-  return new RegExp(`^\\d*(\\.\\d{0,${maxDecimals}})?$`);
-}
+// 8 decimals matches PEP's smallest unit (ribbit). Fiat uses the same cap
+// because sub-cent holdings are real (e.g. $0.0049 at low PEP price), and
+// formatFiat itself emits more than 2 decimals for tiny values.
+const DECIMAL_PATTERN = /^\d*(\.\d{0,8})?$/;
 
 function parseToRibbits(text: string): number {
   const numeric = parseFloat(text);
@@ -85,7 +85,7 @@ function handleBeforeInput(e: Event) {
   const inserted = ev.data.replace(/,/g, '.');
   const next = target.value.slice(0, start) + inserted + target.value.slice(end);
 
-  if (next !== '' && !decimalPattern().test(next)) {
+  if (next !== '' && !DECIMAL_PATTERN.test(next)) {
     ev.preventDefault();
   }
 }
@@ -94,7 +94,7 @@ function handleInput(text: string) {
   // Programmatic / paste fallback: beforeinput catches typed garbage, but
   // pasted strings (and tests using setValue) bypass it.
   const normalized = text.replace(/,/g, '.');
-  if (normalized !== '' && !decimalPattern().test(normalized)) {
+  if (normalized !== '' && !DECIMAL_PATTERN.test(normalized)) {
     // Reject by snapping back to whatever the user had before this edit.
     editBuffer.value = editBuffer.value ?? displayText.value;
     return;

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -33,6 +33,7 @@ const { settings: settingsStore } = useApp();
 
 const inputAmount = ref('');
 let isInternalSync = false;
+let isExternalWrite = false;
 
 function decimalPattern() {
   const maxDecimals = props.isFiatMode ? 2 : 8;
@@ -76,51 +77,67 @@ watch(
   ([newRibbits, fiatMode]) => {
     if (isInternalSync) return;
 
-    if (newRibbits === 0) {
-      inputAmount.value = '';
-      return;
-    }
-
-    if (fiatMode) {
-      inputAmount.value = formatFiat(ribbitsToPep(newRibbits) * props.price);
-    } else {
-      inputAmount.value = pepString.value;
-    }
+    const next =
+      newRibbits === 0
+        ? ''
+        : fiatMode
+          ? formatFiat(ribbitsToPep(newRibbits) * props.price)
+          : pepString.value;
+    if (next === inputAmount.value) return;
+    isExternalWrite = true;
+    inputAmount.value = next;
+    // The sync internal watcher (set up below) clears the flag on fire, but
+    // on the immediate mount-tick it isn't subscribed yet. Reset defensively.
+    isExternalWrite = false;
   },
   { immediate: true }
 );
 
-// Sync INTERNAL text input to EXTERNAL ribbits
-watch(inputAmount, (newVal, oldVal) => {
-  // Normalize comma to dot (covers paste — beforeinput rewrites typed commas).
-  if (newVal.includes(',')) {
-    inputAmount.value = newVal.replace(/,/g, '.');
-    return;
-  }
+// Sync INTERNAL text input to EXTERNAL ribbits.
+// flush: 'sync' so the isExternalWrite flag set by the external watcher is read
+// in the same tick — without it, multiple synchronous changes batch and the flag
+// leaks onto a subsequent user edit.
+watch(
+  inputAmount,
+  (newVal, oldVal) => {
+    // External writes (MAX, currency toggle, prop sync) trust the formatted value
+    // even if it exceeds the per-mode decimal cap (e.g. formatFiat may emit
+    // "0.0023" for tiny amounts). Validation only applies to user-driven edits.
+    const fromExternal = isExternalWrite;
+    isExternalWrite = false;
 
-  // Pasted text may still contain garbage; strip it back to the last valid value.
-  if (newVal !== '' && !decimalPattern().test(newVal)) {
-    inputAmount.value = oldVal;
-    return;
-  }
+    // Normalize comma to dot (covers paste — beforeinput rewrites typed commas).
+    if (!fromExternal && newVal.includes(',')) {
+      inputAmount.value = newVal.replace(/,/g, '.');
+      return;
+    }
 
-  isInternalSync = true;
-  const numeric = parseFloat(newVal);
+    // Pasted text may still contain garbage; strip it back to the last valid value.
+    if (!fromExternal && newVal !== '' && !decimalPattern().test(newVal)) {
+      inputAmount.value = oldVal;
+      return;
+    }
 
-  if (isNaN(numeric) || numeric <= 0) {
-    emit('update:ribbits', 0);
-  } else {
-    const pepVal = props.isFiatMode && props.price > 0 ? numeric / props.price : numeric;
-    emit('update:ribbits', pepToRibbits(pepVal));
-  }
+    isInternalSync = true;
+    const numeric = parseFloat(newVal);
 
-  // If user is typing, we are no longer in "MAX" state
-  if (newVal !== oldVal) {
-    emit('change-max', false);
-  }
+    if (isNaN(numeric) || numeric <= 0) {
+      emit('update:ribbits', 0);
+    } else {
+      const pepVal = props.isFiatMode && props.price > 0 ? numeric / props.price : numeric;
+      emit('update:ribbits', pepToRibbits(pepVal));
+    }
 
-  isInternalSync = false;
-});
+    // If user is typing, we are no longer in "MAX" state. External writes
+    // (including the MAX click itself) must not clear the MAX flag.
+    if (!fromExternal && newVal !== oldVal) {
+      emit('change-max', false);
+    }
+
+    isInternalSync = false;
+  },
+  { flush: 'sync' }
+);
 
 function toggleMode() {
   emit('update:isFiatMode', !props.isFiatMode);

--- a/src/components/ui/form/PepInput.vue
+++ b/src/components/ui/form/PepInput.vue
@@ -20,7 +20,7 @@ const props = withDefaults(defineProps<Props>(), {
   clearable: false,
   disabled: false
 });
-const emit = defineEmits(['update:modelValue', 'blur']);
+const emit = defineEmits(['update:modelValue', 'blur', 'beforeinput']);
 
 const formDisabled = inject<ComputedRef<boolean>>(
   'isFormDisabled',
@@ -62,6 +62,7 @@ function handleClear() {
         :autofocus="autofocus"
         :disabled="isDisabled"
         @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+        @beforeinput="$emit('beforeinput', $event)"
         @blur="$emit('blur', $event)"
         :placeholder="placeholder"
         class="text-offwhite block min-w-0 grow bg-transparent py-1.5 text-base placeholder:text-gray-500 focus:outline-none sm:text-sm"


### PR DESCRIPTION
## Summary
Refactors `PepAmountInput` to fix three related bugs and remove the flag-based two-way sync that was masking them.

**Bugs fixed**
- Typing non-numeric characters (e.g. `1x3e`) was silently accepted because `parseFloat` extracts the leading number while the field still showed the garbage text.
- Toggling currency on a tiny amount (where `formatFiat` emits more decimals than the per-mode cap) caused the validator to reject the formatted value, revert, re-reject, and freeze the popup.
- Clicking MAX in fiat mode wrote the exact wallet balance, formatted it as fiat, parsed that back, and emitted a slightly higher ribbits value — triggering "insufficient funds" on review.

**Refactor**
- `ribbits` is the single source of truth. A computed `displayText` derives the rendered string from ribbits + mode + price; it is never validated or round-tripped.
- An `editBuffer` exists only while the user is mid-edit. It is dropped on blur, on currency toggle, and when an external `ribbits` change doesn't match what the buffer parses to.
- `update:ribbits` and `change-max:false` are emitted **only** from real user input — never from a watcher echo.
- `beforeinput` blocks invalid keystrokes at the source; `handleInput` rejects pasted/programmatic garbage as a fallback.
- Decimal cap is 8 in both modes — sub-cent fiat holdings are real (e.g. $0.0049) and `formatFiat` itself emits more than 2 decimals for tiny values.
- Removes `isInternalSync`, `isExternalWrite`, and `flush: 'sync'` — the new model has no echo loop to break.
- `PepInput` now forwards the `beforeinput` event so amount-style fields can intercept it.

## Test plan
- [x] Type `1x3e` into the Send amount field — characters after `1` are blocked.
- [x] Paste `1x3e` — input is rejected and snaps back to the previous valid value.
- [x] Type `1,5` — normalized to `1.5`.
- [x] Try entering more than 8 decimals — blocked (in either mode).
- [x] Type a sub-cent fiat amount (e.g. `0.0049`) — accepted.
- [x] Toggle to fiat with a sub-cent amount — no freeze, value stays visible.
- [x] Click MAX in fiat mode → review → Send — no "insufficient funds".
- [x] Type `1.` mid-edit — the trailing dot stays in the field; blur normalizes to `1`.