### PR TITLE
Drop isMax flag and infer change output from the math

### DIFF
--- a/src/components/ui/form/PepAmountInput.spec.ts
+++ b/src/components/ui/form/PepAmountInput.spec.ts
@@ -123,26 +123,6 @@ describe('PepAmountInput UI Component', () => {
     expect(displayedValue(wrapper)).toBe('0.0050');
   });
 
-  it('does not clear MAX flag when ribbits are set externally', async () => {
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 0, price: 10, isFiatMode: false },
-      global: { stubs }
-    });
-
-    await wrapper.setProps({ ribbits: 500_000_000 });
-    expect(wrapper.emitted('change-max')).toBeUndefined();
-  });
-
-  it('emits change-max:false when user types', async () => {
-    const wrapper = mount(PepAmountInput, {
-      props: { ribbits: 100, price: 10, isFiatMode: false },
-      global: { stubs }
-    });
-
-    await wrapper.find('input').setValue('101');
-    expect(wrapper.emitted('change-max')?.[0]).toEqual([false]);
-  });
-
   it('preserves exact ribbits when MAX is set in fiat mode (no parse round-trip)', async () => {
     // Regression: in fiat mode, MAX would write the exact ribbits, the
     // component would format them as e.g. "$1.23", parse that back, divide by

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -26,7 +26,6 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{
   'update:ribbits': [val: number];
   'update:isFiatMode': [val: boolean];
-  'change-max': [isMax: boolean];
 }>();
 
 const { settings: settingsStore } = useApp();
@@ -102,7 +101,6 @@ function handleInput(text: string) {
 
   editBuffer.value = normalized;
   emit('update:ribbits', parseToRibbits(normalized));
-  emit('change-max', false);
 }
 
 function handleBlur() {

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -80,6 +80,19 @@ describe('useSendTransaction Composable', () => {
     expect(tx.value.utxos).toHaveLength(1);
   });
 
+  it('drops the fee to the 1-output amount when amount equals maxRibbits', async () => {
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'u1', vout: 0, value: 3_781_000_000, status: { confirmed: true } }
+    ] as any);
+
+    const { tx, displayFee, maxRibbits, loadFees } = useSendTransaction();
+    await loadFees();
+
+    tx.value.amountRibbits = maxRibbits.value;
+    expect(displayFee.value).toBe('0.00192 PEP');
+  });
+
   it('shows the 2-output fee for a non-max amount once UTXOs are loaded', async () => {
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
     vi.mocked(api.fetchUtxos).mockResolvedValue([

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -63,8 +63,11 @@ describe('useSendTransaction Composable', () => {
     } as any);
   });
 
-  it('should load fees without fetching UTXOs', async () => {
+  it('loads fees and UTXOs together so the displayed fee uses real coin selection', async () => {
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'u1', vout: 0, value: 500_000_000, status: { confirmed: true } }
+    ] as any);
 
     const { tx, loadFees, isLoadingFees } = useSendTransaction();
 
@@ -73,17 +76,32 @@ describe('useSendTransaction Composable', () => {
     expect(isLoadingFees.value).toBe(false);
 
     expect(tx.value.fees?.fastestFee).toBe(1000);
-    expect(api.fetchUtxos).not.toHaveBeenCalled();
+    expect(api.fetchUtxos).toHaveBeenCalledWith('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
+    expect(tx.value.utxos).toHaveLength(1);
+  });
+
+  it('shows the 2-output fee for a non-max amount once UTXOs are loaded', async () => {
+    vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([
+      { txid: 'u1', vout: 0, value: 3_781_000_000, status: { confirmed: true } }
+    ] as any);
+
+    const { tx, displayFee, loadFees } = useSendTransaction();
+    await loadFees();
+
+    tx.value.amountRibbits = 10 * RIBBITS_PER_PEP;
+    expect(displayFee.value).toBe('0.00226 PEP');
   });
 
   it('should check insufficient funds against spendable balance', async () => {
     mockAccount.spendableBalanceRibbits = 100_000;
     vi.mocked(api.fetchRecommendedFees).mockResolvedValue({ fastestFee: 1000 } as any);
+    vi.mocked(api.fetchUtxos).mockResolvedValue([]);
 
-    const { isInsufficientFunds, tx, isLoadingFees, loadFees } = useSendTransaction();
+    const { isInsufficientFunds, tx, loadFees } = useSendTransaction();
     await loadFees();
 
-    tx.value.amountRibbits = 200_000; // More than balance
+    tx.value.amountRibbits = 200_000;
     expect(isInsufficientFunds.value).toBe(true);
   });
 
@@ -105,7 +123,7 @@ describe('useSendTransaction Composable', () => {
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 100_000_000;
 
-    await send('password', false);
+    await send('password');
 
     // UTXOs should have been fetched and filtered
     expect(api.fetchUtxos).toHaveBeenCalledWith('PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU');
@@ -127,7 +145,7 @@ describe('useSendTransaction Composable', () => {
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 100_000_000;
 
-    const result = await send('password', false);
+    const result = await send('password');
     expect(result).toBe('new-txid');
     expect(tx.value.utxos).toHaveLength(1);
   });
@@ -171,7 +189,7 @@ describe('useSendTransaction Composable', () => {
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 500_000_000;
 
-    const result = await send('password', false);
+    const result = await send('password');
 
     expect(result).toBe('new-txid');
     expect(api.broadcastTx).toHaveBeenCalledWith('signed-hex');
@@ -201,13 +219,13 @@ describe('useSendTransaction Composable', () => {
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 500_000_000;
 
-    await expect(send('password', false)).rejects.toThrow('Network error');
+    await expect(send('password')).rejects.toThrow('Network error');
   });
 
   it('should throw error if password is missing and mnemonic not loaded', async () => {
     mockWallet.isMnemonicLoaded = false;
     const { send } = useSendTransaction();
-    await expect(send('', false)).rejects.toThrow('Password required');
+    await expect(send('')).rejects.toThrow('Password required');
   });
 
   it('should estimate max amount from wallet balance', async () => {
@@ -240,7 +258,7 @@ describe('useSendTransaction Composable', () => {
     tx.value.recipient = 'recipient';
     tx.value.amountRibbits = 500_000_000;
 
-    await send('password', false);
+    await send('password');
 
     expect(crypto.deriveSigner).toHaveBeenCalledWith('test mnemonic', 5, 3);
   });

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -51,7 +51,13 @@ export function useSendTransaction() {
   async function loadFees() {
     isLoadingFees.value = true;
     try {
-      tx.value.fees = await fetchRecommendedFees();
+      const [fees, utxos, inscriptionSet] = await Promise.all([
+        fetchRecommendedFees(),
+        fetchUtxos(walletStore.address!),
+        inscriptionStore.getOutputsSet(walletStore.address!)
+      ]);
+      tx.value.fees = fees;
+      tx.value.utxos = filterSpendableUtxos(utxos, inscriptionSet);
     } catch (e) {
       console.error('Failed to load fees', e);
       throw e;
@@ -92,7 +98,7 @@ export function useSendTransaction() {
 
   let isSending = false;
 
-  async function send(password: string, isMax: boolean) {
+  async function send(password: string) {
     if (isSending) throw new Error('Transaction already in progress');
     isSending = true;
 
@@ -105,18 +111,15 @@ export function useSendTransaction() {
         mnemonic = await decryptMnemonic(walletStore.encryptedMnemonic!, password);
       }
 
-      // Fetch fresh UTXOs at send time to ensure accurate coin selection
+      // Refresh UTXOs at send time to catch anything that confirmed since the
+      // form was opened.
       const [utxos, inscriptionSet] = await Promise.all([
         fetchUtxos(walletStore.address!),
         inscriptionStore.getOutputsSet(walletStore.address!)
       ]);
       tx.value.utxos = filterSpendableUtxos(utxos, inscriptionSet);
 
-      if (isMax) {
-        tx.value.amountRibbits = tx.value.maxRibbits;
-      }
-
-      const { selectedUtxos } = tx.value.selectUtxos(isMax);
+      const { selectedUtxos } = tx.value.selectUtxos();
       const usedUtxosWithHex: UTXO[] = [];
 
       for (const utxo of selectedUtxos) {

--- a/src/composables/useSendTransaction.ts
+++ b/src/composables/useSendTransaction.ts
@@ -15,12 +15,11 @@ import {
   isValidAddress,
   deriveSigner,
   parseDerivationPath,
-  estimateTxSize,
   type UTXO
 } from '@/utils/crypto';
 import { decrypt as decryptMnemonic } from '@/utils/encryption';
 import { SendTransaction } from '@/models/SendTransaction';
-import { RIBBITS_PER_PEP, MIN_SEND_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
+import { RIBBITS_PER_PEP, MIN_SEND_PEP } from '@/utils/constants';
 
 export function useSendTransaction() {
   const { wallet: walletStore, account } = useApp();
@@ -39,14 +38,7 @@ export function useSendTransaction() {
 
   const displayFee = computed(() => price.formatPep(tx.value.estimatedFeeRibbits));
 
-  const maxRibbits = computed(() => {
-    const txSize = estimateTxSize(1, 2);
-    const feeRate = tx.value.fees
-      ? Math.max(RECOMMENDED_FEE_RATE, tx.value.fees.fastestFee)
-      : RECOMMENDED_FEE_RATE;
-    const feeRibbits = Math.ceil(txSize * feeRate);
-    return Math.max(0, account.spendableBalanceRibbits - feeRibbits);
-  });
+  const maxRibbits = computed(() => tx.value.maxRibbits);
 
   async function loadFees() {
     isLoadingFees.value = true;

--- a/src/models/SendTransaction.spec.ts
+++ b/src/models/SendTransaction.spec.ts
@@ -147,18 +147,19 @@ describe('SendTransaction', () => {
   });
 
   describe('UTXO selection', () => {
-    it('should select all UTXOs when isMax is true', () => {
+    it('selects all UTXOs when the amount drains the wallet', () => {
       const tx = createTx([RIBBITS_PER_PEP, RIBBITS_PER_PEP * 2, RIBBITS_PER_PEP * 3]);
-      const { selectedUtxos, totalValue } = tx.selectUtxos(true);
+      tx.amountPep = tx.calculateMaxPep();
+      const { selectedUtxos, totalValue } = tx.selectUtxos();
       expect(selectedUtxos.length).toBe(3);
       expect(totalValue).toBe(RIBBITS_PER_PEP * 6);
     });
 
     it('should select minimal UTXOs to cover amount + fees', () => {
       const tx = createTx([RIBBITS_PER_PEP * 5, RIBBITS_PER_PEP * 3, RIBBITS_PER_PEP * 1]);
-      tx.amountPep = 0.5; // Small amount, first UTXO should suffice
+      tx.amountPep = 0.5;
 
-      const { selectedUtxos } = tx.selectUtxos(false);
+      const { selectedUtxos } = tx.selectUtxos();
       expect(selectedUtxos.length).toBe(1);
     });
 
@@ -166,24 +167,23 @@ describe('SendTransaction', () => {
       const tx = createTx([RIBBITS_PER_PEP, RIBBITS_PER_PEP, RIBBITS_PER_PEP]);
       tx.amountPep = 2.5;
 
-      const { selectedUtxos } = tx.selectUtxos(false);
+      const { selectedUtxos } = tx.selectUtxos();
       expect(selectedUtxos.length).toBe(3);
     });
 
     it('should estimate fee buffer per selected UTXOs, not total UTXOs', () => {
-      // 20 UTXOs of 1 PEP each, sending 0.5 PEP — should only need 1 UTXO
       const utxos = Array.from({ length: 20 }, () => RIBBITS_PER_PEP);
       const tx = createTx(utxos);
       tx.amountPep = 0.5;
 
-      const { selectedUtxos } = tx.selectUtxos(false);
+      const { selectedUtxos } = tx.selectUtxos();
       expect(selectedUtxos.length).toBe(1);
     });
 
     it('should return empty array when there are no UTXOs', () => {
       const tx = createTx([]);
       tx.amountPep = 1;
-      const { selectedUtxos, totalValue } = tx.selectUtxos(true);
+      const { selectedUtxos, totalValue } = tx.selectUtxos();
       expect(selectedUtxos.length).toBe(0);
       expect(totalValue).toBe(0);
     });
@@ -227,19 +227,23 @@ describe('SendTransaction', () => {
   });
 
   describe('integer safety', () => {
-    it('isMax detection should work with integer comparison, not float epsilon', () => {
+    it('drops the change output when sending the full max amount', () => {
       const tx = createTx([RIBBITS_PER_PEP * 2]);
       tx.recipient = 'PmockRecipientAddress1234567890123';
 
-      const maxPep = tx.calculateMaxPep();
-      tx.amountPep = maxPep;
+      tx.amountPep = tx.calculateMaxPep();
 
-      // The amountRibbits should >= maxRibbits (isMax = true)
-      expect(tx.amountRibbits).toBeGreaterThanOrEqual(tx.maxRibbits);
-
-      // Fee with isMax should be for 1 output
       const maxFee = Math.ceil(estimateTxSize(1, 1) * RECOMMENDED_FEE_RATE);
       expect(tx.estimatedFeeRibbits).toBe(maxFee);
+    });
+
+    it('keeps the 2-output fee for a partial send on a single-UTXO wallet', () => {
+      const tx = createTx([RIBBITS_PER_PEP * 10]);
+      tx.recipient = 'PmockRecipientAddress1234567890123';
+      tx.amountPep = 1;
+
+      const expectedFee = Math.ceil(estimateTxSize(1, 2) * RECOMMENDED_FEE_RATE);
+      expect(tx.estimatedFeeRibbits).toBe(expectedFee);
     });
 
     it('should not have floating point errors affect isValid at boundary', () => {

--- a/src/models/SendTransaction.ts
+++ b/src/models/SendTransaction.ts
@@ -1,8 +1,6 @@
 import { estimateTxSize, type UTXO } from '@/utils/crypto';
 import type { RecommendedFees } from '@/models/Fees';
-import { RIBBITS_PER_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
-
-const OUTPUT_BYTES = 34;
+import { RIBBITS_PER_PEP, RECOMMENDED_FEE_RATE, P2PKH_OUTPUT_BYTES } from '@/utils/constants';
 
 export class SendTransaction {
   public utxos: UTXO[] = [];
@@ -54,7 +52,7 @@ export class SendTransaction {
     const fee2 = Math.ceil(estimateTxSize(selectedUtxos.length, 2) * feeRate);
     const change = totalValue - this.amountRibbits - fee2;
 
-    if (change > OUTPUT_BYTES * feeRate) {
+    if (change > P2PKH_OUTPUT_BYTES * feeRate) {
       return fee2;
     }
 

--- a/src/models/SendTransaction.ts
+++ b/src/models/SendTransaction.ts
@@ -2,6 +2,8 @@ import { estimateTxSize, type UTXO } from '@/utils/crypto';
 import type { RecommendedFees } from '@/models/Fees';
 import { RIBBITS_PER_PEP, RECOMMENDED_FEE_RATE } from '@/utils/constants';
 
+const OUTPUT_BYTES = 34;
+
 export class SendTransaction {
   public utxos: UTXO[] = [];
   public fees: RecommendedFees | null = null;
@@ -13,16 +15,12 @@ export class SendTransaction {
     this.userAddress = userAddress;
   }
 
-  /**
-   * Returns the amount in PEP as a string, formatted with 100% precision.
-   * e.g. 100000000 -> "1", 1 -> "0.00000001"
-   */
   get amountPep(): string {
     if (this.amountRibbits === 0) return '0';
 
     const s = this.amountRibbits.toString().padStart(9, '0');
-    const integerPart = s.slice(0, -8).replace(/^0+(?=\d)/, ''); // Remove leading zeros but keep at least one digit
-    const decimalPart = s.slice(-8).replace(/0+$/, ''); // Remove trailing zeros
+    const integerPart = s.slice(0, -8).replace(/^0+(?=\d)/, '');
+    const decimalPart = s.slice(-8).replace(/0+$/, '');
 
     return decimalPart ? `${integerPart || '0'}.${decimalPart}` : integerPart;
   }
@@ -40,39 +38,38 @@ export class SendTransaction {
     return this.balanceRibbits / RIBBITS_PER_PEP;
   }
 
-  get estimatedFeeRibbits(): number {
-    const isMax = this.amountRibbits > 0 && this.amountRibbits >= this.maxRibbits;
-    const { selectedUtxos } = this.selectUtxos(isMax);
-    const outputCount = isMax ? 1 : 2;
-    const size = estimateTxSize(selectedUtxos.length || 1, outputCount);
-
-    // Fallback if API is down
-    if (!this.fees) return Math.ceil(size * RECOMMENDED_FEE_RATE);
-
-    /**
-     * Logic:
-     * Use API fastestFee but force a floor of RECOMMENDED_FEE_RATE (1000)
-     * to ensure we always meet the network recommendation.
-     */
-    const feeRate = Math.max(RECOMMENDED_FEE_RATE, this.fees.fastestFee);
-    return Math.ceil(size * feeRate);
+  private get feeRate(): number {
+    if (!this.fees) return RECOMMENDED_FEE_RATE;
+    return Math.max(RECOMMENDED_FEE_RATE, this.fees.fastestFee);
   }
 
-  public selectUtxos(isMax = false) {
-    if (isMax) {
-      return {
-        selectedUtxos: [...this.utxos],
-        totalValue: this.balanceRibbits
-      };
+  get estimatedFeeRibbits(): number {
+    const feeRate = this.feeRate;
+    const { selectedUtxos, totalValue } = this.selectUtxos();
+
+    if (selectedUtxos.length === 0) {
+      return Math.ceil(estimateTxSize(1, 2) * feeRate);
     }
 
+    const fee2 = Math.ceil(estimateTxSize(selectedUtxos.length, 2) * feeRate);
+    const change = totalValue - this.amountRibbits - fee2;
+
+    if (change > OUTPUT_BYTES * feeRate) {
+      return fee2;
+    }
+
+    // No worthwhile change output. The leftover (totalValue - amount) is the
+    // fee — but never report below the 1-output size-based floor, otherwise
+    // isValid would falsely accept a transaction that miners would reject.
+    const fee1 = Math.ceil(estimateTxSize(selectedUtxos.length, 1) * feeRate);
+    return Math.max(fee1, totalValue - this.amountRibbits);
+  }
+
+  public selectUtxos() {
     const amountRibbits = this.amountRibbits;
+    const feeRate = this.feeRate;
     const selectedUtxos: UTXO[] = [];
     let totalValue = 0;
-
-    const feeRate = this.fees
-      ? Math.max(RECOMMENDED_FEE_RATE, this.fees.fastestFee)
-      : RECOMMENDED_FEE_RATE;
 
     for (const utxo of this.utxos) {
       selectedUtxos.push(utxo);
@@ -86,12 +83,7 @@ export class SendTransaction {
 
   get maxRibbits(): number {
     const utxoCount = this.utxos.length || 1;
-    const txSize = estimateTxSize(utxoCount, 1); // 1 output, no change
-    const feeRate = this.fees
-      ? Math.max(RECOMMENDED_FEE_RATE, this.fees.fastestFee)
-      : RECOMMENDED_FEE_RATE;
-    const feeRibbits = Math.ceil(txSize * feeRate);
-
+    const feeRibbits = Math.ceil(estimateTxSize(utxoCount, 1) * this.feeRate);
     return Math.max(0, this.balanceRibbits - feeRibbits);
   }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -10,6 +10,9 @@ export const APP_VERSION = pkg.version;
 export const RECOMMENDED_FEE_RATE = 1000;
 export const MIN_SEND_PEP = 0.01;
 
+// Size of one P2PKH output in bytes: 8 (value) + 1 (script length) + 25 (script).
+export const P2PKH_OUTPUT_BYTES = 34;
+
 // Pepecoin (Dogecoin-derived) soft dust rule: outputs below 1 PEP add a flat
 // surcharge to the effective minimum fee miners enforce. Inscription postage
 // outputs are always sub-dust, which is why inscription transfers stall at

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -4,6 +4,7 @@ import { BIP32Factory } from 'bip32';
 import * as ecc from 'tiny-secp256k1';
 import message from 'bitcoinjs-message';
 import { PEPECOIN } from './networks';
+import { P2PKH_OUTPUT_BYTES } from './constants';
 
 const bip32 = BIP32Factory(ecc);
 
@@ -78,7 +79,7 @@ export function isValidAddress(address: string): boolean {
  * Estimates the virtual size of a P2PKH transaction
  */
 export function estimateTxSize(inputCount: number, outputCount: number): number {
-  return inputCount * 148 + outputCount * 34 + 10;
+  return inputCount * 148 + outputCount * P2PKH_OUTPUT_BYTES + 10;
 }
 
 export interface UTXO {

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -91,7 +91,7 @@ async function handleApprove() {
       throw new Error('Insufficient confirmed balance');
     }
 
-    const { selectedUtxos } = sendTx.selectUtxos(false);
+    const { selectedUtxos } = sendTx.selectUtxos();
     const finalFee = sendTx.estimatedFeeRibbits;
 
     const utxosWithHex: UTXO[] = [];

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -302,15 +302,13 @@ describe('SendView', () => {
     expect(wrapper.vm.form.errors.general).toBe('Invalid step 1');
   });
 
-  it('setMax should set isMax and update amount', () => {
+  it('setMax fills the amount field with the max sendable value', () => {
     mockSendTransaction.maxRibbits.value = 5000;
     const wrapper = mount(SendView, { global });
 
     // @ts-ignore
     wrapper.vm.setMax();
 
-    // @ts-ignore
-    expect(wrapper.vm.form.isMax).toBe(true);
     // @ts-ignore
     expect(wrapper.vm.form.amountRibbits).toBe(5000);
   });

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -53,7 +53,6 @@ onMounted(() => {
           v-model:isFiatMode="form.isFiatMode"
           :price="currentPrice"
           :disabled="form.isProcessing"
-          @change-max="form.isMax = $event"
         >
           <template #extra>
             <button

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -32,7 +32,6 @@ const form = useForm({
   amountRibbits: 0,
   isFiatMode: false,
   password: '',
-  isMax: false,
   step: 1,
   txid: ''
 });
@@ -45,7 +44,6 @@ const draft = useSessionDraft({
     recipient: form.recipient,
     amountRibbits: form.amountRibbits,
     isFiatMode: form.isFiatMode,
-    isMax: form.isMax,
     step: form.step,
     txid: form.txid
   })
@@ -100,7 +98,6 @@ watch(
 );
 
 function setMax() {
-  form.isMax = true;
   form.amountRibbits = maxRibbits.value;
 }
 
@@ -141,7 +138,7 @@ async function handleSend() {
   const startTime = Date.now();
 
   try {
-    await send(form.password, form.isMax);
+    await send(form.password);
 
     const elapsed = Date.now() - startTime;
     if (elapsed < 500) await new Promise((r) => setTimeout(r, 500 - elapsed));
@@ -150,7 +147,6 @@ async function handleSend() {
     form.recipient = '';
     form.amountRibbits = 0;
     form.password = '';
-    form.isMax = false;
     form.step = 3;
   } catch (e: any) {
     form.setError('general', e.message || 'Failed to send');


### PR DESCRIPTION
## Summary
The send form's "Estimated Fee" was inaccurate for any non-max amount. Root cause was twofold:

1. UTXOs weren't loaded until `send()` ran, so on the form the model had no coin selection to estimate against.
2. `SendTransaction.estimatedFeeRibbits` inferred max-send from internal state (\`amountRibbits >= maxRibbits\`). With empty UTXOs, \`maxRibbits === 0\`, which made every non-zero amount look like a max send and report the 1-output fee (~0.00192 PEP) instead of the real 2-output fee (~0.00226 PEP).

\`isMax\` as a UI flag was also conceptually wrong. Pressing MAX is just "fill the field with the max sendable amount." Whether the tx has a change output isn't a UI mode — it's a property of the numbers: if leftover \`= totalSelected - amount - fee\` is too small to be worth keeping, drop it; otherwise keep it.

## Changes
- \`SendTransaction.estimatedFeeRibbits\` now computes whether a change output is worthwhile from the actual numbers (\`change > 34 bytes × feeRate\`), never inferring from \`maxRibbits\`. The 1-output size-based floor is enforced so \`isValid\` can't accept an infeasibly low fee.
- \`SendTransaction.selectUtxos()\` drops its boolean arg; greedy selection already covers the max case correctly.
- \`useSendTransaction.loadFees()\` now fetches UTXOs in parallel so the form has real coin selection data on mount. \`send()\` still re-fetches fresh UTXOs at broadcast time.
- \`useSendTransaction.send(password)\` drops the \`isMax\` parameter.
- \`SendView.setMax()\` no longer flips a flag; it just sets the amount.
- \`PepAmountInput\` no longer emits \`change-max\` (its only consumer is gone).
- \`form.isMax\` removed entirely, including from the session draft.

## Test plan
- [x] Open the send page with a positive balance — fee shows the 2-output amount (~0.00226 PEP for 1 input).
- [x] Type a partial amount (e.g. 10 PEP) — fee stays at the 2-output amount.
- [x] Click MAX — fee drops to the 1-output amount (~0.00192 PEP), reflecting the absence of a change output.
- [x] Type a smaller amount after pressing MAX — fee goes back up to the 2-output amount.
- [x] Send a transaction end-to-end and confirm it broadcasts.
- [x] dApp \`sendTransfer\` approval still works.