### PR TITLE
Guard signPsbt against PSBTs not involving the active account

### DIFF
--- a/src/background.spec.ts
+++ b/src/background.spec.ts
@@ -1,4 +1,48 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as bitcoin from 'bitcoinjs-lib';
+import { PEPECOIN } from '@/utils/networks';
+
+function payment(hashByte: number) {
+  const hash = new Uint8Array(20).fill(hashByte);
+  return bitcoin.payments.p2pkh({ hash, network: PEPECOIN as any });
+}
+
+const PAY_A = payment(0x11);
+const PAY_B = payment(0x22);
+const REAL_ADDR_A = PAY_A.address!;
+const REAL_ADDR_B = PAY_B.address!;
+
+function buildPsbt(prevPayment: { output?: Uint8Array }, outAddress: string): string {
+  const prevTx = new bitcoin.Transaction();
+  prevTx.version = 1;
+  prevTx.addInput(new Uint8Array(32), 0);
+  prevTx.addOutput(prevPayment.output!, 100_000n as any);
+
+  const psbt = new bitcoin.Psbt({ network: PEPECOIN as any });
+  psbt.setVersion(1);
+  psbt.addInput({
+    hash: prevTx.getId(),
+    index: 0,
+    nonWitnessUtxo: Uint8Array.from(prevTx.toBuffer()) as any
+  });
+  psbt.addOutput({ address: outAddress, value: 90_000n as any });
+  return psbt.toBase64();
+}
+
+function buildPsbtWithoutNonWitnessUtxo(
+  payTo: { output?: Uint8Array },
+  outAddress: string
+): string {
+  const psbt = new bitcoin.Psbt({ network: PEPECOIN as any });
+  psbt.setVersion(1);
+  psbt.addInput({
+    hash: '00'.repeat(32),
+    index: 0,
+    witnessUtxo: { script: payTo.output!, value: 100_000n as any }
+  });
+  psbt.addOutput({ address: outAddress, value: 90_000n as any });
+  return psbt.toBase64();
+}
 
 // Capture the onMessage listener when background.ts loads
 let messageListener: (...args: any[]) => any;
