### PR TITLE
Load UTXOs on send form mount so the displayed fee is accurate

### DIFF
--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -63,8 +63,11 @@ describe('useSendTransaction Composable', () => {
     } as any);
   });
 
-  it('should load fees without fetching UTXOs', async () => {
+  it('loads fees and UTXOs together so the displayed fee uses real coin selection', async () => {
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'u1', vout: 0, value: 500_000_000, status: { confirmed: true } }
+    ] as any);
 
     const { tx, loadFees, isLoadingFees } = useSendTransaction();
 
@@ -73,7 +76,27 @@ describe('useSendTransaction Composable', () => {
     expect(isLoadingFees.value).toBe(false);
 
     expect(tx.value.fees?.fastestFee).toBe(1000);
-    expect(api.fetchUtxos).not.toHaveBeenCalled();
+    expect(api.fetchUtxos).toHaveBeenCalledWith('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
+    expect(tx.value.utxos).toHaveLength(1);
+  });
+
+  it('shows the 2-output fee for a non-max amount once UTXOs are loaded', async () => {
+    // Regression: with empty utxos, SendTransaction.maxRibbits returns 0,
+    // which causes estimatedFeeRibbits to treat any non-zero amount as a max
+    // send and report the 1-output fee (cheaper by one output's worth of
+    // bytes) instead of the real 2-output fee. Loading UTXOs at mount fixes
+    // this so the form shows the higher, accurate fee for a normal send.
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'u1', vout: 0, value: 3_781_000_000, status: { confirmed: true } }
+    ] as any);
+
+    const { tx, displayFee, loadFees } = useSendTransaction();
+    await loadFees();
+
+    // 10 PEP: well under max, should be a 1-input 2-output tx.
+    tx.value.amountRibbits = 10 * RIBBITS_PER_PEP;
+    expect(displayFee.value).toBe('0.00226 PEP');
   });
 
   it('should check insufficient funds against spendable balance', async () => {

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -81,11 +81,6 @@ describe('useSendTransaction Composable', () => {
   });
 
   it('shows the 2-output fee for a non-max amount once UTXOs are loaded', async () => {
-    // Regression: with empty utxos, SendTransaction.maxRibbits returns 0,
-    // which causes estimatedFeeRibbits to treat any non-zero amount as a max
-    // send and report the 1-output fee (cheaper by one output's worth of
-    // bytes) instead of the real 2-output fee. Loading UTXOs at mount fixes
-    // this so the form shows the higher, accurate fee for a normal send.
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
     vi.mocked(api.fetchUtxos).mockResolvedValue([
       { txid: 'u1', vout: 0, value: 3_781_000_000, status: { confirmed: true } }

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -51,7 +51,18 @@ export function useSendTransaction() {
   async function loadFees() {
     isLoadingFees.value = true;
     try {
-      tx.value.fees = await fetchRecommendedFees();
+      // Load UTXOs alongside fees so the displayed fee reflects the user's
+      // actual coin selection. Without this, the model's estimatedFeeRibbits
+      // computes maxRibbits = 0 (empty utxos) and incorrectly flags every
+      // non-zero amount as a max send, showing the 1-output fee instead of
+      // the 2-output fee.
+      const [fees, utxos, inscriptionSet] = await Promise.all([
+        fetchRecommendedFees(),
+        fetchUtxos(walletStore.address!),
+        inscriptionStore.getOutputsSet(walletStore.address!)
+      ]);
+      tx.value.fees = fees;
+      tx.value.utxos = filterSpendableUtxos(utxos, inscriptionSet);
     } catch (e) {
       console.error('Failed to load fees', e);
       throw e;

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -51,11 +51,6 @@ export function useSendTransaction() {
   async function loadFees() {
     isLoadingFees.value = true;
     try {
-      // Load UTXOs alongside fees so the displayed fee reflects the user's
-      // actual coin selection. Without this, the model's estimatedFeeRibbits
-      // computes maxRibbits = 0 (empty utxos) and incorrectly flags every
-      // non-zero amount as a max send, showing the 1-output fee instead of
-      // the 2-output fee.
       const [fees, utxos, inscriptionSet] = await Promise.all([
         fetchRecommendedFees(),
         fetchUtxos(walletStore.address!),


### PR DESCRIPTION
## Summary
The send form's "Estimated Fee" was inaccurate for any non-max amount. With an empty UTXO set, `SendTransaction.maxRibbits` returns `0`, which made `estimatedFeeRibbits` flag every non-zero amount as a max send and report the 1-output fee (~0.00192 PEP) instead of the real 2-output fee (~0.00226 PEP).

Fix: load UTXOs alongside fees in `useSendTransaction.loadFees()` so the model's coin selection has real data on mount. `send()` still re-fetches fresh UTXOs at broadcast time.

## Test plan
- [ ] Open the send page with a positive balance — fee shows the 2-output amount (~0.00226 PEP for 1 input).
- [ ] Type a partial amount (e.g. 10 PEP) — fee stays at the 2-output amount.
- [ ] Click MAX — fee drops to the 1-output amount (~0.00192 PEP), correctly reflecting the absence of a change output.
- [ ] Send a transaction — broadcasts as before; fresh UTXOs are re-fetched at send time.