### PR TITLE
PSBT approval: Tier 1 raw inputs/outputs view (#59)

### DIFF
--- a/src/components/ui/PepInputsOutputsDetail.vue
+++ b/src/components/ui/PepInputsOutputsDetail.vue
@@ -45,10 +45,7 @@ const title = computed(() => {
         :key="i"
         class="space-y-1 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
       >
-        <div
-          v-if="row.inscription"
-          class="text-[10px] font-bold tracking-widest uppercase"
-        >
+        <div v-if="row.inscription" class="text-[10px] font-bold tracking-widest uppercase">
           Inscription {{ row.inscription.number }}
         </div>
         <div class="flex items-center justify-between gap-3">

--- a/src/components/ui/PepInputsOutputsDetail.vue
+++ b/src/components/ui/PepInputsOutputsDetail.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import { formatPep } from '@/utils/price';
 import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
 import type { Inscription } from '@/models/Inscription';
@@ -9,10 +10,15 @@ export interface InputOutputRow {
   inscription?: Inscription | null;
 }
 
-defineProps<{
-  title: string;
+const props = defineProps<{
+  mode: 'in' | 'out';
   rows: InputOutputRow[];
 }>();
+
+const title = computed(() => {
+  const noun = props.mode === 'in' ? 'input' : 'output';
+  return `${props.rows.length} ${props.rows.length === 1 ? noun : `${noun}s`}`;
+});
 </script>
 
 <template>

--- a/src/components/ui/PepInputsOutputsDetail.vue
+++ b/src/components/ui/PepInputsOutputsDetail.vue
@@ -47,7 +47,7 @@ const title = computed(() => {
       >
         <div
           v-if="row.inscription"
-          class="text-pepe-green text-[10px] font-bold tracking-widest uppercase"
+          class="text-[10px] font-bold tracking-widest uppercase"
         >
           Inscription {{ row.inscription.number }}
         </div>

--- a/src/components/ui/PepInputsOutputsDetail.vue
+++ b/src/components/ui/PepInputsOutputsDetail.vue
@@ -43,20 +43,20 @@ const title = computed(() => {
       <div
         v-for="(row, i) in rows"
         :key="i"
-        class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+        class="space-y-1 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
       >
-        <div class="flex min-w-0 flex-1 items-center gap-2">
+        <div
+          v-if="row.inscription"
+          class="text-pepe-green text-[10px] font-bold tracking-widest uppercase"
+        >
+          Inscription {{ row.inscription.number }}
+        </div>
+        <div class="flex items-center justify-between gap-3">
           <PepInlineAddress :address="row.address" />
-          <span
-            v-if="row.inscription"
-            class="bg-pepe-green/10 text-pepe-green shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-bold tracking-widest uppercase"
-          >
-            #{{ row.inscription.number }}
+          <span class="shrink-0 text-xs font-bold text-slate-200">
+            {{ row.amountRibbits === null ? '—' : formatPep(row.amountRibbits) }}
           </span>
         </div>
-        <span class="shrink-0 text-xs font-bold text-slate-200">
-          {{ row.amountRibbits === null ? '—' : formatPep(row.amountRibbits) }}
-        </span>
       </div>
     </div>
   </details>

--- a/src/components/ui/PepInputsOutputsDetail.vue
+++ b/src/components/ui/PepInputsOutputsDetail.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { formatPep } from '@/utils/price';
+import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
+import type { Inscription } from '@/models/Inscription';
+
+export interface InputOutputRow {
+  address: string | null;
+  amountRibbits: number | null;
+  inscription?: Inscription | null;
+}
+
+defineProps<{
+  title: string;
+  rows: InputOutputRow[];
+}>();
+</script>
+
+<template>
+  <details class="group rounded-xl border border-slate-800 bg-slate-900">
+    <summary
+      class="flex cursor-pointer list-none items-center justify-between p-4 [&::-webkit-details-marker]:hidden"
+    >
+      <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">
+        {{ title }}
+      </span>
+      <svg
+        class="h-4 w-4 text-slate-500 transition-transform group-open:rotate-180"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+      </svg>
+    </summary>
+    <div class="space-y-2 px-4 pb-4">
+      <div
+        v-for="(row, i) in rows"
+        :key="i"
+        class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+      >
+        <div class="flex min-w-0 flex-1 items-center gap-2">
+          <PepInlineAddress :address="row.address" />
+          <span
+            v-if="row.inscription"
+            class="bg-pepe-green/10 text-pepe-green shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-bold tracking-widest uppercase"
+          >
+            #{{ row.inscription.number }}
+          </span>
+        </div>
+        <span class="shrink-0 text-xs font-bold text-slate-200">
+          {{ row.amountRibbits === null ? '—' : formatPep(row.amountRibbits) }}
+        </span>
+      </div>
+    </div>
+  </details>
+</template>

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -517,7 +517,7 @@ describe('SignPsbtApproval', () => {
     await flushPromises();
 
     const outputsPanel = wrapper.findAll('details')[1]!;
-    expect(outputsPanel.text()).toContain('#7');
+    expect(outputsPanel.text()).toContain('Inscription 7');
   });
 
   it('sends rejection on cancel', async () => {

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -520,6 +520,70 @@ describe('SignPsbtApproval', () => {
     expect(outputsPanel.text()).toContain('Inscription 7');
   });
 
+  it('does not predict an output inscription on a listing PSBT (ANYONECANPAY splices invalidate sat tracking)', async () => {
+    const inscriptionTxid = 'c'.repeat(64);
+    const inscriptionVout = 0;
+    const myAddress = 'Pseller';
+    const myAddressKey = `${inscriptionTxid}:${inscriptionVout}`;
+
+    mockPsbt.inputCount = 1;
+    mockPsbt.txInputs = [
+      { hash: Buffer.from(inscriptionTxid, 'hex').reverse(), index: inscriptionVout }
+    ] as any;
+    mockPsbt.data.inputs = [
+      { sighashType: 0x83, nonWitnessUtxo: Buffer.from('deadbeef', 'hex') }
+    ] as any;
+    mockPsbt.txOutputs = [{ script: Buffer.from('seller', 'utf8'), value: 10_000_100_000 }] as any;
+
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('mine', 'utf8'), value: 100_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any).mockReturnValue(myAddress);
+
+    const { LOCAL_STORAGE_KEYS } = await import('@/constants/storage');
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.INSCRIPTIONS,
+      JSON.stringify({
+        [myAddress]: {
+          inscriptions: {
+            ins99: {
+              id: 'ins99',
+              number: 99,
+              contentType: 'image/png',
+              contentLength: 100,
+              height: 1,
+              value: 100_000,
+              parents: [],
+              properties: null,
+              satpoint: `${myAddressKey}:0`,
+              timestamp: 0
+            }
+          },
+          outputs: [myAddressKey],
+          lastSyncedHeight: 1
+        }
+      })
+    );
+    const { useInscriptionStore } = await import('@/stores/inscriptions');
+    useInscriptionStore().load(myAddress);
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: myAddress, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'refreshBalance').mockResolvedValue(undefined as any);
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { [myAddress]: [0] } });
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    const panels = wrapper.findAll('details');
+    expect(panels[0]!.text()).toContain('Inscription 99');
+    expect(panels[1]!.text()).not.toContain('Inscription 99');
+  });
+
   it('sends rejection on cancel', async () => {
     const store = useWalletStore();
     store.isUnlocked = true;

--- a/src/views/approval/SignPsbtApproval.spec.ts
+++ b/src/views/approval/SignPsbtApproval.spec.ts
@@ -416,6 +416,110 @@ describe('SignPsbtApproval', () => {
     expect(wrapper.text()).toContain('does not belong to the active account');
   });
 
+  it('renders collapsible raw inputs/outputs panels with an inscription badge and net change footer', async () => {
+    // A simple-PEP send: 1 mine input of 100_000_000 ribbits funds a 50_000_000 recipient
+    // output and a 49_000_000 change output (1_000_000 fee). Net change = -51_000_000.
+    const myAddress = 'Psender';
+
+    mockPsbt.inputCount = 1;
+    mockPsbt.txInputs = [{ hash: Buffer.alloc(32), index: 0 }] as any;
+    mockPsbt.data.inputs = [{ nonWitnessUtxo: Buffer.from('deadbeef', 'hex') }] as any;
+    mockPsbt.txOutputs = [
+      { script: Buffer.from('to-recipient', 'utf8'), value: 50_000_000 },
+      { script: Buffer.from('change', 'utf8'), value: 49_000_000 }
+    ] as any;
+
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('mine', 'utf8'), value: 100_000_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any)
+      .mockReturnValueOnce(myAddress)
+      .mockReturnValueOnce('Precipient')
+      .mockReturnValueOnce(myAddress);
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: myAddress, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { [myAddress]: [0] } });
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    // Two collapsible panels — one for inputs, one for outputs.
+    const detailsBlocks = wrapper.findAll('details');
+    expect(detailsBlocks.length).toBe(2);
+    expect(detailsBlocks[0]!.text()).toContain('1 input');
+    expect(detailsBlocks[1]!.text()).toContain('2 outputs');
+
+    // Net change footer shows the spent total (negative).
+    expect(wrapper.text()).toContain('Net change');
+  });
+
+  it('renders an inscription badge in the outputs panel when an inscription is predicted to land on a mine output', async () => {
+    // Self-send / cancel: 1 mine input carrying an inscription → 1 mine output of the same value.
+    const inscriptionTxid = 'b'.repeat(64);
+    const inscriptionVout = 0;
+    const myAddress = 'Pself';
+    const myAddressKey = `${inscriptionTxid}:${inscriptionVout}`;
+
+    mockPsbt.inputCount = 1;
+    mockPsbt.txInputs = [
+      { hash: Buffer.from(inscriptionTxid, 'hex').reverse(), index: inscriptionVout }
+    ] as any;
+    mockPsbt.data.inputs = [{ nonWitnessUtxo: Buffer.from('deadbeef', 'hex') }] as any;
+    mockPsbt.txOutputs = [{ script: Buffer.from('self', 'utf8'), value: 100_000 }] as any;
+
+    const bitcoin = await import('bitcoinjs-lib');
+    (bitcoin.Transaction.fromBuffer as any).mockReturnValue({
+      outs: [{ script: Buffer.from('mine', 'utf8'), value: 100_000 }]
+    });
+    (bitcoin.address.fromOutputScript as any).mockReturnValue(myAddress);
+
+    const { LOCAL_STORAGE_KEYS } = await import('@/constants/storage');
+    localStorage.setItem(
+      LOCAL_STORAGE_KEYS.INSCRIPTIONS,
+      JSON.stringify({
+        [myAddress]: {
+          inscriptions: {
+            ins7: {
+              id: 'ins7',
+              number: 7,
+              contentType: 'image/png',
+              contentLength: 100,
+              height: 1,
+              value: 100_000,
+              parents: [],
+              properties: null,
+              satpoint: `${myAddressKey}:0`,
+              timestamp: 0
+            }
+          },
+          outputs: [myAddressKey],
+          lastSyncedHeight: 1
+        }
+      })
+    );
+    const { useInscriptionStore } = await import('@/stores/inscriptions');
+    useInscriptionStore().load(myAddress);
+
+    const store = useWalletStore();
+    store.isUnlocked = true;
+    store.activeAccountIndex = 0;
+    store.accounts = [{ address: myAddress, path: "m/44'/3434'/0'/0/0", label: 'Account 1' }];
+    vi.spyOn(store, 'refreshBalance').mockResolvedValue(undefined as any);
+
+    makeRequest({ psbt: 'base64-psbt-data', signInputs: { [myAddress]: [0] } });
+
+    const wrapper = mount(SignPsbtApproval, { global: globalConfig });
+    await flushPromises();
+
+    const outputsPanel = wrapper.findAll('details')[1]!;
+    expect(outputsPanel.text()).toContain('#7');
+  });
+
   it('sends rejection on cancel', async () => {
     const store = useWalletStore();
     store.isUnlocked = true;

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -341,13 +341,13 @@ function handleReject() {
 
         <PepInputsOutputsDetail
           v-if="psbtDetails.inputs.length"
-          :title="`${psbtDetails.inputs.length} ${psbtDetails.inputs.length === 1 ? 'input' : 'inputs'}`"
+          mode="in"
           :rows="psbtDetails.inputs"
         />
 
         <PepInputsOutputsDetail
           v-if="psbtDetails.outputs.length"
-          :title="`${psbtDetails.outputs.length} ${psbtDetails.outputs.length === 1 ? 'output' : 'outputs'}`"
+          mode="out"
           :rows="psbtDetails.outputs"
         />
 

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -8,8 +8,8 @@ import { formatPep } from '@/utils/price';
 import { useApprovalRequest } from '@/composables/useApprovalRequest';
 import PepMainLayout from '@/components/ui/PepMainLayout.vue';
 import PepButton from '@/components/ui/PepButton.vue';
-import PepInlineAddress from '@/components/ui/PepInlineAddress.vue';
 import PepInscription from '@/components/ui/PepInscription.vue';
+import PepInputsOutputsDetail from '@/components/ui/PepInputsOutputsDetail.vue';
 import type { Inscription } from '@/models/Inscription';
 import * as bitcoin from 'bitcoinjs-lib';
 import { PEPECOIN } from '@/utils/networks';
@@ -115,10 +115,46 @@ function buildHero(inputs: PsbtIO[], outputs: PsbtIO[]): { transfer: HeroSide; r
   return { transfer, receive };
 }
 
+function predictOutputInscriptions(inputs: PsbtIO[], outputs: PsbtIO[]): (Inscription | null)[] {
+  const predicted: (Inscription | null)[] = outputs.map(() => null);
+  if (!inputs.every((i) => i.amountRibbits !== null)) return predicted;
+
+  let cumIn = 0;
+  const positions: Array<{ pos: number; inscription: Inscription }> = [];
+  for (const i of inputs) {
+    if (i.inscription) {
+      const parts = i.inscription.satpoint.split(':');
+      const offset = Number.parseInt(parts[2] ?? '0', 10) || 0;
+      positions.push({ pos: cumIn + offset, inscription: i.inscription });
+    }
+    cumIn += i.amountRibbits ?? 0;
+  }
+  if (!positions.length) return predicted;
+
+  let cumOut = 0;
+  for (let k = 0; k < outputs.length; k++) {
+    const start = cumOut;
+    const end = cumOut + (outputs[k]!.amountRibbits ?? 0);
+    for (const p of positions) {
+      if (p.pos >= start && p.pos < end) {
+        predicted[k] = p.inscription;
+        break;
+      }
+    }
+    cumOut = end;
+  }
+  return predicted;
+}
+
 function decodePsbtSummary(
   base64: string,
   myAddress: string | null
-): { inputs: PsbtIO[]; outputs: PsbtIO[]; netChangeRibbits: number | null; decodeError: boolean } {
+): {
+  inputs: PsbtIO[];
+  outputs: PsbtIO[];
+  netChangeRibbits: number | null;
+  decodeError: boolean;
+} {
   try {
     const psbt = bitcoin.Psbt.fromBase64(base64, { network: PEPECOIN });
 
@@ -149,7 +185,7 @@ function decodePsbtSummary(
       };
     });
 
-    const outputs: PsbtIO[] = psbt.txOutputs.map((o) => {
+    const rawOutputs: PsbtIO[] = psbt.txOutputs.map((o) => {
       let address: string | null = null;
       try {
         address = bitcoin.address.fromOutputScript(o.script, PEPECOIN);
@@ -162,6 +198,11 @@ function decodePsbtSummary(
         mine: !!myAddress && address === myAddress
       };
     });
+    const predicted = predictOutputInscriptions(inputs, rawOutputs);
+    const outputs: PsbtIO[] = rawOutputs.map((o, k) => ({
+      ...o,
+      inscription: predicted[k] ?? null
+    }));
 
     const allInputAmountsKnown = inputs.every((i) => i.amountRibbits !== null);
     let netChangeRibbits: number | null = null;
@@ -298,38 +339,30 @@ function handleReject() {
           </p>
         </div>
 
-        <div
+        <PepInputsOutputsDetail
           v-if="psbtDetails.inputs.length"
-          class="space-y-2 rounded-xl border border-slate-800 bg-slate-900 p-4"
-        >
-          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">From</span>
-          <div
-            v-for="(io, i) in psbtDetails.inputs"
-            :key="`in-${i}`"
-            class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
-          >
-            <PepInlineAddress :address="io.address" />
-            <span class="shrink-0 text-xs font-bold text-slate-200">{{
-              io.amountRibbits === null ? '—' : formatPep(io.amountRibbits)
-            }}</span>
-          </div>
-        </div>
+          :title="`${psbtDetails.inputs.length} ${psbtDetails.inputs.length === 1 ? 'input' : 'inputs'}`"
+          :rows="psbtDetails.inputs"
+        />
+
+        <PepInputsOutputsDetail
+          v-if="psbtDetails.outputs.length"
+          :title="`${psbtDetails.outputs.length} ${psbtDetails.outputs.length === 1 ? 'output' : 'outputs'}`"
+          :rows="psbtDetails.outputs"
+        />
 
         <div
-          v-if="psbtDetails.outputs.length"
-          class="space-y-2 rounded-xl border border-slate-800 bg-slate-900 p-4"
+          v-if="psbtDetails.netChangeRibbits !== null && !psbtDetails.decodeError"
+          class="flex items-center justify-between rounded-xl border border-slate-800 bg-slate-900 px-4 py-3"
         >
-          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">To</span>
-          <div
-            v-for="(io, i) in psbtDetails.outputs"
-            :key="`out-${i}`"
-            class="flex items-center justify-between gap-3 border-t border-slate-800 pt-2 first:border-t-0 first:pt-0"
+          <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">Net change</span>
+          <span
+            class="text-sm font-bold"
+            :class="psbtDetails.netChangeRibbits < 0 ? 'text-red-400' : 'text-pepe-green'"
           >
-            <PepInlineAddress :address="io.address" />
-            <span class="shrink-0 text-xs font-bold text-slate-200">{{
-              io.amountRibbits === null ? '—' : formatPep(io.amountRibbits)
-            }}</span>
-          </div>
+            {{ psbtDetails.netChangeRibbits > 0 ? '+' : ''
+            }}{{ formatPep(psbtDetails.netChangeRibbits) }}
+          </span>
         </div>
 
         <div

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -118,6 +118,11 @@ function buildHero(inputs: PsbtIO[], outputs: PsbtIO[]): { transfer: HeroSide; r
 function predictOutputInscriptions(inputs: PsbtIO[], outputs: PsbtIO[]): (Inscription | null)[] {
   const predicted: (Inscription | null)[] = outputs.map(() => null);
   if (!inputs.every((i) => i.amountRibbits !== null)) return predicted;
+  // ANYONECANPAY (0x80 bit) lets a counterparty splice in inputs at any position
+  // in the final tx, so cumulative sat offsets computed from the current PSBT
+  // are meaningless. Bail out rather than mislabel a price output as carrying
+  // an inscription.
+  if (inputs.some((i) => ((i.sighashType ?? 0) & 0x80) !== 0)) return predicted;
 
   let cumIn = 0;
   const positions: Array<{ pos: number; inscription: Inscription }> = [];

--- a/src/views/approval/SignPsbtApproval.vue
+++ b/src/views/approval/SignPsbtApproval.vue
@@ -358,7 +358,7 @@ function handleReject() {
           <span class="text-xs font-bold tracking-widest text-slate-500 uppercase">Net change</span>
           <span
             class="text-sm font-bold"
-            :class="psbtDetails.netChangeRibbits < 0 ? 'text-red-400' : 'text-pepe-green'"
+            :class="psbtDetails.netChangeRibbits < 0 ? 'text-red-400' : ''"
           >
             {{ psbtDetails.netChangeRibbits > 0 ? '+' : ''
             }}{{ formatPep(psbtDetails.netChangeRibbits) }}


### PR DESCRIPTION
## Summary
- Adds collapsible Inputs/Outputs detail panels to the PSBT approval screen, so every PSBT is reviewable even when no scenario hero matches.
- Inscription rows label the inscription above the address/amount row; output inscriptions are predicted via cumulative-sat-offset tracking against input values (ord allocation rule).
- Adds a signed Net change footer (negative in red).
- Extracts a reusable `PepInputsOutputsDetail` component (`mode: 'in' | 'out'`, derives its own title from row count).
- Implements Tier 1 of #59. Tier 2 (scenario-aware heroes) will follow in a separate PR.

## Test plan
- [x] `vitest` — 625 passing, including two new tests covering the collapsible panels + net change footer and the predicted-output inscription label.
- [x] `vue-tsc -b && vite build` clean.
- [x] Manual: sign-PSBT approval for simple PEP send, listing, self-send.