@@ -319,10 +363,10 @@ describe('background sendTransfer param validation', () => {
 describe('background signPsbt param validation', () => {
   const storageData: Record<string, any> = {
     peppool_permissions: {
-      'https://dapp.com': { accounts: ['Ptest123'], permissions: ['connect'] }
+      'https://dapp.com': { accounts: [REAL_ADDR_A], permissions: ['connect'] }
     },
     peppool_accounts: JSON.stringify([
-      { address: 'Ptest123', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }
+      { address: REAL_ADDR_A, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }
     ]),
     peppool_active_account: '0'
   };
@@ -370,9 +414,45 @@ describe('background signPsbt param validation', () => {
 
   it('opens approval popup for valid signPsbt request', async () => {
     sendDappMessage('signPsbt', 'https://dapp.com', {
-      psbt: 'base64',
-      signInputs: { PJGSjPmY3PzGyE54M3VGiRaEQFBhxuokV1: [0] }
+      psbt: buildPsbt(PAY_A, REAL_ADDR_A),
+      signInputs: { [REAL_ADDR_A]: [0] }
     });
     await vi.waitFor(() => expect(windowsCreateMock).toHaveBeenCalled());
+  });
+
+  it('rejects signPsbt whose prevout pays a foreign address', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: buildPsbt(PAY_B, REAL_ADDR_A),
+      signInputs: { [REAL_ADDR_A]: [0] }
+    });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: 'Input 0 does not belong to the active account.'
+    });
+    expect(windowsCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects signPsbt whose input is missing nonWitnessUtxo', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: buildPsbtWithoutNonWitnessUtxo(PAY_A, REAL_ADDR_A),
+      signInputs: { [REAL_ADDR_A]: [0] }
+    });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: 'Input 0 is missing nonWitnessUtxo; cannot verify ownership.'
+    });
+    expect(windowsCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects signPsbt with an out-of-range index after passing shape validation', async () => {
+    const sendResponse = sendDappMessage('signPsbt', 'https://dapp.com', {
+      psbt: buildPsbt(PAY_A, REAL_ADDR_A),
+      signInputs: { [REAL_ADDR_A]: [5] }
+    });
+    await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+    expect(sendResponse).toHaveBeenCalledWith({
+      error: 'signInputs index 5 is out of range.'
+    });
+    expect(windowsCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,7 +10,7 @@
  */
 
 import { loadPermissions, savePermissions, hasPermission, revokeOrigin } from '@/utils/permissions';
-import { validateSignPsbtParams } from '@/utils/psbt';
+import { validatePsbtParams, verifyPsbtOwnership } from '@/utils/psbt';
 import { CHROME_STORAGE_KEYS } from '@/constants/storage';
 
 const ALARM_NAME_AUTOLOCK = 'peppool-inactivity-lock';
@@ -172,9 +172,21 @@ async function handleDappRequest(
       }
 
       if (method === 'signPsbt') {
-        const validationError = validateSignPsbtParams(request.params);
+        const validationError = validatePsbtParams(request.params);
         if (validationError) {
           sendResponse({ error: validationError });
+          requestQueue.delete(requestId);
+          return;
+        }
+        const activeAddress = await getActiveAddress();
+        if (!activeAddress) {
+          sendResponse({ error: 'No active account.' });
+          requestQueue.delete(requestId);
+          return;
+        }
+        const ownershipError = verifyPsbtOwnership(request.params, activeAddress);
+        if (ownershipError) {
+          sendResponse({ error: ownershipError });
           requestQueue.delete(requestId);
           return;
         }

--- a/src/utils/psbt.spec.ts
+++ b/src/utils/psbt.spec.ts
@@ -4,7 +4,7 @@ import {
   SIGHASH,
   getInputSighash,
   sighashLabel,
-  validateSignPsbtParams
+  validatePsbtParams
 } from './psbt';
 
 const VALID_ADDR = 'PJGSjPmY3PzGyE54M3VGiRaEQFBhxuokV1';
@@ -47,16 +47,14 @@ describe('getInputSighash', () => {
   });
 });
 
-describe('validateSignPsbtParams', () => {
+describe('validatePsbtParams', () => {
   it('accepts a minimal valid request', () => {
-    expect(
-      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0] } })
-    ).toBeNull();
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0] } })).toBeNull();
   });
 
   it('accepts multiple addresses with multiple indices', () => {
     expect(
-      validateSignPsbtParams({
+      validatePsbtParams({
         psbt: 'base64',
         signInputs: { [VALID_ADDR]: [0], [VALID_ADDR_2]: [1, 2] },
         broadcast: true
@@ -65,47 +63,47 @@ describe('validateSignPsbtParams', () => {
   });
 
   it('rejects missing psbt', () => {
-    expect(validateSignPsbtParams({ signInputs: { [VALID_ADDR]: [0] } })).toContain('psbt');
+    expect(validatePsbtParams({ signInputs: { [VALID_ADDR]: [0] } })).toContain('psbt');
   });
 
   it('rejects missing signInputs', () => {
-    expect(validateSignPsbtParams({ psbt: 'base64' })).toContain('signInputs is required');
+    expect(validatePsbtParams({ psbt: 'base64' })).toContain('signInputs is required');
   });
 
   it('rejects empty signInputs', () => {
-    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: {} })).toContain('at least one');
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: {} })).toContain('at least one');
   });
 
   it('rejects invalid address keys', () => {
-    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: { bc1qxyz: [0] } })).toContain(
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { bc1qxyz: [0] } })).toContain(
       'Invalid address'
     );
   });
 
   it('rejects empty index arrays', () => {
-    expect(validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [] } })).toContain(
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [] } })).toContain(
       'non-empty array'
     );
   });
 
   it('rejects negative or non-integer indices', () => {
-    expect(
-      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [-1] } })
-    ).toContain('invalid index');
-    expect(
-      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [1.5] } })
-    ).toContain('invalid index');
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [-1] } })).toContain(
+      'invalid index'
+    );
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [1.5] } })).toContain(
+      'invalid index'
+    );
   });
 
   it('rejects duplicate indices for the same address', () => {
-    expect(
-      validateSignPsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0, 0] } })
-    ).toContain('duplicate');
+    expect(validatePsbtParams({ psbt: 'base64', signInputs: { [VALID_ADDR]: [0, 0] } })).toContain(
+      'duplicate'
+    );
   });
 
   it('rejects non-boolean broadcast', () => {
     expect(
-      validateSignPsbtParams({
+      validatePsbtParams({
         psbt: 'base64',
         signInputs: { [VALID_ADDR]: [0] },
         broadcast: 'yes'

--- a/src/utils/psbt.ts
+++ b/src/utils/psbt.ts
@@ -1,4 +1,5 @@
 import * as bitcoin from 'bitcoinjs-lib';
+import { PEPECOIN } from '@/utils/networks';
 
 export const SIGHASH = {
   ALL: 0x01,
@@ -48,7 +49,7 @@ const PEP_ADDRESS_RE = /^P[1-9A-HJ-NP-Za-km-z]{25,33}$/;
  * popup. Deeper checks (PSBT decoding, index range, sighash allowlist) happen
  * in the approval view which already parses the PSBT.
  */
-export function validateSignPsbtParams(params: any): string | null {
+export function validatePsbtParams(params: any): string | null {
   if (!params || typeof params !== 'object') return 'Missing PSBT parameters.';
 
   if (typeof params.psbt !== 'string' || params.psbt.length === 0) {
@@ -83,6 +84,48 @@ export function validateSignPsbtParams(params: any): string | null {
 
   if (params.broadcast != null && typeof params.broadcast !== 'boolean') {
     return 'broadcast must be a boolean.';
+  }
+
+  return null;
+}
+
+export function verifyPsbtOwnership(
+  params: { psbt: string; signInputs: Record<string, number[]> },
+  activeAddress: string
+): string | null {
+  const indices = params.signInputs[activeAddress];
+  if (!indices || indices.length === 0) {
+    return 'This PSBT is not for the active account.';
+  }
+
+  let psbt: bitcoin.Psbt;
+  try {
+    psbt = bitcoin.Psbt.fromBase64(params.psbt, { network: PEPECOIN });
+  } catch {
+    return 'Unable to decode PSBT.';
+  }
+
+  for (const i of indices) {
+    if (i < 0 || i >= psbt.inputCount) {
+      return `signInputs index ${i} is out of range.`;
+    }
+    const data = psbt.data.inputs[i];
+    if (!data?.nonWitnessUtxo) {
+      return `Input ${i} is missing nonWitnessUtxo; cannot verify ownership.`;
+    }
+    const txIn = psbt.txInputs[i]!;
+    let prevAddress: string | null = null;
+    try {
+      const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
+      const out = prevTx.outs[txIn.index];
+      if (!out) return `Input ${i} prevout vout is out of range.`;
+      prevAddress = bitcoin.address.fromOutputScript(out.script, PEPECOIN);
+    } catch {
+      return `Input ${i} prevout could not be decoded.`;
+    }
+    if (prevAddress !== activeAddress) {
+      return `Input ${i} does not belong to the active account.`;
+    }
   }
 
   return null;

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -72,7 +72,7 @@ function makeRequest(params: Record<string, unknown>) {
 }
 
 describe('SignPsbtApproval', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     setActivePinia(createPinia());
     localStorage.clear();
     vi.clearAllMocks();
@@ -82,7 +82,21 @@ describe('SignPsbtApproval', () => {
     vi.spyOn(store, 'checkSession').mockResolvedValue(true);
 
     mockPsbt.inputCount = 2;
-    mockPsbt.data.inputs = [{}, {}] as any;
+    mockPsbt.data.inputs = [
+      { nonWitnessUtxo: Buffer.from('aa', 'hex') },
+      { nonWitnessUtxo: Buffer.from('aa', 'hex') }
+    ] as any;
+    mockPsbt.txInputs = [
+      { hash: Buffer.alloc(32), index: 0 },
+      { hash: Buffer.alloc(32), index: 0 }
+    ] as any;
+
+    // Default: every prevout decodes to the active account 'Psender'.
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('mine', 'utf8'), value: 100_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any).mockReturnValue('Psender');
 
     makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
   });
@@ -201,7 +215,8 @@ describe('SignPsbtApproval', () => {
 
   it('honors SIGHASH_SINGLE | ANYONECANPAY from PSBT input data', async () => {
     mockPsbt.inputCount = 1;
-    mockPsbt.data.inputs = [{ sighashType: 0x83 }] as any;
+    mockPsbt.data.inputs = [{ sighashType: 0x83, nonWitnessUtxo: Buffer.from('aa', 'hex') }] as any;
+    mockPsbt.txInputs = [{ hash: Buffer.alloc(32), index: 0 }] as any;
     makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
     mockSignInput.mockImplementation(() => {});
 
@@ -226,7 +241,8 @@ describe('SignPsbtApproval', () => {
 
   it('rejects unsupported sighash types', async () => {
     mockPsbt.inputCount = 1;
-    mockPsbt.data.inputs = [{ sighashType: 0x02 }] as any;
+    mockPsbt.data.inputs = [{ sighashType: 0x02, nonWitnessUtxo: Buffer.from('aa', 'hex') }] as any;
+    mockPsbt.txInputs = [{ hash: Buffer.alloc(32), index: 0 }] as any;
     makeRequest({ psbt: 'base64-psbt-data', signInputs: { Psender: [0] } });
 
     const store = useWalletStore();
@@ -250,7 +266,8 @@ describe('SignPsbtApproval', () => {
 
   it('rejects broadcast when any signed input has non-default sighash', async () => {
     mockPsbt.inputCount = 1;
-    mockPsbt.data.inputs = [{ sighashType: 0x83 }] as any;
+    mockPsbt.data.inputs = [{ sighashType: 0x83, nonWitnessUtxo: Buffer.from('aa', 'hex') }] as any;
+    mockPsbt.txInputs = [{ hash: Buffer.alloc(32), index: 0 }] as any;
     makeRequest({
       psbt: 'base64-psbt-data',
       signInputs: { Psender: [0] },
@@ -376,6 +393,29 @@ describe('SignPsbtApproval', () => {
 
     expect(wrapper.text()).toContain('You will transfer');
     expect(wrapper.text()).not.toContain('You will receive');
+  });
+
+  it('rejects when prevout decodes to a non-mine address', async () => {
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.address.fromOutputScript as any).mockReturnValue('Pforeign');
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: 'Psender', path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'isMnemonicLoaded', 'get').mockReturnValue(true);
+    vi.spyOn(store, 'withMnemonic').mockImplementation((fn: any) =>
+      fn('suffer dish east miss seat great brother hello motion mountain celery plunge')
+    );
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    await wrapper.find('#approve-transaction-button').trigger('click');
+    await flushPromises();
+
+    expect(mockSignInput).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain('does not belong to the active account');
   });
 
   it('sends rejection on cancel', async () => {

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -13,7 +13,13 @@ import PepInscription from '@/components/ui/PepInscription.vue';
 import type { Inscription } from '@/models/Inscription';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
-import { ALLOWED_SIGHASHES, SIGHASH, getInputSighash, sighashLabel } from '@/utils/psbt';
+import {
+  ALLOWED_SIGHASHES,
+  SIGHASH,
+  getInputSighash,
+  sighashLabel,
+  verifyPsbtOwnership
+} from '@/utils/psbt';
 
 interface SignPsbtParams {
   psbt: string;
@@ -180,15 +186,10 @@ async function handleApprove() {
     const myAddress = walletStore.address;
     if (!myAddress) throw new Error('No active account.');
 
+    const ownershipError = verifyPsbtOwnership({ psbt: base64Psbt, signInputs }, myAddress);
+    if (ownershipError) throw new Error(ownershipError);
+
     const indices = signInputs[myAddress] ?? [];
-    if (indices.length === 0) {
-      throw new Error('This PSBT is not for the active account.');
-    }
-    for (const i of indices) {
-      if (i < 0 || i >= psbt.inputCount) {
-        throw new Error(`signInputs index ${i} is out of range.`);
-      }
-    }
 
     const sighashes = indices.map((i) => getInputSighash(psbt, i));
     for (const flag of sighashes) {


### PR DESCRIPTION
Fixes #61.

`signPsbt` previously trusted the dApp-supplied `signInputs` map to identify which inputs the active account owns. A malicious or buggy dApp could list any active-account address against any input index and trick the wallet into surfacing an approval popup for a PSBT the user has no stake in.

Two layers, one commit each:

1. **Background pre-popup guard** — new `verifyPsbtOwnership` helper decodes the PSBT and confirms every claimed index's `nonWitnessUtxo` prevout pays the active account. Bad PSBTs are rejected before `openApprovalPopup` is ever called. Inputs missing `nonWitnessUtxo` are rejected (Pepecoin is non-segwit, so legitimate inputs always carry it). Also renames `validateSignPsbtParams` → `validatePsbtParams`.
2. **`SignPsbtApproval.vue` defense-in-depth** — same check runs at sign time, so the guard still holds if background routing is refactored or the popup is reached via another path.

## Test plan
- [x] `npx vitest run` — 623 passed
- [x] `npx vue-tsc -b` — clean
- [x] Manual: dev/connect.html with a foreign-owned PSBT → wallet returns `Input 0 does not belong to the active account.`, no popup opens