### PR TITLE
Split signPsbt hero into transfer/receive pair with inscription detection

### DIFF
--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -17,7 +17,12 @@ Object.defineProperty(window, 'location', {
 window.close = vi.fn();
 
 vi.mock('@/utils/api', () => ({
-  broadcastTx: vi.fn().mockResolvedValue('mock-txid')
+  broadcastTx: vi.fn().mockResolvedValue('mock-txid'),
+  fetchTipHeight: vi.fn().mockResolvedValue(0),
+  fetchAddressInfo: vi.fn().mockResolvedValue({ balance: 0 }),
+  fetchAddressInscriptions: vi.fn().mockResolvedValue({ inscriptions: [], outputs: [], total: 0 }),
+  fetchInscription: vi.fn(),
+  fetchInscriptionOutputs: vi.fn().mockResolvedValue([])
 }));
 
 vi.mock('@/utils/crypto', () => ({
@@ -270,6 +275,107 @@ describe('SignPsbtApproval', () => {
     expect(mockSignInput).not.toHaveBeenCalled();
     expect(mockFinalizeAllInputs).not.toHaveBeenCalled();
     expect(wrapper.text()).toContain('Cannot broadcast');
+  });
+
+  it('renders inscription transfer and PEP receive for a listing PSBT', async () => {
+    const inscriptionTxid = 'a'.repeat(64);
+    const inscriptionVout = 0;
+    const myAddress = 'Pseller';
+    const myAddressKey = `${inscriptionTxid}:${inscriptionVout}`;
+
+    mockPsbt.inputCount = 1;
+    mockPsbt.txInputs = [
+      // Buffer.from(hash).reverse().toString('hex') must yield inscriptionTxid,
+      // so the hash buffer is the byte-reversed txid.
+      { hash: Buffer.from(inscriptionTxid, 'hex').reverse(), index: inscriptionVout }
+    ] as any;
+    mockPsbt.data.inputs = [{ nonWitnessUtxo: Buffer.from('deadbeef', 'hex') }] as any;
+    mockPsbt.txOutputs = [{ script: Buffer.from('00', 'hex'), value: 100_000_100_000_000 }] as any;
+
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('seller', 'utf8'), value: 100_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any).mockReturnValue(myAddress);
+
+    // Seed inscription store cache before mount.
+    const { LOCAL_STORAGE_KEYS } = await import('@/constants/storage');
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.INSCRIPTIONS,
+      JSON.stringify({
+        [myAddress]: {
+          inscriptions: {
+            ins1: {
+              id: 'ins1',
+              number: 42,
+              contentType: 'image/png',
+              contentLength: 100,
+              height: 1,
+              value: 100_000,
+              parents: [],
+              properties: null,
+              satpoint: `${myAddressKey}:0`,
+              timestamp: 0
+            }
+          },
+          outputs: [myAddressKey],
+          lastSyncedHeight: 1
+        }
+      })
+    );
+    const { useInscriptionStore } = await import('@/stores/inscriptions');
+    useInscriptionStore().load(myAddress);
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: myAddress, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'refreshBalance').mockResolvedValue(undefined as any);
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { [myAddress]: [0] } });
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('You will transfer');
+    expect(wrapper.text()).toContain('Inscription 42');
+    expect(wrapper.text()).toContain('You will receive');
+    // Net receive = 100_000_100_000_000 - 100_000 = 100_000_000_000_000 ribbits = 1,000,000 PEP
+    // (Test values are illustrative; the formatPep value is what matters for presence.)
+  });
+
+  it('shows only a transfer card for a pure-PEP send (change to self should not show as receive)', async () => {
+    const myAddress = 'Psender';
+
+    mockPsbt.inputCount = 1;
+    mockPsbt.txInputs = [{ hash: Buffer.alloc(32), index: 0 }] as any;
+    mockPsbt.data.inputs = [{ nonWitnessUtxo: Buffer.from('deadbeef', 'hex') }] as any;
+    mockPsbt.txOutputs = [
+      { script: Buffer.from('to-recipient', 'utf8'), value: 50_000_000 },
+      { script: Buffer.from('change', 'utf8'), value: 49_000_000 }
+    ] as any;
+
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('mine', 'utf8'), value: 100_000_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any)
+      .mockReturnValueOnce(myAddress) // input prev-out (mine)
+      .mockReturnValueOnce('Precipient') // output 0
+      .mockReturnValueOnce(myAddress); // output 1 (change)
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: myAddress, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { [myAddress]: [0] } });
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain('You will transfer');
+    expect(wrapper.text()).not.toContain('You will receive');
   });
 
   it('sends rejection on cancel', async () => {

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 import { useWalletStore } from '@/stores/wallet';
+import { useInscriptionStore } from '@/stores/inscriptions';
 import { deriveSigner, parseDerivationPath } from '@/utils/crypto';
 import { broadcastTx } from '@/utils/api';
 import { formatPep } from '@/utils/price';
@@ -8,6 +9,8 @@ import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
 import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
+import PepInscription from '@/components/ui/PepInscription.vue';
+import type { Inscription } from '@/models/Inscription';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
 import { ALLOWED_SIGHASHES, SIGHASH, getInputSighash, sighashLabel } from '@/utils/psbt';
@@ -22,21 +25,89 @@ interface PsbtIO {
   address: string | null;
   amountRibbits: number | null;
   mine: boolean;
+  inscription?: Inscription | null;
+  sighashType?: number | null;
 }
 
+type HeroSide =
+  | { kind: 'pep'; amountRibbits: number }
+  | { kind: 'inscription'; inscription: Inscription | null }
+  | null;
+
 const walletStore = useWalletStore();
+const inscriptionStore = useInscriptionStore();
+
+// Best-effort sync so the inscription cache catches up while the user reads.
+// Non-blocking: render works against whatever is in the store right now and
+// re-renders reactively when the sync resolves.
+onMounted(() => {
+  void walletStore.refreshBalance();
+});
+
+function findInscriptionByOutput(txid: string, vout: number): Inscription | null {
+  if (!inscriptionStore.outputs.includes(`${txid}:${vout}`)) return null;
+  const prefix = `${txid}:${vout}:`;
+  for (const insc of Object.values(inscriptionStore.inscriptions)) {
+    if (insc.satpoint.startsWith(prefix)) return insc as Inscription;
+  }
+  return null;
+}
 
 const { origin, requestData, error, isProcessing, runWithMnemonic, approve, reject } =
   useApprovalRequest<SignPsbtParams>();
 
 const psbtDetails = computed(() => {
   if (!requestData.value) return null;
+  // Touch the inscription store so changes from background sync re-trigger
+  // this computed. We read it inside decodePsbtSummary too, but reading at the
+  // top level keeps the dependency explicit.
+  void inscriptionStore.outputs;
+  void inscriptionStore.inscriptions;
   return {
     psbt: requestData.value.params.psbt,
     broadcast: requestData.value.params.broadcast === true,
     ...decodePsbtSummary(requestData.value.params.psbt, walletStore.address)
   };
 });
+
+const hero = computed(() => {
+  if (!psbtDetails.value || psbtDetails.value.decodeError) return null;
+  return buildHero(psbtDetails.value.inputs, psbtDetails.value.outputs);
+});
+
+function buildHero(inputs: PsbtIO[], outputs: PsbtIO[]): { transfer: HeroSide; receive: HeroSide } {
+  const mineIn = inputs.filter((i) => i.mine);
+  const mineOut = outputs.filter((o) => o.mine);
+  const mineInscriptionInput = mineIn.find((i) => i.inscription);
+
+  let transfer: HeroSide = null;
+  if (mineInscriptionInput) {
+    transfer = { kind: 'inscription', inscription: mineInscriptionInput.inscription! };
+  } else if (mineIn.length) {
+    const sumIn = mineIn.reduce((s, i) => s + (i.amountRibbits ?? 0), 0);
+    const sumOut = mineOut.reduce((s, o) => s + (o.amountRibbits ?? 0), 0);
+    const net = sumIn - sumOut;
+    if (net > 0) transfer = { kind: 'pep', amountRibbits: net };
+  }
+
+  let receive: HeroSide = null;
+  if (mineOut.length) {
+    const sumIn = mineIn.reduce((s, i) => s + (i.amountRibbits ?? 0), 0);
+    const sumOut = mineOut.reduce((s, o) => s + (o.amountRibbits ?? 0), 0);
+    const net = sumOut - sumIn;
+    if (net > 0) receive = { kind: 'pep', amountRibbits: net };
+    // Buy-listing heuristic: a foreign 0x83 input means a counterparty is
+    // delegating SIGHASH_SINGLE | ANYONECANPAY — the matching output landing
+    // on me is almost certainly the inscription. We can't yet name it without
+    // a per-output lookup, so render an "Inscription" placeholder.
+    if (!receive) {
+      const foreignAnyoneCanPay = inputs.some((i) => !i.mine && i.sighashType === 0x83);
+      if (foreignAnyoneCanPay) receive = { kind: 'inscription', inscription: null };
+    }
+  }
+
+  return { transfer, receive };
+}
 
 function decodePsbtSummary(
   base64: string,
@@ -49,6 +120,7 @@ function decodePsbtSummary(
       const data = psbt.data.inputs[i];
       let address: string | null = null;
       let value: number | null = null;
+      let inscription: Inscription | null = null;
       if (data?.nonWitnessUtxo) {
         const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
         const out = prevTx.outs[txIn.index];
@@ -61,10 +133,14 @@ function decodePsbtSummary(
           }
         }
       }
+      const prevTxid = Buffer.from(txIn.hash).reverse().toString('hex');
+      inscription = findInscriptionByOutput(prevTxid, txIn.index);
       return {
         address,
         amountRibbits: value,
-        mine: !!myAddress && address === myAddress
+        mine: !!myAddress && address === myAddress,
+        inscription,
+        sighashType: data?.sighashType ?? null
       };
     });
 
@@ -172,15 +248,53 @@ function handleReject() {
           </p>
         </div>
 
-        <div
-          v-if="psbtDetails.netChangeRibbits !== null"
-          class="rounded-xl border border-slate-800 bg-slate-900 p-4"
-        >
+        <div v-if="hero?.transfer" class="rounded-xl border border-slate-800 bg-slate-900 p-4">
           <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">
-            {{ psbtDetails.netChangeRibbits < 0 ? 'You will send' : 'You will receive' }}
+            You will transfer
           </span>
-          <p class="text-pepe-green mt-1 text-lg font-bold">
-            {{ formatPep(Math.abs(psbtDetails.netChangeRibbits)) }}
+          <div v-if="hero.transfer.kind === 'inscription'" class="mt-2 flex items-center gap-3">
+            <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-slate-700">
+              <PepInscription
+                v-if="hero.transfer.inscription"
+                :id="hero.transfer.inscription.id"
+                :content-type="hero.transfer.inscription.contentType"
+              />
+            </div>
+            <span class="text-offwhite text-base font-bold">
+              {{
+                hero.transfer.inscription
+                  ? `Inscription ${hero.transfer.inscription.number}`
+                  : 'Inscription'
+              }}
+            </span>
+          </div>
+          <p v-else class="text-pepe-green mt-1 text-lg font-bold">
+            {{ formatPep(hero.transfer.amountRibbits) }}
+          </p>
+        </div>
+
+        <div v-if="hero?.receive" class="rounded-xl border border-slate-800 bg-slate-900 p-4">
+          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">
+            You will receive
+          </span>
+          <div v-if="hero.receive.kind === 'inscription'" class="mt-2 flex items-center gap-3">
+            <div class="h-14 w-14 shrink-0 overflow-hidden rounded-xl border border-slate-700">
+              <PepInscription
+                v-if="hero.receive.inscription"
+                :id="hero.receive.inscription.id"
+                :content-type="hero.receive.inscription.contentType"
+              />
+            </div>
+            <span class="text-offwhite text-base font-bold">
+              {{
+                hero.receive.inscription
+                  ? `Inscription ${hero.receive.inscription.number}`
+                  : 'Inscription'
+              }}
+            </span>
+          </div>
+          <p v-else class="text-pepe-green mt-1 text-lg font-bold">
+            {{ formatPep(hero.receive.amountRibbits) }}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace the single \"You will send/receive\" net-change card in \`SignPsbtApproval.vue\` with a paired \"You will transfer\" / \"You will receive\" hero.
- Detect inscriptions on PSBT inputs by matching \`prevTxid:prevVout\` against the local \`inscriptionStore\` cache; surface inscription thumbnail + number when known.
- Add a buy-listing heuristic: a foreign \`SIGHASH_SINGLE | ANYONECANPAY\` input combined with a mine output renders an unnamed \"Inscription\" receive label until #58 wires up per-output lookup.
- Trigger a non-blocking \`walletStore.refreshBalance()\` on mount so the inscription cache catches up while the user reads.

## Why
The single net-change card misrepresents listing PSBTs (where a 1-input 1-output 0x83 listing has 0 net change in raw aggregate without the postage trick) and hides what's actually moving. The paired layout matches user mental model: \"what leaves my wallet / what arrives\".

This is the foundation; #59 will layer scenario-specific heroes (Listing / Buy / Send PEP / Send inscription / Self-send / Bundle) on top, with this two-card hero kept as the \`unknown\` fallback.

## Test plan
- [ ] Sign a listing PSBT — hero shows inscription thumb + number on transfer side, PEP price on receive side.
- [ ] Send PEP via dApp — hero shows only the transfer card (no \"receive\" for change-to-self).
- [ ] Paste a raw PSBT in dev/connect.html without inscription cache — hero degrades to PEP-only display, no crash.
- [ ] Stale cache: import wallet, immediately sign a listing — sync kicks in on mount, hero updates reactively.