### PR TITLE
Add ESLint with flat config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,7 @@ export default tseslint.config(
     rules: {
       'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
       'vue/no-mutating-props': ['error', { shallowOnly: true }],
+      'vue/require-default-prop': 'off',
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,11 @@ export default tseslint.config(
   {
     files: ['**/*.spec.ts', '**/*.test.ts'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'off'
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/ban-ts-comment': [
+        'error',
+        { 'ts-expect-error': false, 'ts-ignore': true, 'ts-nocheck': true, 'ts-check': false }
+      ]
     }
   },
   prettier

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,5 @@
 import js from '@eslint/js';
+import globals from 'globals';
 import tseslint from 'typescript-eslint';
 import vue from 'eslint-plugin-vue';
 import vueParser from 'vue-eslint-parser';
@@ -25,6 +26,12 @@ export default tseslint.config(
   },
   {
     files: ['**/*.{ts,vue}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.webextensions
+      }
+    },
     rules: {
       'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
       '@typescript-eslint/no-unused-vars': [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,45 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import vue from 'eslint-plugin-vue';
+import vueParser from 'vue-eslint-parser';
+import prettier from 'eslint-config-prettier';
+
+export default tseslint.config(
+  {
+    ignores: ['dist/**', 'node_modules/**', 'coverage/**', '*.config.js', '*.config.ts']
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  ...vue.configs['flat/recommended'],
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parser: vueParser,
+      parserOptions: {
+        parser: tseslint.parser,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        extraFileExtensions: ['.vue']
+      }
+    }
+  },
+  {
+    files: ['**/*.{ts,vue}'],
+    rules: {
+      'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }
+      ],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'vue/multi-word-component-names': 'off'
+    }
+  },
+  {
+    files: ['**/*.spec.ts', '**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off'
+    }
+  },
+  prettier
+);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,11 +29,13 @@ export default tseslint.config(
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.webextensions
+        ...globals.webextensions,
+        Buffer: 'readonly'
       }
     },
     rules: {
       'lines-between-class-members': ['error', 'always', { exceptAfterSingleLine: true }],
+      'vue/no-mutating-props': ['error', { shallowOnly: true }],
       '@typescript-eslint/no-unused-vars': [
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.4.0",
+        "@eslint/js": "^10.0.1",
         "@pinia/testing": "^1.0.3",
         "@playwright/test": "^1.60.0",
         "@tailwindcss/vite": "^4.3.0",
@@ -34,16 +35,21 @@
         "@vitest/coverage-v8": "^4.1.6",
         "@vue/test-utils": "^2.4.10",
         "@vue/tsconfig": "^0.9.1",
+        "eslint": "^10.3.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-vue": "^10.9.1",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.0",
         "typescript": "6.0.3",
+        "typescript-eslint": "^8.59.3",
         "vite": "^7.3.3",
         "vite-plugin-node-polyfills": "^0.26.0",
         "vite-plugin-top-level-await": "^1.6.0",
         "vite-plugin-wasm": "^3.6.0",
         "vitest": "^4.1.6",
+        "vue-eslint-parser": "^10.4.0",
         "vue-tsc": "^3.2.8"
       }
     },
@@ -793,6 +799,173 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -809,6 +982,72 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -1991,6 +2230,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2022,6 +2268,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "25.7.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
@@ -2030,6 +2283,275 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/type-utils": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.3",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.3",
+        "@typescript-eslint/types": "^8.59.3",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.3",
+        "@typescript-eslint/tsconfig-utils": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/visitor-keys": "8.59.3",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.3",
+        "@typescript-eslint/types": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.3",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -2467,9 +2989,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2477,6 +2999,16 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -2490,6 +3022,23 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/alien-signals": {
@@ -3359,6 +3908,19 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -3401,6 +3963,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3751,11 +4320,286 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-vue": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.1.tgz",
+      "integrity": "sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "natural-compare": "^1.4.0",
+        "nth-check": "^2.1.1",
+        "postcss-selector-parser": "^7.1.0",
+        "semver": "^7.6.3",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "peerDependencies": {
+        "@stylistic/eslint-plugin": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
+        "@typescript-eslint/parser": "^7.0.0 || ^8.0.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "vue-eslint-parser": "^10.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@stylistic/eslint-plugin": {
+          "optional": true
+        },
+        "@typescript-eslint/parser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-vue/node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -3787,6 +4631,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -3803,6 +4654,20 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -3841,6 +4706,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -3876,6 +4754,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -4223,6 +5122,26 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -4596,6 +5515,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -4607,6 +5547,30 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lightningcss": {
@@ -5112,6 +6076,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/node-html-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
@@ -5262,6 +6233,24 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
@@ -5583,6 +6572,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
@@ -6680,6 +7693,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -6693,6 +7719,19 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
@@ -6720,6 +7759,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.59.3",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.59.3",
+        "@typescript-eslint/parser": "8.59.3",
+        "@typescript-eslint/typescript-estree": "8.59.3",
+        "@typescript-eslint/utils": "8.59.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uint8array-tools": {
@@ -6756,6 +7819,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/url": {
@@ -7086,6 +8169,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vue-eslint-parser": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-10.4.0.tgz",
+      "integrity": "sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "eslint-scope": "^8.2.0 || ^9.0.0",
+        "eslint-visitor-keys": "^4.2.0 || ^5.0.0",
+        "espree": "^10.3.0 || ^11.0.0",
+        "esquery": "^1.6.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.6.4",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
@@ -7233,6 +8340,16 @@
       "license": "MIT",
       "dependencies": {
         "bs58check": "^4.0.0"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-vue": "^10.9.1",
+        "globals": "^17.6.0",
         "jsdom": "^29.1.1",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.8.0",
@@ -4943,6 +4944,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:compact": "vitest run --reporter=dot --silent",
     "test:coverage": "vitest run --coverage",
     "format": "prettier --write --log-level warn \"src/**/*.{ts,vue,css}\" \"*.{html,json}\"",
+    "lint": "eslint \"src/**/*.{ts,vue}\"",
+    "lint:fix": "eslint --fix \"src/**/*.{ts,vue}\"",
     "zip": "npm run build && zip -r peppool-wallet-v$npm_package_version.zip dist",
     "screenshots": "npx playwright install chromium && npx tsx scripts/capture-screenshots.ts",
     "screenshots:frame": "npx playwright install chromium && npx tsx scripts/capture-screenshots.ts --frame"
@@ -33,6 +35,7 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.4.0",
+    "@eslint/js": "^10.0.1",
     "@pinia/testing": "^1.0.3",
     "@playwright/test": "^1.60.0",
     "@tailwindcss/vite": "^4.3.0",
@@ -42,16 +45,21 @@
     "@vitest/coverage-v8": "^4.1.6",
     "@vue/test-utils": "^2.4.10",
     "@vue/tsconfig": "^0.9.1",
+    "eslint": "^10.3.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-vue": "^10.9.1",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.0",
     "typescript": "6.0.3",
+    "typescript-eslint": "^8.59.3",
     "vite": "^7.3.3",
     "vite-plugin-node-polyfills": "^0.26.0",
     "vite-plugin-top-level-await": "^1.6.0",
     "vite-plugin-wasm": "^3.6.0",
     "vitest": "^4.1.6",
+    "vue-eslint-parser": "^10.4.0",
     "vue-tsc": "^3.2.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-vue": "^10.9.1",
+    "globals": "^17.6.0",
     "jsdom": "^29.1.1",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.8.0",

--- a/src/background.spec.ts
+++ b/src/background.spec.ts
@@ -10,7 +10,6 @@ function payment(hashByte: number) {
 const PAY_A = payment(0x11);
 const PAY_B = payment(0x22);
 const REAL_ADDR_A = PAY_A.address!;
-const REAL_ADDR_B = PAY_B.address!;
 
 function buildPsbt(prevPayment: { output?: Uint8Array }, outAddress: string): string {
   const prevTx = new bitcoin.Transaction();

--- a/src/components/ui/PepCopyableId.vue
+++ b/src/components/ui/PepCopyableId.vue
@@ -13,9 +13,9 @@ const truncated = computed(() => truncateId(props.id));
 <template>
   <PepInputGroup
     v-if="label"
-    :label="label"
     :id="id"
-    labelClass="text-[10px] text-slate-500 font-bold uppercase tracking-widest ml-1 text-left"
+    :label="label"
+    label-class="text-[10px] text-slate-500 font-bold uppercase tracking-widest ml-1 text-left"
   >
     <div class="flex items-center gap-2">
       <div

--- a/src/components/ui/PepGlobalHeader.vue
+++ b/src/components/ui/PepGlobalHeader.vue
@@ -25,7 +25,7 @@ const { isVisible } = useGlobalHeader();
 
     <div class="relative z-10 border-b border-slate-800 px-4 py-1">
       <div class="flex items-center justify-between">
-        <div @click="router.push('/dashboard')" class="group flex cursor-pointer items-center">
+        <div class="group flex cursor-pointer items-center" @click="router.push('/dashboard')">
           <img
             :src="logoUrl"
             class="mr-2 h-8 w-8 transition-transform group-hover:scale-105"
@@ -37,10 +37,10 @@ const { isVisible } = useGlobalHeader();
         <button
           id="app-settings-button"
           type="button"
-          @click="router.push('/settings')"
           class="cursor-pointer p-1 text-slate-400 transition-colors hover:text-white"
           aria-label="Settings"
           tabindex="-1"
+          @click="router.push('/settings')"
         >
           <PepIcon name="settings" />
         </button>

--- a/src/components/ui/PepPageHeader.vue
+++ b/src/components/ui/PepPageHeader.vue
@@ -23,10 +23,10 @@ function handleBack() {
     <button
       id="header-back-button"
       type="button"
-      @click="handleBack"
       class="mr-4 cursor-pointer text-slate-400 hover:text-white"
       aria-label="Go back"
       tabindex="-1"
+      @click="handleBack"
     >
       <PepIcon name="back" />
     </button>

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -146,12 +146,12 @@ function toggleMode() {
 
     <PepInput
       :id="id"
-      :modelValue="inputValue"
+      :model-value="inputValue"
       placeholder="0.00"
       inputmode="decimal"
       :disabled="disabled"
-      inputClass="font-bold"
-      @update:modelValue="handleInput"
+      input-class="font-bold"
+      @update:model-value="handleInput"
       @beforeinput="handleBeforeInput"
       @blur="handleBlur"
     >
@@ -165,12 +165,12 @@ function toggleMode() {
         <button
           :id="`${id}-currency-toggle`"
           type="button"
-          @click="toggleMode"
           :disabled="disabled"
           class="hover:text-pep-green-light mr-1 shrink-0 cursor-pointer rounded p-1 text-slate-500 transition-colors disabled:cursor-not-allowed"
           aria-label="Switch currency"
           title="Switch currency"
           tabindex="-1"
+          @click="toggleMode"
         >
           <PepIcon name="swap" size="16" />
         </button>

--- a/src/components/ui/form/PepAmountInput.vue
+++ b/src/components/ui/form/PepAmountInput.vue
@@ -10,7 +10,7 @@ import PepIcon from '@/components/ui/PepIcon.vue';
 interface Props {
   ribbits: number;
   price: number; // Price of 1 PEP in current fiat
-  isFiatMode: boolean;
+  isFiatMode?: boolean;
   disabled?: boolean;
   label?: string;
   id?: string;

--- a/src/components/ui/form/PepCheckbox.vue
+++ b/src/components/ui/form/PepCheckbox.vue
@@ -28,8 +28,8 @@ const isDisabled = computed(() => props.disabled || formDisabled.value);
           type="checkbox"
           :checked="modelValue"
           :disabled="isDisabled"
-          @change="$emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
           class="checked:border-pep-green checked:bg-pep-green focus-visible:outline-pep-green hover:border-pep-green-light col-start-1 row-start-1 cursor-pointer appearance-none rounded-md border border-white/40 bg-white/5 transition-all focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
+          @change="$emit('update:modelValue', ($event.target as HTMLInputElement).checked)"
         />
         <div
           class="pointer-events-none col-start-1 row-start-1 flex size-4 items-center justify-center self-center justify-self-center"

--- a/src/components/ui/form/PepForm.spec.ts
+++ b/src/components/ui/form/PepForm.spec.ts
@@ -5,11 +5,11 @@ import PepForm from './PepForm.vue';
 
 // A test child component that injects the form state
 const ChildComponent = defineComponent({
-  template: '<div>{{ isFormDisabled }}</div>',
   setup() {
     const isFormDisabled = inject('isFormDisabled');
     return { isFormDisabled };
-  }
+  },
+  template: '<div>{{ isFormDisabled }}</div>'
 });
 
 describe('PepForm UI Component', () => {

--- a/src/components/ui/form/PepForm.vue
+++ b/src/components/ui/form/PepForm.vue
@@ -27,7 +27,7 @@ function handleSubmit(e: Event) {
 </script>
 
 <template>
-  <form :id="id" @submit.prevent="handleSubmit" class="flex flex-1 flex-col gap-6">
+  <form :id="id" class="flex flex-1 flex-col gap-6" @submit.prevent="handleSubmit">
     <div class="flex-1 space-y-6">
       <slot />
     </div>

--- a/src/components/ui/form/PepInput.vue
+++ b/src/components/ui/form/PepInput.vue
@@ -41,7 +41,7 @@ function handleClear() {
 </script>
 
 <template>
-  <PepInputGroup :label="label" :id="id">
+  <PepInputGroup :id="id" :label="label">
     <div
       class="flex items-center rounded-md bg-white/5 outline-1 -outline-offset-1 transition-opacity duration-200 focus-within:outline-2 focus-within:-outline-offset-2"
       :class="[
@@ -61,9 +61,6 @@ function handleClear() {
         :value="modelValue"
         :autofocus="autofocus"
         :disabled="isDisabled"
-        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
-        @beforeinput="$emit('beforeinput', $event)"
-        @blur="$emit('blur', $event)"
         :placeholder="placeholder"
         class="text-offwhite block min-w-0 grow bg-transparent py-1.5 text-base placeholder:text-gray-500 focus:outline-none sm:text-sm"
         :class="[
@@ -74,6 +71,9 @@ function handleClear() {
         ]"
         :aria-invalid="!!error"
         :aria-describedby="`${id}-error`"
+        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+        @beforeinput="$emit('beforeinput', $event)"
+        @blur="$emit('blur', $event)"
       />
 
       <div
@@ -88,10 +88,10 @@ function handleClear() {
           :id="`${id}-clear`"
           type="button"
           :disabled="isDisabled"
-          @mousedown.prevent="handleClear"
           aria-label="Clear input"
           class="cursor-pointer text-slate-500 transition-colors hover:text-slate-300 disabled:cursor-not-allowed"
           tabindex="-1"
+          @mousedown.prevent="handleClear"
         >
           <PepIcon name="clear" size="16" />
         </button>

--- a/src/components/ui/form/PepPasswordFields.vue
+++ b/src/components/ui/form/PepPasswordFields.vue
@@ -51,8 +51,8 @@ const strength = computed(() => {
 <template>
   <div class="space-y-4">
     <PepInput
-      v-model="passwordValue"
       id="new-password"
+      v-model="passwordValue"
       type="password"
       :label="passwordLabel || 'New password'"
       :placeholder="`Min. ${MIN_PASSWORD_LENGTH} characters`"
@@ -62,8 +62,8 @@ const strength = computed(() => {
     />
 
     <PepInput
-      v-model="confirmPasswordValue"
       id="confirm-password"
+      v-model="confirmPasswordValue"
       type="password"
       :label="confirmLabel || 'Confirm password'"
       placeholder="Repeat password"

--- a/src/components/ui/form/PepPasswordInput.vue
+++ b/src/components/ui/form/PepPasswordInput.vue
@@ -36,7 +36,7 @@ defineExpose({
 </script>
 
 <template>
-  <PepInputGroup :label="label" :id="id">
+  <PepInputGroup :id="id" :label="label">
     <div class="grid grid-cols-1">
       <input
         :id="id"
@@ -45,7 +45,6 @@ defineExpose({
         :value="modelValue"
         :autofocus="autofocus"
         :disabled="isDisabled"
-        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
         :placeholder="isDisabled ? '' : placeholder"
         class="text-offwhite focus:outline-pep-green col-start-1 row-start-1 block w-full rounded-md bg-white/5 py-1.5 pr-10 pl-3 text-base outline-1 -outline-offset-1 outline-white/10 transition-all placeholder:text-gray-500 focus:outline-2 focus:-outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm"
         :class="[
@@ -57,6 +56,7 @@ defineExpose({
         ]"
         :aria-invalid="!!error"
         :aria-describedby="`${id}-error`"
+        @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
       />
 
       <div class="pointer-events-none col-start-1 row-start-1 flex items-center justify-end pr-3">
@@ -66,11 +66,11 @@ defineExpose({
           v-else
           :id="`${id}-toggle`"
           type="button"
-          @click="showPassword = !showPassword"
           :disabled="isDisabled"
           :aria-label="showPassword ? 'Hide password' : 'Show password'"
           class="pointer-events-auto flex cursor-pointer items-center justify-center text-gray-500 transition-colors hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
           tabindex="-1"
+          @click="showPassword = !showPassword"
         >
           <PepIcon :name="showPassword ? 'eye' : 'eye-slash'" size="16" />
         </button>

--- a/src/composables/useConnectedSites.spec.ts
+++ b/src/composables/useConnectedSites.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useConnectedSites } from './useConnectedSites';
-import { flushPromises } from '@vue/test-utils';
 
 describe('useConnectedSites Composable', () => {
   beforeEach(() => {

--- a/src/composables/useCreateWallet.spec.ts
+++ b/src/composables/useCreateWallet.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { effectScope } from 'vue';
 import { useCreateWallet } from './useCreateWallet';
 import { useApp } from '@/composables/useApp';
-import * as crypto from '@/utils/crypto';
 
 // Mock dependencies
 vi.mock('@/composables/useApp');
@@ -53,7 +52,7 @@ describe('useCreateWallet Composable', () => {
   });
 
   it('should call importWallet when creating wallet', async () => {
-    const { mnemonic, confirmedSeed, prepareMnemonic, createWallet } = useCreateWallet();
+    const { confirmedSeed, prepareMnemonic, createWallet } = useCreateWallet();
     prepareMnemonic('Password123!', 'Password123!');
     confirmedSeed.value = true;
 

--- a/src/composables/useImportWallet.spec.ts
+++ b/src/composables/useImportWallet.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useImportWallet } from './useImportWallet';
 import { useApp } from '@/composables/useApp';
-import { flushPromises, mount } from '@vue/test-utils';
+import { flushPromises } from '@vue/test-utils';
 import { defineComponent, createApp } from 'vue';
 
 // Mock dependencies

--- a/src/composables/useSendTransaction.spec.ts
+++ b/src/composables/useSendTransaction.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useSendTransaction } from './useSendTransaction';
-import { flushPromises } from '@vue/test-utils';
 import { useApp } from '@/composables/useApp';
 import * as api from '@/utils/api';
 import * as crypto from '@/utils/crypto';

--- a/src/composables/useShowMnemonic.ts
+++ b/src/composables/useShowMnemonic.ts
@@ -25,7 +25,7 @@ export function useShowMnemonic() {
 
       step.value = 2;
       return true;
-    } catch (e) {
+    } catch {
       error.value = 'Incorrect password';
       return false;
     }

--- a/src/models/Address.ts
+++ b/src/models/Address.ts
@@ -7,15 +7,14 @@ export class Address {
     this.value = value;
   }
 
-  /** For PepCopyableId split rendering */
   get start() {
     return truncateId(this.value).start;
   }
+
   get end() {
     return truncateId(this.value).end;
   }
 
-  /** Plain string: "Pmu...FZSU" */
   get truncated() {
     if (!this.value || this.value.length <= 12) return this.value || '';
     return `${this.value.slice(0, 6)}…${this.value.slice(-6)}`;

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -176,7 +176,7 @@ export const useWalletStore = defineStore('wallet', () => {
       await lockout.reset();
       await refreshBalance(true);
       return true;
-    } catch (e) {
+    } catch {
       const { wipe } = await lockout.recordFailure();
       if (wipe) {
         await resetWallet();

--- a/src/utils/api.spec.ts
+++ b/src/utils/api.spec.ts
@@ -26,11 +26,9 @@ vi.mock('./auth', () => ({
 }));
 
 describe('API Utils', () => {
-  let errorSpy: any;
-
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn());
-    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -70,7 +70,7 @@ export function isValidAddress(address: string): boolean {
   try {
     bitcoin.address.toOutputScript(address, PEPECOIN);
     return true;
-  } catch (e) {
+  } catch {
     return false;
   }
 }

--- a/src/utils/psbt.ts
+++ b/src/utils/psbt.ts
@@ -114,7 +114,7 @@ export function verifyPsbtOwnership(
       return `Input ${i} is missing nonWitnessUtxo; cannot verify ownership.`;
     }
     const txIn = psbt.txInputs[i]!;
-    let prevAddress: string | null = null;
+    let prevAddress: string;
     try {
       const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
       const out = prevTx.outs[txIn.index];

--- a/src/views/approval/SendTransferApproval.vue
+++ b/src/views/approval/SendTransferApproval.vue
@@ -191,7 +191,7 @@ function handleReject() {
 
     <template #actions>
       <div v-if="invalidRequest">
-        <PepButton id="reject-transaction-button" variant="secondary" @click="handleReject" block
+        <PepButton id="reject-transaction-button" variant="secondary" block @click="handleReject"
           >Close</PepButton
         >
       </div>
@@ -199,15 +199,15 @@ function handleReject() {
         <PepButton
           id="reject-transaction-button"
           variant="secondary"
-          @click="handleReject"
           :disabled="isProcessing"
+          @click="handleReject"
           >Cancel</PepButton
         >
         <PepButton
           id="approve-transaction-button"
-          @click="handleApprove"
           :loading="isProcessing"
           :disabled="!displayFee"
+          @click="handleApprove"
           >Approve</PepButton
         >
       </div>

--- a/src/views/approval/SignMessageView.vue
+++ b/src/views/approval/SignMessageView.vue
@@ -60,11 +60,11 @@ function handleReject() {
         <PepButton
           id="reject-signature-button"
           variant="secondary"
-          @click="handleReject"
           :disabled="isProcessing"
+          @click="handleReject"
           >Cancel</PepButton
         >
-        <PepButton id="approve-signature-button" @click="handleApprove" :loading="isProcessing"
+        <PepButton id="approve-signature-button" :loading="isProcessing" @click="handleApprove"
           >Sign</PepButton
         >
       </div>

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -30,24 +30,22 @@ vi.mock('@/utils/crypto', () => ({
   parseDerivationPath: vi.fn().mockReturnValue({ accountIndex: 0, addressIndex: 0 })
 }));
 
-const { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt } = vi.hoisted(
-  () => {
-    const mockSignInput = vi.fn();
-    const mockFinalizeAllInputs = vi.fn();
-    const mockExtractTransaction = vi.fn().mockReturnValue({ toHex: () => 'finalized-tx-hex' });
-    const mockPsbt = {
-      inputCount: 2,
-      txInputs: [],
-      txOutputs: [],
-      data: { inputs: [] },
-      signInput: mockSignInput,
-      finalizeAllInputs: mockFinalizeAllInputs,
-      extractTransaction: mockExtractTransaction,
-      toBase64: vi.fn().mockReturnValue('signed-psbt-base64')
-    };
-    return { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt };
-  }
-);
+const { mockSignInput, mockFinalizeAllInputs, mockPsbt } = vi.hoisted(() => {
+  const mockSignInput = vi.fn();
+  const mockFinalizeAllInputs = vi.fn();
+  const mockExtractTransaction = vi.fn().mockReturnValue({ toHex: () => 'finalized-tx-hex' });
+  const mockPsbt = {
+    inputCount: 2,
+    txInputs: [],
+    txOutputs: [],
+    data: { inputs: [] },
+    signInput: mockSignInput,
+    finalizeAllInputs: mockFinalizeAllInputs,
+    extractTransaction: mockExtractTransaction,
+    toBase64: vi.fn().mockReturnValue('signed-psbt-base64')
+  };
+  return { mockSignInput, mockFinalizeAllInputs, mockExtractTransaction, mockPsbt };
+});
 
 vi.mock('bitcoinjs-lib', () => ({
   Psbt: { fromBase64: vi.fn().mockReturnValue(mockPsbt) },

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -353,11 +353,11 @@ function handleReject() {
         <PepButton
           id="reject-transaction-button"
           variant="secondary"
-          @click="handleReject"
           :disabled="isProcessing"
+          @click="handleReject"
           >Cancel</PepButton
         >
-        <PepButton id="approve-transaction-button" @click="handleApprove" :loading="isProcessing"
+        <PepButton id="approve-transaction-button" :loading="isProcessing" @click="handleApprove"
           >Approve</PepButton
         >
       </div>

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -126,7 +126,6 @@ function decodePsbtSummary(
       const data = psbt.data.inputs[i];
       let address: string | null = null;
       let value: number | null = null;
-      let inscription: Inscription | null = null;
       if (data?.nonWitnessUtxo) {
         const prevTx = bitcoin.Transaction.fromBuffer(data.nonWitnessUtxo);
         const out = prevTx.outs[txIn.index];
@@ -140,7 +139,7 @@ function decodePsbtSummary(
         }
       }
       const prevTxid = Buffer.from(txIn.hash).reverse().toString('hex');
-      inscription = findInscriptionByOutput(prevTxid, txIn.index);
+      const inscription = findInscriptionByOutput(prevTxid, txIn.index);
       return {
         address,
         amountRibbits: value,

--- a/src/views/inscriptions/InscriptionDetailView.vue
+++ b/src/views/inscriptions/InscriptionDetailView.vue
@@ -66,7 +66,7 @@ function goToSend() {
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Inscription" :onBack="() => router.push('/inscriptions')" />
+      <PepPageHeader title="Inscription" :on-back="() => router.push('/inscriptions')" />
     </template>
 
     <div class="flex min-h-0 flex-1 flex-col">
@@ -136,14 +136,14 @@ function goToSend() {
           </div>
         </PepCard>
 
-        <PepCopyableId label="Inscription ID" :id="inscription.id" />
+        <PepCopyableId :id="inscription.id" label="Inscription ID" />
       </div>
     </div>
 
     <template #actions>
       <div v-if="inscription" class="w-full space-y-3">
-        <PepButton id="send-inscription" @click="goToSend" class="w-full"> Send </PepButton>
-        <PepButton id="view-on-explorer" @click="openExplorer" variant="secondary" class="w-full">
+        <PepButton id="send-inscription" class="w-full" @click="goToSend"> Send </PepButton>
+        <PepButton id="view-on-explorer" variant="secondary" class="w-full" @click="openExplorer">
           View on Explorer
         </PepButton>
       </div>

--- a/src/views/inscriptions/InscriptionsView.vue
+++ b/src/views/inscriptions/InscriptionsView.vue
@@ -28,7 +28,7 @@ function open(id: string) {
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Inscriptions" :onBack="() => router.push('/dashboard')" />
+      <PepPageHeader title="Inscriptions" :on-back="() => router.push('/dashboard')" />
     </template>
 
     <div class="flex min-h-0 flex-1 flex-col">
@@ -52,8 +52,8 @@ function open(id: string) {
             v-for="item in items"
             :key="item.id"
             type="button"
-            @click="open(item.id)"
             class="group overflow-hidden rounded-xl border border-slate-700 bg-slate-800/50 text-left transition-colors hover:border-slate-600"
+            @click="open(item.id)"
           >
             <div class="aspect-square w-full overflow-hidden">
               <PepInscription :id="item.id" :content-type="item.contentType" :interactive="false" />

--- a/src/views/inscriptions/send/SendInscriptionStepForm.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepForm.vue
@@ -36,9 +36,9 @@ onMounted(() => {
       </div>
 
       <PepInput
+        id="recipient"
         ref="recipientInput"
         v-model="form.recipient"
-        id="recipient"
         label="Recipient Address"
         placeholder="Enter address"
         :error="form.errors.recipient"

--- a/src/views/inscriptions/send/SendInscriptionStepReview.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepReview.vue
@@ -53,8 +53,8 @@ const { wallet: walletStore } = useApp();
 
       <div v-if="!walletStore.isMnemonicLoaded" class="mt-0">
         <PepPasswordInput
-          v-model="form.password"
           id="confirm-password"
+          v-model="form.password"
           label="Enter Password to Confirm"
           placeholder="Enter your password"
           :error="form.errors.general"

--- a/src/views/inscriptions/send/SendInscriptionStepSuccess.vue
+++ b/src/views/inscriptions/send/SendInscriptionStepSuccess.vue
@@ -7,7 +7,7 @@ defineProps<{
 <template>
   <div class="flex flex-1 flex-col">
     <PepSuccessState title="Inscription sent!" description="Your inscription is on its way.">
-      <PepCopyableId label="Transaction ID" :id="txid" />
+      <PepCopyableId :id="txid" label="Transaction ID" />
     </PepSuccessState>
   </div>
 </template>

--- a/src/views/inscriptions/send/SendInscriptionView.vue
+++ b/src/views/inscriptions/send/SendInscriptionView.vue
@@ -150,7 +150,7 @@ onMounted(async () => {
 
   try {
     await loadFees();
-  } catch (e) {
+  } catch {
     // surfaced via isInsufficientFunds / loading state
   }
 });

--- a/src/views/inscriptions/send/SendInscriptionView.vue
+++ b/src/views/inscriptions/send/SendInscriptionView.vue
@@ -161,7 +161,7 @@ onMounted(async () => {
     <template #header>
       <PepPageHeader
         :title="form.step === 3 ? 'Success' : 'Send Inscription'"
-        :onBack="
+        :on-back="
           form.step === 3
             ? handleClose
             : form.step === 2
@@ -196,8 +196,8 @@ onMounted(async () => {
       v-else-if="inscription && form.step === 1"
       :form="form"
       :inscription="inscription"
-      :isInsufficientFunds="isInsufficientFunds"
-      :displayFee="displayFee"
+      :is-insufficient-funds="isInsufficientFunds"
+      :display-fee="displayFee"
       @address-blur="handleAddressBlur"
       @next="handleReview"
     />
@@ -206,7 +206,7 @@ onMounted(async () => {
       v-else-if="inscription && form.step === 2"
       :form="form"
       :inscription="inscription"
-      :displayFee="displayFee"
+      :display-fee="displayFee"
       @send="handleSend"
     />
 
@@ -215,40 +215,40 @@ onMounted(async () => {
     <template #actions>
       <PepLoadingButton
         v-if="inscription && form.step === 1"
-        @click="handleReview"
         :loading="form.isProcessing"
-        :minLoadingMs="UX_DELAY_FAST"
+        :min-loading-ms="UX_DELAY_FAST"
         :disabled="!canReview"
         :variant="isInsufficientFunds ? 'danger' : 'primary'"
         class="w-full"
+        @click="handleReview"
       >
         {{ nextButtonLabel }}
       </PepLoadingButton>
 
       <div v-if="inscription && form.step === 2" class="space-y-3">
         <PepLoadingButton
-          @click="handleSend"
           :loading="form.isProcessing"
-          :minLoadingMs="UX_DELAY_SLOW"
+          :min-loading-ms="UX_DELAY_SLOW"
           :disabled="form.hasError()"
           class="w-full"
+          @click="handleSend"
         >
           Send
         </PepLoadingButton>
         <PepButton
           type="button"
-          @click="handleCancel"
           variant="secondary"
           :disabled="form.isProcessing"
           class="w-full"
+          @click="handleCancel"
         >
           Cancel
         </PepButton>
       </div>
 
       <div v-if="form.step === 3" class="w-full space-y-3">
-        <PepButton @click="openExplorer" class="w-full">View on Explorer</PepButton>
-        <PepButton @click="handleClose" variant="secondary" class="w-full">Close</PepButton>
+        <PepButton class="w-full" @click="openExplorer">View on Explorer</PepButton>
+        <PepButton variant="secondary" class="w-full" @click="handleClose">Close</PepButton>
       </div>
     </template>
   </PepMainLayout>

--- a/src/views/onboarding/CreateWalletView.spec.ts
+++ b/src/views/onboarding/CreateWalletView.spec.ts
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import CreateWalletView from './CreateWalletView.vue';
 import { useApp } from '@/composables/useApp';
-import { useCreateWallet } from '@/composables/useCreateWallet';
 
 // UI Components
 import PepForm from '@/components/ui/form/PepForm.vue';

--- a/src/views/onboarding/CreateWalletView.vue
+++ b/src/views/onboarding/CreateWalletView.vue
@@ -51,8 +51,8 @@ async function handleCreate() {
     <template #header>
       <PepPageHeader
         title="Create wallet"
-        :onBack="step === 2 ? backToPassword : undefined"
-        :backTo="step === 1 ? '/' : undefined"
+        :on-back="step === 2 ? backToPassword : undefined"
+        :back-to="step === 1 ? '/' : undefined"
       />
     </template>
 
@@ -60,8 +60,8 @@ async function handleCreate() {
     <div v-if="step === 1" class="flex flex-1 flex-col pt-0">
       <PepForm
         id="create-wallet-password-form"
-        @submit="handleNextToSeed"
         class="flex flex-1 flex-col"
+        @submit="handleNextToSeed"
       >
         <div class="space-y-2 text-sm text-slate-400">
           <p>Set a password to protect your wallet.</p>
@@ -70,7 +70,7 @@ async function handleCreate() {
 
         <PepPasswordFields
           v-model:password="form.password"
-          v-model:confirmPassword="form.confirmPassword"
+          v-model:confirm-password="form.confirmPassword"
           :errors="form.errors"
           @blur-password="onBlurPassword"
           @blur-confirm="onBlurConfirmPassword"
@@ -83,8 +83,8 @@ async function handleCreate() {
       <PepForm
         id="create-wallet-confirm-form"
         :loading="form.isProcessing"
-        @submit="handleCreate"
         class="flex flex-1 flex-col"
+        @submit="handleCreate"
       >
         <div class="space-y-2 pb-0 text-sm text-slate-400">
           <p class="text-offwhite font-bold">Write down your secret phrase</p>
@@ -97,8 +97,8 @@ async function handleCreate() {
 
         <div class="pt-0">
           <PepCheckbox
-            v-model="confirmedSeed"
             id="confirm-seed"
+            v-model="confirmedSeed"
             label="I have written down my secret phrase and stored it in a safe place."
             :disabled="form.isProcessing"
           />

--- a/src/views/onboarding/ForgotPasswordView.vue
+++ b/src/views/onboarding/ForgotPasswordView.vue
@@ -36,15 +36,15 @@ async function handleReset() {
 
       <div class="pt-2">
         <PepCheckbox
-          v-model="confirmedBackup"
           id="confirm-backup"
+          v-model="confirmedBackup"
           label="I have backed up my secret phrase."
         />
       </div>
     </div>
 
     <template #actions>
-      <PepButton @click="handleReset" :disabled="!confirmedBackup" variant="danger" class="w-full">
+      <PepButton :disabled="!confirmedBackup" variant="danger" class="w-full" @click="handleReset">
         Reset wallet
       </PepButton>
     </template>

--- a/src/views/onboarding/ImportWalletView.spec.ts
+++ b/src/views/onboarding/ImportWalletView.spec.ts
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import ImportWalletView from './ImportWalletView.vue';
 import { useApp } from '@/composables/useApp';
-import { useImportWallet } from '@/composables/useImportWallet';
 
 // UI Components
 import PepForm from '@/components/ui/form/PepForm.vue';

--- a/src/views/onboarding/ImportWalletView.vue
+++ b/src/views/onboarding/ImportWalletView.vue
@@ -75,17 +75,17 @@ async function handleImport() {
     <PepForm
       id="import-wallet-form"
       :loading="form.isProcessing"
-      @submit="handleImport"
       class="flex flex-1 flex-col"
+      @submit="handleImport"
     >
       <PepInputGroup
-        label="Secret phrase (12 or 24 words)"
         id="mnemonic"
+        label="Secret phrase (12 or 24 words)"
         :error="invalidWords.length > 0 ? '' : form.errors.mnemonic"
       >
         <textarea
-          v-model="form.mnemonic"
           id="mnemonic"
+          v-model="form.mnemonic"
           rows="3"
           placeholder="word1 word2 ..."
           :disabled="form.isProcessing"
@@ -105,7 +105,7 @@ async function handleImport() {
 
       <PepPasswordFields
         v-model:password="form.password"
-        v-model:confirmPassword="form.confirmPassword"
+        v-model:confirm-password="form.confirmPassword"
         :errors="form.errors"
         @blur-password="onBlurPassword"
         @blur-confirm="onBlurConfirmPassword"

--- a/src/views/onboarding/WelcomeView.spec.ts
+++ b/src/views/onboarding/WelcomeView.spec.ts
@@ -200,18 +200,18 @@ describe('WelcomeView Logic', () => {
     mockStore.isCreated = true;
     const wrapper = mount(WelcomeView, { global });
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.password = 'some-text';
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.setError('general', 'Previous error');
 
     // Trigger lockout
     isLockedOut.value = true;
     await nextTick();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.password).toBe('');
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.hasError()).toBe(false);
   });
 
@@ -226,7 +226,7 @@ describe('WelcomeView Logic', () => {
     mockStore.unlock.mockRejectedValue(new Error('Boom'));
 
     const wrapper = mount(WelcomeView, { global });
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleUnlock();
 
     expect(wrapper.text()).toContain('Incorrect password');

--- a/src/views/onboarding/WelcomeView.vue
+++ b/src/views/onboarding/WelcomeView.vue
@@ -64,7 +64,7 @@ async function handleUnlock() {
 
     form.setError('general', 'Incorrect password');
     passwordInput.value?.focus();
-  } catch (e) {
+  } catch {
     const elapsed = Date.now() - startTime;
     if (elapsed < UX_DELAY_FAST) {
       await new Promise((r) => setTimeout(r, UX_DELAY_FAST - elapsed));

--- a/src/views/onboarding/WelcomeView.vue
+++ b/src/views/onboarding/WelcomeView.vue
@@ -92,9 +92,9 @@ async function handleUnlock() {
       <div v-if="walletStore.isCreated" class="w-full">
         <PepForm id="welcome-unlock-form" :loading="form.isProcessing" @submit="handleUnlock">
           <PepPasswordInput
+            id="password"
             ref="passwordInput"
             v-model="form.password"
-            id="password"
             label="Password"
             placeholder="Enter your password"
             :error="loginErrorMessage"
@@ -117,9 +117,9 @@ async function handleUnlock() {
 
           <button
             type="button"
-            @click="router.push('/forgot-password')"
             class="w-full cursor-pointer text-xs text-slate-500 underline transition-colors hover:text-white hover:no-underline"
             tabindex="-1"
+            @click="router.push('/forgot-password')"
           >
             Forgot your password?
           </button>
@@ -127,9 +127,9 @@ async function handleUnlock() {
       </div>
 
       <div v-else class="w-full space-y-4">
-        <PepButton @click="router.push('/create')" class="w-full"> Create new wallet </PepButton>
+        <PepButton class="w-full" @click="router.push('/create')"> Create new wallet </PepButton>
 
-        <PepButton @click="router.push('/import')" variant="secondary" class="w-full">
+        <PepButton variant="secondary" class="w-full" @click="router.push('/import')">
           Import secret phrase
         </PepButton>
       </div>

--- a/src/views/settings/AccountsView.spec.ts
+++ b/src/views/settings/AccountsView.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount, flushPromises } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import AccountsView from './AccountsView.vue';
 import { useApp } from '@/composables/useApp';
 import PepButton from '@/components/ui/PepButton.vue';

--- a/src/views/settings/AccountsView.vue
+++ b/src/views/settings/AccountsView.vue
@@ -27,10 +27,10 @@ function handleAdd() {
     <PepList id="accounts-list">
       <div
         v-for="(account, index) in walletStore.accounts"
-        :key="account.address"
         :id="`account-item-${index}`"
-        @click="handleSwitch(index)"
+        :key="account.address"
         class="group relative flex cursor-pointer items-center justify-between border-b border-slate-800/50 p-4 transition-colors last:border-0 hover:bg-slate-800"
+        @click="handleSwitch(index)"
       >
         <div class="flex min-w-0 items-center space-x-4">
           <div
@@ -42,9 +42,9 @@ function handleAdd() {
             "
           >
             <PepIcon
+              v-if="walletStore.activeAccountIndex === index"
               :name="walletStore.activeAccountIndex === index ? 'check' : 'checkmark-circle'"
               size="20"
-              v-if="walletStore.activeAccountIndex === index"
             />
             <span v-else class="text-xs font-bold">P</span>
           </div>
@@ -53,10 +53,10 @@ function handleAdd() {
         </div>
 
         <button
-          type="button"
           :id="`edit-account-button-${index}`"
-          @click="handleEdit(index, $event)"
+          type="button"
           class="hover:text-pep-green-light rounded-lg p-2 text-slate-500 transition-colors"
+          @click="handleEdit(index, $event)"
         >
           <PepIcon name="edit" size="18" />
         </button>
@@ -64,7 +64,7 @@ function handleAdd() {
     </PepList>
 
     <template #actions>
-      <PepButton id="add-account-button" @click="handleAdd" variant="secondary" class="w-full">
+      <PepButton id="add-account-button" variant="secondary" class="w-full" @click="handleAdd">
         Add New Account
       </PepButton>
     </template>

--- a/src/views/settings/AutoLockView.vue
+++ b/src/views/settings/AutoLockView.vue
@@ -28,10 +28,10 @@ async function selectDuration(val: number) {
       </p>
 
       <PepRadioList
-        :modelValue="settingsStore.settings.lockDuration"
+        :model-value="settingsStore.settings.lockDuration"
         :options="options"
         name="auto-lock"
-        @update:modelValue="selectDuration"
+        @update:model-value="selectDuration"
       />
     </div>
   </PepMainLayout>

--- a/src/views/settings/ChangePasswordView.spec.ts
+++ b/src/views/settings/ChangePasswordView.spec.ts
@@ -3,7 +3,7 @@ import { ref } from 'vue';
 import { mount, flushPromises } from '@vue/test-utils';
 import ChangePasswordView from './ChangePasswordView.vue';
 import { useApp } from '@/composables/useApp';
-import { useChangePassword, ChangePasswordError } from '@/composables/useChangePassword';
+import { ChangePasswordError } from '@/composables/useChangePassword';
 import { replaceMock, pushMock } from '@/composables/__mocks__/useApp';
 import * as encryption from '@/utils/encryption';
 

--- a/src/views/settings/ChangePasswordView.vue
+++ b/src/views/settings/ChangePasswordView.vue
@@ -71,8 +71,8 @@ async function handleChangePassword() {
   <PepMainLayout>
     <template #header>
       <PepPageHeader
-        :title="isSuccess ? 'Success' : 'Change password'"
         :key="isSuccess ? 'success' : 'form'"
+        :title="isSuccess ? 'Success' : 'Change password'"
       />
     </template>
 
@@ -87,12 +87,12 @@ async function handleChangePassword() {
       v-else
       id="change-password-form"
       :loading="form.isProcessing"
-      @submit="handleChangePassword"
       class="flex flex-1 flex-col"
+      @submit="handleChangePassword"
     >
       <PepPasswordInput
-        v-model="form.oldPassword"
         id="old-password"
+        v-model="form.oldPassword"
         label="Current password"
         placeholder="Enter current password"
         :error="oldPasswordError"
@@ -101,11 +101,11 @@ async function handleChangePassword() {
 
       <PepPasswordFields
         v-model:password="form.password"
-        v-model:confirmPassword="form.confirmPassword"
+        v-model:confirm-password="form.confirmPassword"
         :errors="form.errors"
         :disabled="isLockedOut"
-        passwordLabel="New password"
-        confirmLabel="Confirm new password"
+        password-label="New password"
+        confirm-label="Confirm new password"
         @blur-password="onBlurPassword"
         @blur-confirm="onBlurConfirmPassword"
       />
@@ -114,16 +114,16 @@ async function handleChangePassword() {
     <template #actions>
       <PepLoadingButton
         v-if="!isSuccess"
-        @click="handleChangePassword"
         :loading="form.isProcessing"
-        :minLoadingMs="UX_DELAY_NORMAL"
+        :min-loading-ms="UX_DELAY_NORMAL"
         :disabled="!canSubmit"
         class="w-full"
+        @click="handleChangePassword"
       >
         {{ isLockedOut ? 'Locked' : form.isProcessing ? 'Updating...' : 'Update password' }}
       </PepLoadingButton>
 
-      <PepButton v-else @click="router.push('/dashboard')" variant="secondary" class="w-full">
+      <PepButton v-else variant="secondary" class="w-full" @click="router.push('/dashboard')">
         Close
       </PepButton>
     </template>

--- a/src/views/settings/ConnectedSitesView.vue
+++ b/src/views/settings/ConnectedSitesView.vue
@@ -16,7 +16,7 @@ onMounted(async () => {
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Connected Sites" backTo="/settings" />
+      <PepPageHeader title="Connected Sites" back-to="/settings" />
     </template>
 
     <div class="space-y-6">
@@ -42,9 +42,9 @@ onMounted(async () => {
           </p>
 
           <button
-            @click="revokeAccess(site)"
             class="flex-shrink-0 rounded-lg p-2 text-slate-500 transition-colors hover:bg-red-400/10 hover:text-red-400"
             title="Revoke access"
+            @click="revokeAccess(site)"
           >
             <PepIcon name="clear" size="18" />
           </button>

--- a/src/views/settings/CurrencyView.vue
+++ b/src/views/settings/CurrencyView.vue
@@ -25,10 +25,10 @@ function selectCurrency(code: 'USD' | 'EUR') {
       </p>
 
       <PepRadioList
-        :modelValue="settingsStore.settings.currency"
+        :model-value="settingsStore.settings.currency"
         :options="options"
         name="currency"
-        @update:modelValue="selectCurrency"
+        @update:model-value="selectCurrency"
       />
     </div>
   </PepMainLayout>

--- a/src/views/settings/EditAccountView.vue
+++ b/src/views/settings/EditAccountView.vue
@@ -68,7 +68,7 @@ async function handleSave() {
     <template #actions>
       <div class="grid grid-cols-2 gap-4">
         <PepButton id="cancel-button" variant="secondary" @click="router.back()">Cancel</PepButton>
-        <PepButton id="save-account-name-button" @click="handleSave" :loading="isSaving">{{
+        <PepButton id="save-account-name-button" :loading="isSaving" @click="handleSave">{{
           isNew ? 'Add Account' : 'Save Changes'
         }}</PepButton>
       </div>

--- a/src/views/settings/PreferredExplorerView.vue
+++ b/src/views/settings/PreferredExplorerView.vue
@@ -27,10 +27,10 @@ function selectExplorer(id: ExplorerId) {
       </p>
 
       <PepRadioList
-        :modelValue="settingsStore.settings.explorer"
+        :model-value="settingsStore.settings.explorer"
         :options="options"
         name="explorer"
-        @update:modelValue="selectExplorer"
+        @update:model-value="selectExplorer"
       />
     </div>
   </PepMainLayout>

--- a/src/views/settings/ResetWalletView.spec.ts
+++ b/src/views/settings/ResetWalletView.spec.ts
@@ -56,13 +56,13 @@ describe('ResetWalletView Feature', () => {
     const resetSpy = vi.spyOn(mockWallet, 'resetWallet');
 
     // 1. Initial state: button should be disabled
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.confirmedBackup).toBe(false);
 
     // 2. Check the checkbox
     const checkbox = wrapper.find('input[type="checkbox"]');
     await checkbox.setValue(true);
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.confirmedBackup).toBe(true);
 
     // 3. Trigger form submit

--- a/src/views/settings/ResetWalletView.vue
+++ b/src/views/settings/ResetWalletView.vue
@@ -21,7 +21,7 @@ async function handleReset() {
     <template #header>
       <PepPageHeader title="Reset wallet" />
     </template>
-    <PepForm id="reset-wallet-form" @submit="handleReset" class="flex flex-1 flex-col">
+    <PepForm id="reset-wallet-form" class="flex flex-1 flex-col" @submit="handleReset">
       <div class="space-y-4 text-sm text-slate-400">
         <p class="text-offwhite font-bold">
           This will completely wipe your wallet data from this browser.
@@ -38,8 +38,8 @@ async function handleReset() {
 
       <div class="pt-0">
         <PepCheckbox
-          v-model="confirmedBackup"
           id="confirm-backup"
+          v-model="confirmedBackup"
           label="I have backed up my secret phrase."
         />
       </div>
@@ -50,7 +50,7 @@ async function handleReset() {
         type="submit"
         form="reset-wallet-form"
         :loading="isProcessing"
-        :minLoadingMs="UX_DELAY_NORMAL"
+        :min-loading-ms="UX_DELAY_NORMAL"
         :disabled="!confirmedBackup"
         variant="danger"
         class="w-full"

--- a/src/views/settings/SecurityView.vue
+++ b/src/views/settings/SecurityView.vue
@@ -28,9 +28,9 @@ const { router } = useApp();
       <div class="pt-6">
         <PepButton
           id="security-reset-wallet-button"
-          @click="router.push('/reset-wallet')"
           variant="secondary"
           class="w-full !text-red-400"
+          @click="router.push('/reset-wallet')"
         >
           Reset wallet
         </PepButton>

--- a/src/views/settings/SettingsView.vue
+++ b/src/views/settings/SettingsView.vue
@@ -12,7 +12,7 @@ function handleLock() {
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Settings" backTo="/dashboard" />
+      <PepPageHeader title="Settings" back-to="/dashboard" />
     </template>
 
     <div class="mt-0 flex-1 space-y-2">
@@ -50,7 +50,7 @@ function handleLock() {
       </PepList>
 
       <div class="pt-6">
-        <PepButton @click="handleLock" variant="secondary" class="w-full"> Lock Wallet </PepButton>
+        <PepButton variant="secondary" class="w-full" @click="handleLock"> Lock Wallet </PepButton>
       </div>
     </div>
   </PepMainLayout>

--- a/src/views/settings/ShowMnemonicView.spec.ts
+++ b/src/views/settings/ShowMnemonicView.spec.ts
@@ -3,7 +3,6 @@ import { ref } from 'vue';
 import { mount } from '@vue/test-utils';
 import ShowMnemonicView from './ShowMnemonicView.vue';
 import { useApp } from '@/composables/useApp';
-import { useShowMnemonic } from '@/composables/useShowMnemonic';
 
 // UI Components
 import PepForm from '@/components/ui/form/PepForm.vue';

--- a/src/views/settings/ShowMnemonicView.vue
+++ b/src/views/settings/ShowMnemonicView.vue
@@ -64,9 +64,9 @@ async function handleReveal() {
 
       <div class="space-y-6">
         <PepPasswordInput
+          id="reveal-password"
           ref="passwordInput"
           v-model="password"
-          id="reveal-password"
           label="Password"
           placeholder="Enter your password"
           :error="errorMessage"
@@ -92,19 +92,19 @@ async function handleReveal() {
       <PepLoadingButton
         v-if="step === 1"
         id="reveal-button"
-        @click="handleReveal"
         :loading="isProcessing"
         :disabled="isLockedOut || !password || !!errorMessage || isProcessing"
         class="w-full"
+        @click="handleReveal"
       >
         {{ isLockedOut ? 'Locked' : 'Reveal Phrase' }}
       </PepLoadingButton>
 
       <PepButton
         v-if="step === 2"
-        @click="router.push('/dashboard')"
         variant="secondary"
         class="w-full"
+        @click="router.push('/dashboard')"
       >
         Close
       </PepButton>

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -45,7 +45,7 @@ async function handleLoadMore() {
   isLoadingMore.value = true;
   try {
     await account.fetchMoreTransactions(walletStore.address!);
-  } catch (e) {
+  } catch {
     // Error handled in store
   } finally {
     isLoadingMore.value = false;

--- a/src/views/wallet/DashboardView.vue
+++ b/src/views/wallet/DashboardView.vue
@@ -58,8 +58,8 @@ async function handleLoadMore() {
     <!-- Account Indicator -->
     <div
       id="account-indicator"
-      @click="router.push('/settings/accounts')"
       class="mb-2 flex cursor-pointer items-center justify-between rounded-xl px-1 py-2 transition-colors hover:bg-slate-800/50"
+      @click="router.push('/settings/accounts')"
     >
       <span class="text-xs font-bold text-white">{{ walletStore.activeAccount?.label }}</span>
       <PepIcon name="chevron-right" size="16" class="text-slate-500" />
@@ -68,8 +68,8 @@ async function handleLoadMore() {
     <!-- Inscriptions Indicator -->
     <div
       id="inscriptions-entry"
-      @click="router.push('/inscriptions')"
       class="mb-2 flex cursor-pointer items-center justify-between rounded-xl px-1 py-2 transition-colors hover:bg-slate-800/50"
+      @click="router.push('/inscriptions')"
     >
       <span class="text-xs font-bold text-white">{{ inscriptionCount }} inscriptions</span>
       <PepIcon name="chevron-right" size="16" class="text-slate-500" />
@@ -94,7 +94,7 @@ async function handleLoadMore() {
     <!-- Actions -->
     <div class="mb-6 grid grid-cols-2 gap-4">
       <PepButton @click="router.push('/send')"> Send </PepButton>
-      <PepButton @click="router.push('/receive')" variant="secondary"> Receive </PepButton>
+      <PepButton variant="secondary" @click="router.push('/receive')"> Receive </PepButton>
     </div>
 
     <!-- Recent Activity -->
@@ -119,9 +119,9 @@ async function handleLoadMore() {
         <div v-if="account.canLoadMoreTransactions" class="mt-4 flex justify-center">
           <button
             type="button"
-            @click="handleLoadMore"
             :disabled="isLoadingMore"
             class="text-pep-green-light hover:text-pep-green cursor-pointer text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            @click="handleLoadMore"
           >
             {{ isLoadingMore ? 'Loading...' : 'Load more' }}
           </button>

--- a/src/views/wallet/ReceiveView.vue
+++ b/src/views/wallet/ReceiveView.vue
@@ -10,7 +10,7 @@ const { router, wallet: walletStore } = useApp();
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Receive PEP" :onBack="() => router.push('/dashboard')" />
+      <PepPageHeader title="Receive PEP" :on-back="() => router.push('/dashboard')" />
     </template>
 
     <section class="flex items-center justify-center">

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -133,13 +133,13 @@ describe('SendView', () => {
   it('should toggle between PEP and fiat mode when swap button is clicked', async () => {
     const wrapper = mount(SendView, { global });
     // Ensure we are at step 1
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 1;
 
     await flushPromises();
 
     const amountInput = wrapper.findComponent(PepAmountInput);
-    // @ts-ignore
+    // @ts-expect-error
     expect(amountInput.vm.isFiatMode).toBe(false);
 
     // Find and click swap button
@@ -147,11 +147,11 @@ describe('SendView', () => {
     expect(swapBtn.exists()).toBe(true);
 
     await swapBtn.trigger('click');
-    // @ts-ignore
+    // @ts-expect-error
     expect(amountInput.vm.isFiatMode).toBe(true);
 
     await swapBtn.trigger('click');
-    // @ts-ignore
+    // @ts-expect-error
     expect(amountInput.vm.isFiatMode).toBe(false);
   });
 
@@ -159,9 +159,9 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
 
     // Manually move to Step 3 and set a TXID in the persisted form
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 3;
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.txid = 'f1e24cd438c630792bdeacf8509eaad1e7248ba4314633189e17da069b5f9ef3';
 
     await wrapper.vm.$nextTick();
@@ -177,7 +177,7 @@ describe('SendView', () => {
     mockAccount.spendableBalanceRibbits = 500_000_000;
 
     const wrapper = mount(SendView, { global });
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 1;
 
     await flushPromises();
@@ -189,7 +189,7 @@ describe('SendView', () => {
   it('should have a MAX button of type="button" that does not trigger form submit', async () => {
     const wrapper = mount(SendView, { global });
     // Ensure we are at step 1
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 1;
 
     await flushPromises();
@@ -223,7 +223,7 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
     await flushPromises();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.errors.recipient).toBe('Invalid address format');
   });
 
@@ -231,9 +231,9 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
 
     // 1. Move to step 3
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 3;
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.recipient = 'some-address';
     await wrapper.vm.$nextTick();
 
@@ -242,9 +242,9 @@ describe('SendView', () => {
     await backBtn.trigger('click');
 
     // 3. Verify form was reset (step back to 1, recipient empty)
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.step).toBe(1);
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.recipient).toBe('');
     expect(pushMock).toHaveBeenCalledWith('/dashboard');
   });
@@ -253,10 +253,10 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
     mockSendTransaction.validateStep1.mockResolvedValue(true);
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleReview();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.step).toBe(2);
   });
 
@@ -264,41 +264,41 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
     mockSendTransaction.send.mockResolvedValue('txid');
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleSend();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.step).toBe(3);
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.txid = 'txid'; // Manually sync for test
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.txid).toBe('txid');
   });
 
   it('handleSend should handle error on failure', async () => {
     const wrapper = mount(SendView, { global });
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.txid = '';
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.step = 2;
     mockSendTransaction.send.mockRejectedValue(new Error('Send failed'));
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleSend();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.errors.general).toBe('Send failed');
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.step).toBe(2);
   });
   it('handleReview should handle error on failure', async () => {
     const wrapper = mount(SendView, { global });
     mockSendTransaction.validateStep1.mockRejectedValue(new Error('Invalid step 1'));
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleReview();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.errors.general).toBe('Invalid step 1');
   });
 
@@ -306,10 +306,10 @@ describe('SendView', () => {
     mockSendTransaction.maxRibbits.value = 5000;
     const wrapper = mount(SendView, { global });
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.setMax();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.amountRibbits).toBe(5000);
   });
 
@@ -319,10 +319,10 @@ describe('SendView', () => {
     const wrapper = mount(SendView, { global });
     const setErrorSpy = vi.spyOn(wrapper.vm.form, 'setError');
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.recipient = 'not-valid';
 
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.handleAddressBlur();
 
     expect(setErrorSpy).toHaveBeenCalledWith('recipient', 'Invalid address format');
@@ -332,13 +332,13 @@ describe('SendView', () => {
   });
   it('handleClose should reset and navigate', () => {
     const wrapper = mount(SendView, { global });
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.recipient = 'some-data';
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.handleClose();
 
-    // @ts-ignore
+    // @ts-expect-error
     expect(wrapper.vm.form.recipient).toBe('');
     expect(pushMock).toHaveBeenCalledWith('/dashboard');
   });
@@ -346,10 +346,10 @@ describe('SendView', () => {
   it('openExplorer should open explorer link', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     const wrapper = mount(SendView, { global });
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.form.txid = 'test-txid';
 
-    // @ts-ignore
+    // @ts-expect-error
     wrapper.vm.openExplorer();
 
     expect(openSpy).toHaveBeenCalledWith('https://peppool.space/tx/test-txid', '_blank');

--- a/src/views/wallet/SendView.spec.ts
+++ b/src/views/wallet/SendView.spec.ts
@@ -18,7 +18,6 @@ import PepPasswordInput from '@/components/ui/form/PepPasswordInput.vue';
 import PepInputGroup from '@/components/ui/form/PepInputGroup.vue';
 import PepLoadingButton from '@/components/ui/PepLoadingButton.vue';
 import { useApp } from '@/composables/useApp';
-import { useSendTransaction } from '@/composables/useSendTransaction';
 
 // Mock useApp
 const pushMock = vi.fn();
@@ -70,11 +69,6 @@ vi.mock('@/utils/crypto', () => ({
   isValidAddress: vi.fn().mockReturnValue(true),
   truncateId: vi.fn().mockReturnValue({ start: 'abc', end: 'xyz', full: 'abc...xyz' })
 }));
-
-// Mock global components
-const stubs = {
-  PepIcon: { template: '<div></div>' }
-};
 
 describe('SendView', () => {
   let mockWallet: any;

--- a/src/views/wallet/TransactionDetailView.spec.ts
+++ b/src/views/wallet/TransactionDetailView.spec.ts
@@ -99,7 +99,7 @@ describe('TransactionDetailView', () => {
     mockAccount.fetchTransaction.mockResolvedValue(
       new Transaction(incomingRaw, 'PmuXQDfN5KZQqPYombmSVscCQXbh7rFZSU')
     );
-    // @ts-ignore
+    // @ts-expect-error
     await wrapper.vm.loadDetails();
     await flushPromises();
 

--- a/src/views/wallet/TransactionDetailView.vue
+++ b/src/views/wallet/TransactionDetailView.vue
@@ -39,7 +39,7 @@ function openExplorer() {
 <template>
   <PepMainLayout>
     <template #header>
-      <PepPageHeader title="Transaction" :onBack="() => router.push('/dashboard')" />
+      <PepPageHeader title="Transaction" :on-back="() => router.push('/dashboard')" />
     </template>
 
     <div class="flex min-h-0 flex-1 flex-col">
@@ -97,13 +97,13 @@ function openExplorer() {
             </div>
           </PepCard>
 
-          <PepCopyableId label="Transaction ID" :id="txModel.txid" />
+          <PepCopyableId :id="txModel.txid" label="Transaction ID" />
         </div>
       </div>
     </div>
 
     <template #actions>
-      <PepButton v-if="txModel" id="view-on-explorer" @click="openExplorer" class="w-full">
+      <PepButton v-if="txModel" id="view-on-explorer" class="w-full" @click="openExplorer">
         View on Explorer
       </PepButton>
     </template>

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -24,9 +24,9 @@ onMounted(() => {
   <div class="flex flex-1 flex-col">
     <PepForm id="send-review-form" class="flex flex-1 flex-col" @submit="$emit('next')">
       <PepInput
+        id="recipient"
         ref="recipientInput"
         v-model="form.recipient"
-        id="recipient"
         label="Recipient Address"
         placeholder="Enter address"
         :error="form.errors.recipient"
@@ -50,7 +50,7 @@ onMounted(() => {
 
         <PepAmountInput
           v-model:ribbits="form.amountRibbits"
-          v-model:isFiatMode="form.isFiatMode"
+          v-model:is-fiat-mode="form.isFiatMode"
           :price="currentPrice"
           :disabled="form.isProcessing"
         >
@@ -58,10 +58,10 @@ onMounted(() => {
             <button
               id="send-max-button"
               type="button"
-              @click="$emit('set-max')"
               :disabled="form.isProcessing"
               class="text-pep-green-light hover:text-pep-green cursor-pointer text-xs font-bold tracking-wider uppercase disabled:cursor-not-allowed disabled:opacity-50"
               tabindex="-1"
+              @click="$emit('set-max')"
             >
               MAX
             </button>

--- a/src/views/wallet/send/SendStepForm.vue
+++ b/src/views/wallet/send/SendStepForm.vue
@@ -9,7 +9,7 @@ const props = defineProps<{
   displayFee: string;
 }>();
 
-const emit = defineEmits(['address-blur', 'set-max', 'next']);
+defineEmits(['address-blur', 'set-max', 'next']);
 
 const recipientInput = ref<any>(null);
 

--- a/src/views/wallet/send/SendStepReview.vue
+++ b/src/views/wallet/send/SendStepReview.vue
@@ -16,8 +16,8 @@ const { wallet: walletStore } = useApp();
     <PepForm
       id="send-transaction-form"
       :loading="form.isProcessing"
-      @submit="$emit('send')"
       class="flex flex-1 flex-col"
+      @submit="$emit('send')"
     >
       <div class="space-y-4 rounded-2xl border border-slate-700 bg-slate-800 p-4 text-left">
         <div class="flex flex-col space-y-0.5">
@@ -44,8 +44,8 @@ const { wallet: walletStore } = useApp();
 
       <div v-if="!walletStore.isMnemonicLoaded" class="mt-0">
         <PepPasswordInput
-          v-model="form.password"
           id="confirm-password"
+          v-model="form.password"
           label="Enter Password to Confirm"
           placeholder="Enter your password"
           :error="form.errors.general"

--- a/src/views/wallet/send/SendStepSuccess.spec.ts
+++ b/src/views/wallet/send/SendStepSuccess.spec.ts
@@ -1,11 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { mount } from '@vue/test-utils';
 import SendStepSuccess from './SendStepSuccess.vue';
 
 // UI Components
 import PepSuccessState from '@/components/ui/PepSuccessState.vue';
 import PepCopyableId from '@/components/ui/PepCopyableId.vue';
-import PepButton from '@/components/ui/PepButton.vue';
 import PepInputGroup from '@/components/ui/form/PepInputGroup.vue';
 
 const stubs = {

--- a/src/views/wallet/send/SendStepSuccess.vue
+++ b/src/views/wallet/send/SendStepSuccess.vue
@@ -9,7 +9,7 @@ defineEmits(['close', 'open-explorer']);
 <template>
   <div class="flex flex-1 flex-col">
     <PepSuccessState title="Transaction sent!" description="Your PEP is on its way.">
-      <PepCopyableId label="Transaction ID" :id="txid" />
+      <PepCopyableId :id="txid" label="Transaction ID" />
     </PepSuccessState>
   </div>
 </template>

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -203,7 +203,7 @@ onMounted(async () => {
     <template #header>
       <PepPageHeader
         :title="form.step === 3 ? 'Success' : 'Send PEP'"
-        :onBack="
+        :on-back="
           form.step === 3
             ? handleClose
             : form.step === 2
@@ -222,10 +222,10 @@ onMounted(async () => {
     <SendStepForm
       v-if="form.step === 1"
       :form="form"
-      :isInsufficientFunds="isInsufficientFunds"
-      :currentPrice="currentPrice"
-      :displayBalance="displayBalance"
-      :displayFee="displayFee"
+      :is-insufficient-funds="isInsufficientFunds"
+      :current-price="currentPrice"
+      :display-balance="displayBalance"
+      :display-fee="displayFee"
       @address-blur="handleAddressBlur"
       @set-max="setMax"
       @next="handleReview"
@@ -235,7 +235,7 @@ onMounted(async () => {
       v-if="form.step === 2"
       :form="form"
       :tx="tx"
-      :displayFee="displayFee"
+      :display-fee="displayFee"
       @send="handleSend"
     />
 
@@ -245,12 +245,12 @@ onMounted(async () => {
       <!-- Step 1 Actions -->
       <PepLoadingButton
         v-if="form.step === 1"
-        @click="handleReview"
         :loading="form.isProcessing"
-        :minLoadingMs="UX_DELAY_FAST"
+        :min-loading-ms="UX_DELAY_FAST"
         :disabled="!canReview"
         :variant="isInsufficientFunds ? 'danger' : 'primary'"
         class="w-full"
+        @click="handleReview"
       >
         {{ nextButtonLabel }}
       </PepLoadingButton>
@@ -258,20 +258,20 @@ onMounted(async () => {
       <!-- Step 2 Actions -->
       <div v-if="form.step === 2" class="space-y-3">
         <PepLoadingButton
-          @click="handleSend"
           :loading="form.isProcessing"
-          :minLoadingMs="UX_DELAY_SLOW"
+          :min-loading-ms="UX_DELAY_SLOW"
           :disabled="form.hasError()"
           class="w-full"
+          @click="handleSend"
         >
           Send
         </PepLoadingButton>
         <PepButton
           type="button"
-          @click="handleCancel"
           variant="secondary"
           :disabled="form.isProcessing"
           class="w-full"
+          @click="handleCancel"
         >
           Cancel
         </PepButton>
@@ -279,8 +279,8 @@ onMounted(async () => {
 
       <!-- Step 3 Actions -->
       <div v-if="form.step === 3" class="w-full space-y-3">
-        <PepButton @click="openExplorer" class="w-full"> View on Explorer </PepButton>
-        <PepButton @click="handleClose" variant="secondary" class="w-full"> Close </PepButton>
+        <PepButton class="w-full" @click="openExplorer"> View on Explorer </PepButton>
+        <PepButton variant="secondary" class="w-full" @click="handleClose"> Close </PepButton>
       </div>
     </template>
   </PepMainLayout>

--- a/src/views/wallet/send/SendView.vue
+++ b/src/views/wallet/send/SendView.vue
@@ -192,7 +192,7 @@ onMounted(async () => {
 
   try {
     await loadFees();
-  } catch (e) {
+  } catch {
     // Error handled in composable
   }
 });


### PR DESCRIPTION
## Summary
- Adds ESLint (flat config) alongside the existing Prettier setup, with `typescript-eslint` + `eslint-plugin-vue` and a small set of project-rules (`no-floating-promises`-adjacent unused-vars, `lines-between-class-members`, `vue/no-mutating-props` with `shallowOnly`).
- Cleans up everything the rules flagged as an error: unused imports/vars/catch bindings, `@ts-ignore` → `@ts-expect-error`, Vue attribute ordering/hyphenation, two `no-useless-assignment` cases.
- 362 → 58 lint problems, **0 errors**, all 623 tests green, build green.

## What's left
58 `@typescript-eslint/no-explicit-any` warnings remain — these are all real typed/untyped boundaries (chrome.runtime messages, Window injection, storage casts). Tracked as a follow-up in #64 with a 3-step plan; not in scope here.

## Test plan
- [x] `npm run lint` → 0 errors, 58 warnings
- [x] `npm run test:compact` → 86 files, 623 tests pass
- [x] `npm run build` → succeeds
- [x] Reviewer: skim `eslint.config.js` for rule disagreements