### PR TITLE
Extract PepNetworkFee component and show fee on send approval

### DIFF
--- a/src/components/ui/PepNetworkFee.spec.ts
+++ b/src/components/ui/PepNetworkFee.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PepNetworkFee from './PepNetworkFee.vue';
+
+describe('PepNetworkFee', () => {
+  it('renders the label and fee value', () => {
+    const wrapper = mount(PepNetworkFee, { props: { fee: '0.00226 PEP' } });
+
+    expect(wrapper.text()).toContain('Network Fee');
+    expect(wrapper.text()).toContain('0.00226 PEP');
+  });
+
+  it('defaults to the stacked layout', () => {
+    const wrapper = mount(PepNetworkFee, { props: { fee: '0.001 PEP' } });
+
+    expect(wrapper.find('.flex-col').exists()).toBe(true);
+    expect(wrapper.find('.justify-between').exists()).toBe(false);
+  });
+
+  it('uses an inline layout when requested', () => {
+    const wrapper = mount(PepNetworkFee, {
+      props: { fee: '0.001 PEP', layout: 'inline' }
+    });
+
+    expect(wrapper.find('.justify-between').exists()).toBe(true);
+    expect(wrapper.find('.flex-col').exists()).toBe(false);
+  });
+});

--- a/src/components/ui/PepNetworkFee.spec.ts
+++ b/src/components/ui/PepNetworkFee.spec.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import PepNetworkFee from './PepNetworkFee.vue';
+import PepSpinner from './PepSpinner.vue';
+
+const globalConfig = { components: { PepSpinner } };
 
 describe('PepNetworkFee', () => {
   it('renders the label and fee value', () => {
-    const wrapper = mount(PepNetworkFee, { props: { fee: '0.00226 PEP' } });
+    const wrapper = mount(PepNetworkFee, { props: { fee: '0.00226 PEP' }, global: globalConfig });
 
     expect(wrapper.text()).toContain('Network Fee');
     expect(wrapper.text()).toContain('0.00226 PEP');
@@ -19,10 +22,22 @@ describe('PepNetworkFee', () => {
 
   it('uses an inline layout when requested', () => {
     const wrapper = mount(PepNetworkFee, {
-      props: { fee: '0.001 PEP', layout: 'inline' }
+      props: { fee: '0.001 PEP', layout: 'inline' },
+      global: globalConfig
     });
 
     expect(wrapper.find('.justify-between').exists()).toBe(true);
     expect(wrapper.find('.flex-col').exists()).toBe(false);
+  });
+
+  it('shows a spinner instead of the fee while loading', () => {
+    const wrapper = mount(PepNetworkFee, {
+      props: { fee: '', loading: true },
+      global: globalConfig
+    });
+
+    expect(wrapper.findComponent(PepSpinner).exists()).toBe(true);
+    expect(wrapper.text()).toContain('Network Fee');
+    expect(wrapper.text()).not.toContain('PEP');
   });
 });

--- a/src/components/ui/PepNetworkFee.vue
+++ b/src/components/ui/PepNetworkFee.vue
@@ -3,20 +3,23 @@ withDefaults(
   defineProps<{
     fee: string;
     layout?: 'stacked' | 'inline';
+    loading?: boolean;
   }>(),
-  { layout: 'stacked' }
+  { layout: 'stacked', loading: false }
 );
 </script>
 
 <template>
   <div v-if="layout === 'inline'" class="flex items-center justify-between">
     <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">Network Fee</span>
-    <span class="text-xs font-bold text-slate-300">{{ fee }}</span>
+    <PepSpinner v-if="loading" :size="12" class="text-slate-400" />
+    <span v-else class="text-xs font-bold text-slate-300">{{ fee }}</span>
   </div>
   <div v-else class="px-1">
     <div class="flex flex-col">
       <span class="text-[10px] font-bold tracking-wider text-slate-500 uppercase">Network Fee</span>
-      <span class="text-xs font-bold text-slate-300">{{ fee }}</span>
+      <PepSpinner v-if="loading" :size="12" class="mt-0.5 text-slate-400" />
+      <span v-else class="text-xs font-bold text-slate-300">{{ fee }}</span>
     </div>
   </div>
 </template>

--- a/src/components/ui/PepNetworkFee.vue
+++ b/src/components/ui/PepNetworkFee.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    fee: string;
+    layout?: 'stacked' | 'inline';
+  }>(),
+  { layout: 'stacked' }
+);
+</script>
+
+<template>
+  <div v-if="layout === 'inline'" class="flex items-center justify-between">
+    <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">Network Fee</span>
+    <span class="text-xs font-bold text-slate-300">{{ fee }}</span>
+  </div>
+  <div v-else class="px-1">
+    <div class="flex flex-col">
+      <span class="text-[10px] font-bold tracking-wider text-slate-500 uppercase">Network Fee</span>
+      <span class="text-xs font-bold text-slate-300">{{ fee }}</span>
+    </div>
+  </div>
+</template>

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import PepSuccessState from '@/components/ui/PepSuccessState.vue';
 import PepAmountInput from '@/components/ui/form/PepAmountInput.vue';
 import PepTransactionItem from '@/components/ui/list/PepTransactionItem.vue';
 import PepInscription from '@/components/ui/PepInscription.vue';
+import PepNetworkFee from '@/components/ui/PepNetworkFee.vue';
 import * as constants from '@/utils/constants';
 
 const app = createApp(App);
@@ -106,4 +107,5 @@ app.component('PepSuccessState', PepSuccessState);
 app.component('PepAmountInput', PepAmountInput);
 app.component('PepTransactionItem', PepTransactionItem);
 app.component('PepInscription', PepInscription);
+app.component('PepNetworkFee', PepNetworkFee);
 app.mount('#app');

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -178,8 +178,8 @@ function handleReject() {
           </div>
         </div>
 
-        <div v-if="displayFee" class="rounded-xl border border-slate-800 bg-slate-900 px-4 py-3">
-          <PepNetworkFee :fee="displayFee" layout="inline" />
+        <div class="rounded-xl border border-slate-800 bg-slate-900 px-4 py-3">
+          <PepNetworkFee :fee="displayFee" layout="inline" :loading="!displayFee" />
         </div>
       </div>
 
@@ -202,7 +202,11 @@ function handleReject() {
           :disabled="isProcessing"
           >Cancel</PepButton
         >
-        <PepButton id="approve-transaction-button" @click="handleApprove" :loading="isProcessing"
+        <PepButton
+          id="approve-transaction-button"
+          @click="handleApprove"
+          :loading="isProcessing"
+          :disabled="!displayFee"
           >Approve</PepButton
         >
       </div>

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useWalletStore } from '@/stores/wallet';
 import {
   deriveSigner,
@@ -18,6 +18,7 @@ import {
 import { useInscriptionStore } from '@/stores/inscriptions';
 import { RIBBITS_PER_PEP } from '@/utils/constants';
 import { SendTransaction } from '@/models/SendTransaction';
+import { formatPep } from '@/utils/price';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
@@ -69,29 +70,47 @@ const transferDetails = computed(() => {
   };
 });
 
+const prepared = ref<{ sendTx: SendTransaction; selectedUtxos: UTXO[] } | null>(null);
+const displayFee = ref('');
+let preparePromise: Promise<void> | null = null;
+
+async function prepare() {
+  if (!requestData.value || invalidRequest.value) return;
+
+  const recipients = normalizeRecipients(requestData.value.params);
+  const recipient = recipients[0]!;
+  const address = walletStore.address!;
+
+  const [fees, rawUtxos] = await Promise.all([fetchRecommendedFees(), fetchUtxos(address)]);
+  const inscriptionSet = await inscriptionStore.getOutputsSet(address);
+
+  const sendTx = new SendTransaction(address);
+  sendTx.utxos = rawUtxos.filter(
+    (u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionSet)
+  );
+  sendTx.fees = fees;
+  sendTx.amountRibbits = recipient.amount;
+  sendTx.recipient = recipient.address;
+
+  const { selectedUtxos } = sendTx.selectUtxos();
+  prepared.value = { sendTx, selectedUtxos };
+  displayFee.value = formatPep(sendTx.estimatedFeeRibbits);
+}
+
+watch(requestData, (v) => {
+  if (v && !invalidRequest.value) preparePromise = prepare();
+});
+
 async function handleApprove() {
   await runWithMnemonic(async (mnemonic) => {
-    const recipients = normalizeRecipients(requestData.value!.params);
-    const recipient = recipients[0]!;
-    const address = walletStore.address!;
+    if (preparePromise) await preparePromise;
+    if (!prepared.value) throw new Error('Transaction not ready');
 
-    const [fees, rawUtxos] = await Promise.all([fetchRecommendedFees(), fetchUtxos(address)]);
-
-    const inscriptionSet = await inscriptionStore.getOutputsSet(address);
-
-    const sendTx = new SendTransaction(address);
-    sendTx.utxos = rawUtxos.filter(
-      (u) => u.status.confirmed && !isInscriptionUtxo(u, inscriptionSet)
-    );
-    sendTx.fees = fees;
-    sendTx.amountRibbits = recipient.amount;
-    sendTx.recipient = recipient.address;
-
+    const { sendTx, selectedUtxos } = prepared.value;
     if (!sendTx.isValid) {
       throw new Error('Insufficient confirmed balance');
     }
 
-    const { selectedUtxos } = sendTx.selectUtxos();
     const finalFee = sendTx.estimatedFeeRibbits;
 
     const utxosWithHex: UTXO[] = [];
@@ -105,8 +124,8 @@ async function handleApprove() {
 
     const txHex = await createSignedTx(
       signer,
-      recipient.address,
-      recipient.amount,
+      sendTx.recipient,
+      sendTx.amountRibbits,
       utxosWithHex,
       finalFee
     );
@@ -157,6 +176,10 @@ function handleReject() {
               {{ r.address }}
             </p>
           </div>
+        </div>
+
+        <div v-if="displayFee" class="rounded-xl border border-slate-800 bg-slate-900 px-4 py-3">
+          <PepNetworkFee :fee="displayFee" layout="inline" />
         </div>
       </div>
 

--- a/src/views/inscriptions/send/SendInscriptionStepForm.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepForm.vue
@@ -48,14 +48,7 @@ onMounted(() => {
         @blur="$emit('address-blur')"
       />
 
-      <div class="px-1">
-        <div class="flex flex-col">
-          <span class="text-[10px] font-bold tracking-wider text-slate-500 uppercase"
-            >Estimated Fee</span
-          >
-          <span class="text-xs font-bold text-slate-300">{{ displayFee }}</span>
-        </div>
-      </div>
+      <PepNetworkFee :fee="displayFee" />
 
       <div class="mt-2 flex h-6 items-center justify-center">
         <p

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -68,14 +68,7 @@ onMounted(() => {
           </template>
         </PepAmountInput>
 
-        <div class="px-1">
-          <div class="flex flex-col">
-            <span class="text-[10px] font-bold tracking-wider text-slate-500 uppercase"
-              >Estimated Fee</span
-            >
-            <span class="text-xs font-bold text-slate-300">{{ displayFee }}</span>
-          </div>
-        </div>
+        <PepNetworkFee :fee="displayFee" />
       </div>
 
       <div class="mt-2 flex h-6 items-center justify-center">


### PR DESCRIPTION
## Summary
- New `PepNetworkFee` UI component (stacked + inline layouts) replaces the duplicated fee row in `SendStepForm` and `SendInscriptionStepForm`.
- Renamed label from "Estimated Fee" to "Network Fee" to match common wallet conventions.
- `SendTransferApproval` now pre-fetches fees/UTXOs on load and displays the network fee in the review card before the user approves. The prepared `SendTransaction` is reused at approve-time (no double fetch).

## Test plan
- [x] Verify the send flow (wallet) shows "Network Fee" with the correct PEP amount.
- [x] Verify the inscription send flow shows the same.
- [x] Open an approval window from a dApp `sendTransfer` request — confirm the fee appears in the review card before approving.
- [x] Approve a transaction end-to-end and confirm it broadcasts.
- [x] Cancel an approval and confirm it rejects cleanly.