### PR TITLE
Improve address readability in approval views

### DIFF
--- a/scripts/build-listing-psbt.ts
+++ b/scripts/build-listing-psbt.ts
@@ -1,0 +1,67 @@
+// Builds a 1-in / 1-out listing PSBT with sighashType 0x83
+// (SIGHASH_SINGLE | ANYONECANPAY) on input 0, spending an inscription UTXO
+// to a payout address for a fixed asking price.
+//
+// Usage:
+//   npx tsx scripts/build-listing-psbt.ts <inscriptionId> <priceInPep> <payoutAddress>
+import { Psbt } from 'bitcoinjs-lib';
+import { PEPECOIN } from '../src/utils/networks';
+
+const API_BASE = 'https://peppool.space/api';
+const SIGHASH_SINGLE_ANYONECANPAY = 0x83;
+
+function parseSatpoint(satpoint: string): { txid: string; vout: number } {
+  const match = satpoint.match(/^([0-9a-f]{64}):(\d+):\d+$/i);
+  if (!match) throw new Error(`Invalid satpoint: ${satpoint}`);
+  return { txid: match[1].toLowerCase(), vout: Number(match[2]) };
+}
+
+async function main() {
+  const [inscriptionId, priceArg, payout] = process.argv.slice(2);
+  if (!inscriptionId || !priceArg || !payout) {
+    console.error(
+      'Usage: npx tsx scripts/build-listing-psbt.ts <inscriptionId> <priceInPep> <payoutAddress>'
+    );
+    process.exit(1);
+  }
+
+  const priceRibbits = BigInt(Math.round(Number(priceArg) * 1e8));
+  if (priceRibbits <= 0n) throw new Error('Price must be positive');
+
+  // Resolve the inscription's current UTXO via the indexer — the reveal output
+  // encoded in the inscription id is stale once the inscription has been moved.
+  const insc = await (await fetch(`${API_BASE}/inscription/${inscriptionId}`)).json();
+  if (!insc?.satpoint) throw new Error(`Inscription not found or has no satpoint: ${inscriptionId}`);
+  const { txid, vout } = parseSatpoint(insc.satpoint);
+
+  // Output = price + postage so the seller's net receive equals the advertised
+  // price exactly (the postage from the inscription input is returned to them).
+  const postage = BigInt(insc.value);
+  const outputValue = priceRibbits + postage;
+
+  const rawHex = (await (await fetch(`${API_BASE}/tx/${txid}/hex`)).text()).trim();
+  if (!/^[0-9a-f]+$/i.test(rawHex)) throw new Error(`Could not fetch raw tx for ${txid}`);
+
+  const psbt = new Psbt({ network: PEPECOIN });
+  psbt.setVersion(1);
+  psbt.addInput({
+    hash: txid,
+    index: vout,
+    nonWitnessUtxo: Buffer.from(rawHex, 'hex'),
+    sighashType: SIGHASH_SINGLE_ANYONECANPAY
+  });
+  psbt.addOutput({ address: payout, value: outputValue });
+
+  console.log(
+    `Listing ${inscriptionId} (held by ${insc.address} at ${insc.satpoint}, ` +
+      `postage ${postage} ribbits) for ${priceArg} PEP (${priceRibbits} ribbits) → ${payout} ` +
+      `[output ${outputValue} ribbits = price + postage]`
+  );
+  console.log();
+  console.log(psbt.toBase64());
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/ui/PepInlineAddress.spec.ts
+++ b/src/components/ui/PepInlineAddress.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import PepInlineAddress from './PepInlineAddress.vue';
+
+const ADDRESS = 'Pq3Qe41neyfA3yEHZie2DNzW55AnN2K3RP';
+const OTHER_ADDRESS = 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU';
+
+// Stub the wallet store so the component can self-detect "mine" without
+// having to spin up the real Pinia store (which has side effects on init).
+const walletAddress = { value: null as string | null };
+vi.mock('@/stores/wallet', () => ({
+  useWalletStore: () => ({
+    get address() {
+      return walletAddress.value;
+    }
+  })
+}));
+
+describe('PepInlineAddress', () => {
+  it('renders the truncated address with the last 6 chars always visible', () => {
+    walletAddress.value = null;
+    const wrapper = mount(PepInlineAddress, { props: { address: ADDRESS } });
+    // The "end" piece (last 6) is rendered in its own non-collapsible span
+    // so it remains visible when the parent narrows. Verify both halves are
+    // present in the rendered output.
+    expect(wrapper.text()).toContain(ADDRESS.slice(0, -6));
+    expect(wrapper.text()).toContain(ADDRESS.slice(-6));
+  });
+
+  it('exposes the full address via title for hover-to-reveal', () => {
+    walletAddress.value = null;
+    const wrapper = mount(PepInlineAddress, { props: { address: ADDRESS } });
+    expect(wrapper.get('[title]').attributes('title')).toBe(ADDRESS);
+  });
+
+  it('auto-detects own address from the wallet store and shows "My Address"', () => {
+    walletAddress.value = ADDRESS;
+    const wrapper = mount(PepInlineAddress, { props: { address: ADDRESS } });
+    expect(wrapper.text()).toContain('My Address');
+  });
+
+  it('does not show "My Address" when the address belongs to a counterparty', () => {
+    walletAddress.value = OTHER_ADDRESS;
+    const wrapper = mount(PepInlineAddress, { props: { address: ADDRESS } });
+    expect(wrapper.text()).not.toContain('My Address');
+  });
+
+  it('renders a non-standard script fallback when address is null', () => {
+    walletAddress.value = null;
+    const wrapper = mount(PepInlineAddress, { props: { address: null } });
+    expect(wrapper.text()).toContain('Non-standard script');
+    expect(wrapper.text()).not.toContain('My Address');
+  });
+});

--- a/src/components/ui/PepInlineAddress.vue
+++ b/src/components/ui/PepInlineAddress.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { truncateId } from '@/utils/constants';
+import { useWalletStore } from '@/stores/wallet';
+
+const props = defineProps<{
+  address: string | null;
+}>();
+
+const walletStore = useWalletStore();
+
+const truncated = computed(() => (props.address ? truncateId(props.address) : null));
+const isMyAddress = computed(() => !!props.address && props.address === walletStore.address);
+</script>
+
+<template>
+  <span class="flex min-w-0 flex-col gap-0.5">
+    <span v-if="isMyAddress" class="text-pepe-green text-[10px] font-bold tracking-wider uppercase">
+      My Address
+    </span>
+    <span
+      v-if="truncated"
+      class="inline-flex min-w-0 font-mono text-xs text-slate-300"
+      :title="truncated.full"
+    >
+      <span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{{
+        truncated.start
+      }}</span>
+      <span class="whitespace-nowrap">{{ truncated.end }}</span>
+    </span>
+    <span v-else class="text-xs text-slate-500 italic">Non-standard script</span>
+  </span>
+</template>

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -22,6 +22,7 @@ import { formatPep } from '@/utils/price';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
+import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
 
 interface Recipient {
   address: string;
@@ -172,9 +173,9 @@ function handleReject() {
           </div>
           <div class="space-y-1">
             <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">To</span>
-            <p class="font-mono text-xs leading-relaxed break-all text-slate-300">
-              {{ r.address }}
-            </p>
+            <div class="pt-0.5">
+              <PepInlineAddress :address="r.address" />
+            </div>
           </div>
         </div>
 

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -7,6 +7,7 @@ import { formatPep } from '@/utils/price';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
+import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
 import { ALLOWED_SIGHASHES, SIGHASH, getInputSighash, sighashLabel } from '@/utils/psbt';
@@ -191,18 +192,9 @@ function handleReject() {
           <div
             v-for="(io, i) in psbtDetails.inputs"
             :key="`in-${i}`"
-            class="flex items-start justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+            class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
           >
-            <div class="min-w-0 space-y-0.5">
-              <p class="font-mono text-xs break-all text-slate-300">
-                {{ io.address ?? 'Non-standard script' }}
-              </p>
-              <span
-                v-if="io.mine"
-                class="text-pepe-green inline-block text-[10px] font-bold tracking-wider uppercase"
-                >Your wallet</span
-              >
-            </div>
+            <PepInlineAddress :address="io.address" />
             <span class="shrink-0 text-xs font-bold text-slate-200">{{
               io.amountRibbits === null ? '—' : formatPep(io.amountRibbits)
             }}</span>
@@ -217,18 +209,9 @@ function handleReject() {
           <div
             v-for="(io, i) in psbtDetails.outputs"
             :key="`out-${i}`"
-            class="flex items-start justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+            class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
           >
-            <div class="min-w-0 space-y-0.5">
-              <p class="font-mono text-xs break-all text-slate-300">
-                {{ io.address ?? 'Non-standard script' }}
-              </p>
-              <span
-                v-if="io.mine"
-                class="text-pepe-green inline-block text-[10px] font-bold tracking-wider uppercase"
-                >Your wallet</span
-              >
-            </div>
+            <PepInlineAddress :address="io.address" />
             <span class="shrink-0 text-xs font-bold text-slate-200">{{
               io.amountRibbits === null ? '—' : formatPep(io.amountRibbits)
             }}</span>


### PR DESCRIPTION
## Summary
- Adds `PepInlineAddress` component that truncates long Base58 addresses to `<start>…<last6>` with hover-to-reveal full address (CSS-ellipsis on the start segment, last 6 chars always visible)
- Auto-detects the active account address from the wallet store and stacks a small green `My Address` label above it — no `mine` prop needed at call sites
- Drops the old `Your wallet` pill / break-all address pattern from `SignPsbtApproval` (input + output rows) and `SendTransferApproval` (recipient row)

## Test plan
- [ ] Open SignPsbt approval with a listing PSBT — own address rows show `My Address` label above truncated address; counterparty rows show address only
- [ ] Open Send approval to a self-address — `My Address` label appears
- [ ] Open Send approval to an external recipient — no label, address truncated
- [ ] Hover any address — tooltip shows full address
- [ ] Non-standard scripts still render `Non-standard script` fallback